### PR TITLE
94: track allocations of device pointer length along with the device …

### DIFF
--- a/nd4j-jcublas-parent/nd4j-jcublas-7.0/src/test/java/jcublas/kernel/TestMultipleThreads.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-7.0/src/test/java/jcublas/kernel/TestMultipleThreads.java
@@ -1,0 +1,55 @@
+package jcublas.kernel;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+public class TestMultipleThreads {
+	
+	@Test
+	public void testMultipleThreads() throws InterruptedException {
+		int numThreads = 50;
+		final INDArray array = Nd4j.rand(3000, 3000);
+		final INDArray expected = array.dup().mmul(array).mmul(array).div(array).div(array);
+		final AtomicInteger correct = new AtomicInteger();
+		final CountDownLatch latch = new CountDownLatch(numThreads);
+		
+		ExecutorService executors = Executors.newCachedThreadPool();
+		
+		for(int x = 0; x< numThreads; x++) {
+			executors.execute(new Runnable() {
+				@Override
+				public void run() {
+					try
+					{
+						int total = 10000;
+						int right = 0;
+						for(int x = 0; x<total; x++) {
+							INDArray actual = array.dup().mmul(array).mmul(array).div(array).div(array);
+							if(expected.equals(actual)) right++;						
+						}
+						
+						if(total == right)
+							correct.incrementAndGet();
+					} finally {
+						latch.countDown();
+					}
+					
+				}
+			});
+		}
+		
+		latch.await();
+		
+		assertEquals(numThreads, correct.get());
+		
+	}
+
+}

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/jcuda/utils/KernelLauncher.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/jcuda/utils/KernelLauncher.java
@@ -1037,7 +1037,7 @@ public class KernelLauncher {
             }
         }
 
-
+        setContext();
 
         checkResult(cuLaunchKernel(function,
                 gridSize.x, gridSize.y, gridSize.z,

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/context/ContextHolder.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/context/ContextHolder.java
@@ -78,15 +78,19 @@ public class ContextHolder {
     	
     	if(stream == null) {
     		stream = new CUstream();
-    		int result = JCudaDriver.cuStreamCreate(stream, CUstream_flags.CU_STREAM_DEFAULT);
-    		if (result != CUresult.CUDA_SUCCESS) {
-                throw new CudaException("Failed to create a stream: "+ CUresult.stringFor(result));
-            }
+    		checkResult(JCudaDriver.cuCtxSetCurrent(ctx));
+    		checkResult(JCudaDriver.cuStreamCreate(stream, CUstream_flags.CU_STREAM_DEFAULT));
     		contextStreams.put(ctx, currentThread.getName(), stream);
     	}
     	
     	return stream;
     }
+
+	private void checkResult(int result) {
+		if (result != CUresult.CUDA_SUCCESS) {
+		    throw new CudaException("Failed to create a stream: "+ CUresult.stringFor(result));
+		}
+	}
 
     /**
      * Retrieve a context for use with the current thread


### PR DESCRIPTION
…pointer itself.

ensure the context is set for new threads before kernels are called. fixes #94 