### PR TITLE
nd4j-api test-jar dependency removed.

### DIFF
--- a/nd4j-jblas/pom.xml
+++ b/nd4j-jblas/pom.xml
@@ -52,12 +52,5 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>    
-		<dependency>
-		  	<groupId>org.nd4j</groupId>
-		  	<artifactId>nd4j-api</artifactId>
-		  	<version>${project.version}</version>
-		  	<type>test-jar</type>
-		  	<scope>test</scope>	
-		</dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
With this dependency, the latest snapshot cannot be built locally as the dependency is not available on Maven central.