### PR TITLE
#67 - add Mojo dependencies

### DIFF
--- a/nd4j-jocl-parent/nd4j-jocl-1.9/pom.xml
+++ b/nd4j-jocl-parent/nd4j-jocl-1.9/pom.xml
@@ -21,5 +21,16 @@
             <artifactId>jocl</artifactId>
             <version>0.1.9</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.3</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Add missing dependencies (#67), using version numbers consistent with the [maven-compiler-plugin](https://maven.apache.org/plugins/maven-compiler-plugin/dependencies.html) dependency.