### PR TITLE
Bytebuffers

### DIFF
--- a/nd4j-api/pom.xml
+++ b/nd4j-api/pom.xml
@@ -61,6 +61,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.12</junit.version>
         <spring.version>3.2.5.RELEASE</spring.version>
+        <netty.version>5.0.0.Alpha2</netty.version>
     </properties>
 
     <dependencyManagement>
@@ -137,6 +138,11 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${netty.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -19,16 +19,17 @@
 
 package org.nd4j.linalg.api.buffer;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import org.nd4j.linalg.api.complex.IComplexDouble;
 import org.nd4j.linalg.api.complex.IComplexFloat;
 import org.nd4j.linalg.api.complex.IComplexNumber;
 import org.nd4j.linalg.factory.Nd4j;
 
-import java.io.RandomAccessFile;
 import java.lang.ref.WeakReference;
-import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.*;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * Base class for a data buffer
@@ -38,19 +39,28 @@ import java.util.concurrent.CopyOnWriteArraySet;
  */
 public abstract class BaseDataBuffer implements DataBuffer {
 
-    public static final int MAPPING_SIZE = 1 << 30;
-    protected final List<ByteBuffer> mappings = new ArrayList<>();
     protected int length;
-    //memory mapped file
-    protected String path;
-    protected transient RandomAccessFile memoryMappedBuffer;
+    protected ByteBuf dataBuffer;
     protected Collection<String> referencing = Collections.synchronizedSet(new HashSet<String>());
     protected transient WeakReference<DataBuffer> ref;
     protected boolean isPersist = false;
 
+    public BaseDataBuffer(float[] data, boolean copy) {
+        dataBuffer = Unpooled.copyFloat(data);
+
+    }
+    public BaseDataBuffer(double[] data, boolean copy) {
+        dataBuffer = Unpooled.copyDouble(data);
+
+    }
+
+    public BaseDataBuffer(int[] data, boolean copy) {
+        dataBuffer = Unpooled.copyInt(data);
+    }
+
     @Override
     public void persist() {
-       isPersist = true;
+        isPersist = true;
     }
 
     @Override
@@ -66,37 +76,10 @@ public abstract class BaseDataBuffer implements DataBuffer {
     protected BaseDataBuffer(int length) {
         this.length = length;
         ref = new WeakReference<DataBuffer>(this,Nd4j.bufferRefQueue());
+        dataBuffer = Unpooled.directBuffer(length);
+        dataBuffer.order(ByteOrder.nativeOrder());
     }
 
-    public static byte[] toByteArray(double value) {
-        byte[] bytes = new byte[8];
-        ByteBuffer.wrap(bytes).putDouble(value);
-        return bytes;
-    }
-
-    public static byte[] toByteArray(float value) {
-        byte[] bytes = new byte[4];
-        ByteBuffer.wrap(bytes).putFloat(value);
-        return bytes;
-    }
-
-    public static byte[] toByteArray(int value) {
-        byte[] bytes = new byte[4];
-        ByteBuffer.wrap(bytes).putFloat(value);
-        return bytes;
-    }
-
-    public static double toDouble(byte[] bytes) {
-        return ByteBuffer.wrap(bytes).getDouble();
-    }
-
-    public static int toInt(byte[] bytes) {
-        return ByteBuffer.wrap(bytes).getInt();
-    }
-
-    public static float toFloat(byte[] bytes) {
-        return ByteBuffer.wrap(bytes).getFloat();
-    }
 
     @Override
     public void removeReferencing(String id) {
@@ -123,6 +106,29 @@ public abstract class BaseDataBuffer implements DataBuffer {
             put(indices[i], data[i]);
         }
     }
+
+
+
+    @Override
+    public void setData(int[] data) {
+        for(int i = 0; i < data.length; i++) {
+            dataBuffer.setInt(i, data[i]);
+        }
+
+    }
+
+    @Override
+    public void setData(float[] data) {
+        for(int i = 0; i < data.length; i++)
+            dataBuffer.setFloat(i, data[i]);
+    }
+
+    @Override
+    public void setData(double[] data) {
+        for(int i = 0; i < data.length; i++)
+            dataBuffer.setDouble(i, data[i]);
+    }
+
 
     @Override
     public void assign(int[] indices, double[] data, boolean contiguous, int inc) {
@@ -182,6 +188,12 @@ public abstract class BaseDataBuffer implements DataBuffer {
         return ret;
     }
 
+
+    @Override
+    public DataBuffer dup() {
+        return null;
+    }
+
     @Override
     public double[] getDoublesAt(int offset, int inc, int length) {
         if (offset + length > length())
@@ -230,6 +242,71 @@ public abstract class BaseDataBuffer implements DataBuffer {
     }
 
     @Override
+    public byte[] asBytes() {
+        return dataBuffer.array();
+    }
+
+    @Override
+    public float[] asFloat() {
+        return dataBuffer.nioBuffer().asFloatBuffer().array();
+    }
+
+    @Override
+    public double[] asDouble() {
+        return dataBuffer.nioBuffer().asDoubleBuffer().array();
+    }
+
+    @Override
+    public int[] asInt() {
+        return dataBuffer.nioBuffer().asIntBuffer().array();
+    }
+
+    @Override
+    public double getDouble(int i) {
+        return dataBuffer.getDouble(i);
+    }
+
+    @Override
+    public float getFloat(int i) {
+        return dataBuffer.getFloat(i);
+    }
+
+    @Override
+    public Number getNumber(int i) {
+        return getDouble(i);
+    }
+
+    @Override
+    public void put(int i, float element) {
+        dataBuffer.setFloat(i, element);
+    }
+
+    @Override
+    public void put(int i, double element) {
+        dataBuffer.setDouble(i,element);
+    }
+
+    @Override
+    public void put(int i, int element) {
+        dataBuffer.setIndex(i,element);
+    }
+
+    @Override
+    public void assign(Number value, int offset) {
+        dataBuffer.setDouble(offset,value.doubleValue());
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public int getInt(int ix) {
+        return 0;
+    }
+
+    @Override
     public void assign(int[] offsets, int[] strides, int n, DataBuffer... buffers) {
         if (offsets.length != strides.length || strides.length != buffers.length)
             throw new IllegalArgumentException("Unable to assign buffers, please specify equal lengths strides, offsets, and buffers");
@@ -262,4 +339,8 @@ public abstract class BaseDataBuffer implements DataBuffer {
     }
 
 
+    @Override
+    public void destroy() {
+        this.dataBuffer = null;
+    }
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
@@ -34,11 +34,33 @@ import java.util.Collection;
  */
 public interface DataBuffer extends Serializable {
 
-	public static enum Type {
-	    DOUBLE,
-	    FLOAT,
-	    INT
-	}
+    enum Type {
+        DOUBLE,
+        FLOAT,
+        INT
+    }
+
+    /**
+     * Direct (off heap) and heap allocation
+     *
+     * Each has their trade offs.
+     *
+     * One allows for storing unlimited array sizes, faster i/o with native
+     * applications
+     *
+     * heap is backed by an array and can be useful depending on the api
+     */
+    enum AllocationMode {
+        DIRECT,
+        HEAP
+    }
+
+
+    /**
+     * Allocation mode for buffers
+     * @return the allocation mode for the buffer
+     */
+    AllocationMode allocationMode();
 
     /**
      * Mark this buffer as persistent
@@ -389,7 +411,7 @@ public interface DataBuffer extends Serializable {
      */
     void assign(int[] offsets, int[] strides, DataBuffer... buffers);
 
-    
+
     /**
      * release all resources for this buffer
      */

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DoubleBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DoubleBuffer.java
@@ -20,6 +20,9 @@
 package org.nd4j.linalg.api.buffer;
 
 
+import io.netty.buffer.ByteBuf;
+import org.nd4j.linalg.factory.Nd4j;
+
 /**
  * Double buffer implementation of data buffer
  *
@@ -32,6 +35,35 @@ public class DoubleBuffer extends BaseDataBuffer {
         super(length);
     }
 
+    public DoubleBuffer(ByteBuf buf,int length) {
+        super(buf,length);
+    }
+
+    public DoubleBuffer(double[] data) {
+        super(data);
+    }
+
+    public DoubleBuffer(int[] data) {
+        this(data, Nd4j.copyOnOps);
+    }
+
+    public DoubleBuffer(int[] data, boolean copyOnOps) {
+        super(data, copyOnOps);
+    }
+
+    public DoubleBuffer(float[] data) {
+        this(data, Nd4j.copyOnOps);
+    }
+
+    public DoubleBuffer(float[] data, boolean copyOnOps) {
+        super(data,copyOnOps);
+    }
+
+    @Override
+    public DataBuffer create(ByteBuf buf,int length) {
+        return new DoubleBuffer(buf,length);
+    }
+
     public DoubleBuffer(double[] doubles, boolean copy) {
         super(doubles, copy);
     }
@@ -42,22 +74,6 @@ public class DoubleBuffer extends BaseDataBuffer {
         return DataBuffer.Type.DOUBLE;
     }
 
-    @Override
-    public float[] asFloat() {
-        return dataBuffer.nioBuffer().asFloatBuffer().array();
-    }
-
-    @Override
-    public double[] asDouble() {
-        return dataBuffer.nioBuffer().asDoubleBuffer().array();
-
-    }
-
-    @Override
-    public int[] asInt() {
-        return dataBuffer.nioBuffer().asIntBuffer().array();
-
-    }
 
 
 
@@ -71,23 +87,20 @@ public class DoubleBuffer extends BaseDataBuffer {
         return (int) getDouble(i);
     }
 
-
     @Override
-    public void put(int i, float element) {
-        put(i, (double) element);
-
+    public DataBuffer create(double[] data) {
+        return new DoubleBuffer(data);
     }
 
     @Override
-    public void put(int i, double element) {
-        dataBuffer.setDouble(i, element);
+    public DataBuffer create(float[] data) {
+        return new DoubleBuffer(data);
     }
 
     @Override
-    public void put(int i, int element) {
-        put(i, (double) element);
+    public DataBuffer create(int[] data) {
+        return new DoubleBuffer(data);
     }
-
 
     @Override
     public int getInt(int ix) {

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DoubleBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DoubleBuffer.java
@@ -20,16 +20,6 @@
 package org.nd4j.linalg.api.buffer;
 
 
-import com.google.common.primitives.Bytes;
-import org.nd4j.linalg.factory.Nd4j;
-import org.nd4j.linalg.util.ArrayUtil;
-
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
-import java.util.Arrays;
-import java.util.UUID;
-
 /**
  * Double buffer implementation of data buffer
  *
@@ -37,48 +27,15 @@ import java.util.UUID;
  */
 public class DoubleBuffer extends BaseDataBuffer {
 
-    private double[] buffer;
 
     public DoubleBuffer(int length) {
         super(length);
-        this.buffer = new double[length];
     }
 
-
-    public DoubleBuffer(double[] buffer) {
-        this(buffer, true);
+    public DoubleBuffer(double[] doubles, boolean copy) {
+        super(doubles, copy);
     }
 
-    public DoubleBuffer(double[] buffer, boolean copy) {
-        super(buffer.length);
-        this.buffer = copy ? Arrays.copyOf(buffer, buffer.length) : buffer;
-    }
-
-
-    @Override
-    public void setData(int[] data) {
-        this.buffer = ArrayUtil.toDoubles(data);
-    }
-
-    @Override
-    public void setData(float[] data) {
-        this.buffer = ArrayUtil.toDoubles(data);
-    }
-
-    @Override
-    public void setData(double[] data) {
-        this.buffer = data;
-    }
-
-    @Override
-    public byte[] asBytes() {
-        byte[][] ret1 = new byte[length][];
-        for (int i = 0; i < length; i++) {
-            ret1[i] = toByteArray(buffer[i]);
-        }
-
-        return Bytes.concat(ret1);
-    }
 
     @Override
     public DataBuffer.Type dataType() {
@@ -87,59 +44,22 @@ public class DoubleBuffer extends BaseDataBuffer {
 
     @Override
     public float[] asFloat() {
-        float[] ret = new float[length];
-        for (int i = 0; i < ret.length; i++) {
-            ret[i] = (float) buffer[i];
-        }
-        return ret;
+        return dataBuffer.nioBuffer().asFloatBuffer().array();
     }
 
     @Override
     public double[] asDouble() {
-        if (buffer == null) {
-            buffer = new double[length];
-            for (int i = 0; i < length; i++) {
-                buffer[i] = getDouble(i);
-            }
-            try {
-                mappings.clear();
-                memoryMappedBuffer.close();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return buffer;
+        return dataBuffer.nioBuffer().asDoubleBuffer().array();
+
     }
 
     @Override
     public int[] asInt() {
-        int[] ret = new int[length];
-        for (int i = 0; i < ret.length; i++) {
-            ret[i] = (int) buffer[i];
-        }
-        return ret;
+        return dataBuffer.nioBuffer().asIntBuffer().array();
+
     }
 
 
-    @Override
-    public double getDouble(int i) {
-        if (buffer != null)
-            return buffer[i];
-        else {
-            long p = i * 8;
-            int mapN = (int) (p / MAPPING_SIZE);
-            int offN = (int) (p % MAPPING_SIZE);
-            return mappings.get(mapN).getDouble(offN);
-        }
-    }
-
-
-    @Override
-    public void assign(Number value, int offset) {
-        for (int i = offset; i < length(); i++) {
-            buffer[i] = value.doubleValue();
-        }
-    }
 
     @Override
     public float getFloat(int i) {
@@ -160,14 +80,7 @@ public class DoubleBuffer extends BaseDataBuffer {
 
     @Override
     public void put(int i, double element) {
-        if (buffer != null)
-            buffer[i] = element;
-        else {
-            long p = i * 8;
-            int mapN = (int) (p / MAPPING_SIZE);
-            int offN = (int) (p % MAPPING_SIZE);
-            mappings.get(mapN).putDouble(offN, element);
-        }
+        dataBuffer.setDouble(i, element);
     }
 
     @Override
@@ -178,37 +91,14 @@ public class DoubleBuffer extends BaseDataBuffer {
 
     @Override
     public int getInt(int ix) {
-        return (int) buffer[ix];
+        return dataBuffer.getInt(ix);
     }
 
-    @Override
-    public DataBuffer dup() {
-        return new DoubleBuffer(buffer);
-    }
+
 
     @Override
     public void flush() {
-        path = UUID.randomUUID().toString();
-        if (memoryMappedBuffer != null)
-            return;
-        try {
-            memoryMappedBuffer = new RandomAccessFile(path, "rw");
-            long size = 8L * length;
-            for (long offset = 0; offset < size; offset += MAPPING_SIZE) {
-                long size2 = Math.min(size - offset, MAPPING_SIZE);
-                mappings.add(memoryMappedBuffer.getChannel().map(FileChannel.MapMode.READ_WRITE, offset, size2));
-            }
-        } catch (IOException e) {
-            try {
-                if (memoryMappedBuffer != null)
-                    memoryMappedBuffer.close();
-            } catch (IOException e1) {
-                throw new RuntimeException(e);
-            }
-            throw new RuntimeException(e);
-        }
-
-        buffer = null;
+        dataBuffer = null;
     }
 
     @Override
@@ -216,34 +106,6 @@ public class DoubleBuffer extends BaseDataBuffer {
         return 8;
     }
 
-    public void destroy() {
-        if (buffer != null)
-            buffer = null;
-        if (memoryMappedBuffer != null) {
-            try {
-                this.memoryMappedBuffer.close();
-                mappings.clear();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
 
-            }
-        }
-    }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DoubleBuffer)) return false;
-
-        DoubleBuffer that = (DoubleBuffer) o;
-
-        if (!Arrays.equals(buffer, that.buffer)) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return buffer != null ? Arrays.hashCode(buffer) : 0;
-    }
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/FloatBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/FloatBuffer.java
@@ -19,15 +19,7 @@
 
 package org.nd4j.linalg.api.buffer;
 
-import com.google.common.primitives.Bytes;
 
-import org.nd4j.linalg.util.ArrayUtil;
-
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
-import java.util.Arrays;
-import java.util.UUID;
 
 /**
  * Data buffer for floats
@@ -36,20 +28,17 @@ import java.util.UUID;
  */
 public class FloatBuffer extends BaseDataBuffer {
 
-    private float[] buffer;
 
+    /**
+     * Create a float buffer with the given length
+     * @param length the float buffer with the given length
+     */
     public FloatBuffer(int length) {
         super(length);
-        this.buffer = new float[length];
     }
 
-    public FloatBuffer(float[] buffer) {
-        this(buffer, true);
-    }
-
-    public FloatBuffer(float[] buffer, boolean copy) {
-        super(buffer.length);
-        this.buffer = copy ? Arrays.copyOf(buffer, buffer.length) : buffer;
+    public FloatBuffer(float[] floats, boolean copy) {
+        super(floats, copy);
     }
 
 
@@ -58,198 +47,14 @@ public class FloatBuffer extends BaseDataBuffer {
         return 4;
     }
 
-    @Override
-    public void assign(Number value, int offset) {
-        for (int i = offset; i < length(); i++) {
-            buffer[i] = value.floatValue();
-        }
-    }
 
 
-    @Override
-    public void setData(int[] data) {
-        this.buffer = ArrayUtil.toFloats(data);
-    }
-
-    @Override
-    public void setData(float[] data) {
-        this.buffer = data;
-    }
-
-    @Override
-    public void setData(double[] data) {
-        this.buffer = ArrayUtil.toFloats(data);
-    }
-
-    @Override
-    public byte[] asBytes() {
-        byte[][] ret1 = new byte[length][];
-        for (int i = 0; i < length; i++) {
-            ret1[i] = toByteArray(buffer[i]);
-        }
-
-        return Bytes.concat(ret1);
-    }
 
     @Override
     public DataBuffer.Type dataType() {
         return DataBuffer.Type.FLOAT;
     }
 
-    @Override
-    public float[] asFloat() {
-        if (buffer == null) {
-            buffer = new float[length];
-            for (int i = 0; i < length; i++) {
-                buffer[i] = getFloat(i);
-            }
-            try {
-                mappings.clear();
-                memoryMappedBuffer.close();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return buffer;
-    }
-
-    @Override
-    public double[] asDouble() {
-        double[] ret = new double[length];
-        for (int i = 0; i < ret.length; i++) {
-            ret[i] = (double) buffer[i];
-        }
-        return ret;
-    }
-
-    @Override
-    public int[] asInt() {
-        int[] ret = new int[length];
-        for (int i = 0; i < ret.length; i++) {
-            ret[i] = (int) buffer[i];
-        }
-        return ret;
-    }
 
 
-    @Override
-    public double getDouble(int i) {
-        if (buffer != null)
-            return buffer[i];
-        else {
-            long p = i * 8;
-            int mapN = (int) (p / MAPPING_SIZE);
-            int offN = (int) (p % MAPPING_SIZE);
-            return mappings.get(mapN).getDouble(offN);
-        }
-    }
-
-    @Override
-    public float getFloat(int i) {
-        return (float) getDouble(i);
-    }
-
-    @Override
-    public Number getNumber(int i) {
-        return (int) getDouble(i);
-    }
-
-
-    @Override
-    public void put(int i, float element) {
-        put(i, (double) element);
-
-    }
-
-    @Override
-    public void put(int i, double element) {
-        if (buffer != null)
-            buffer[i] = (float) element;
-        else {
-            long p = i * 8;
-            int mapN = (int) (p / MAPPING_SIZE);
-            int offN = (int) (p % MAPPING_SIZE);
-            mappings.get(mapN).putDouble(offN, element);
-        }
-    }
-
-    @Override
-    public void put(int i, int element) {
-        put(i, (double) element);
-    }
-
-
-    @Override
-    public int getInt(int ix) {
-        return (int) buffer[ix];
-    }
-
-    @Override
-    public DataBuffer dup() {
-        return new FloatBuffer(buffer);
-    }
-
-    @Override
-    public void flush() {
-        path = UUID.randomUUID().toString();
-        if (memoryMappedBuffer != null)
-            return;
-        try {
-            memoryMappedBuffer = new RandomAccessFile(path, "rw");
-            long size = 8L * length;
-            for (long offset = 0; offset < size; offset += MAPPING_SIZE) {
-                long size2 = Math.min(size - offset, MAPPING_SIZE);
-                mappings.add(memoryMappedBuffer.getChannel().map(FileChannel.MapMode.READ_WRITE, offset, size2));
-            }
-        } catch (IOException e) {
-            try {
-                if (memoryMappedBuffer != null)
-                    memoryMappedBuffer.close();
-            } catch (IOException e1) {
-                throw new RuntimeException(e);
-            }
-            throw new RuntimeException(e);
-        }
-
-        buffer = null;
-    }
-
-    public void destroy() {
-        if (buffer != null)
-            buffer = null;
-        if (memoryMappedBuffer != null) {
-            try {
-                this.mappings.clear();
-                this.memoryMappedBuffer.close();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-
-            }
-        }
-    }
-
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof FloatBuffer)) return false;
-
-        FloatBuffer that = (FloatBuffer) o;
-
-        if (!Arrays.equals(buffer, that.buffer)) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return buffer != null ? Arrays.hashCode(buffer) : 0;
-    }
-
-    @Override
-    public String toString() {
-        return "FloatBuffer{" +
-                "buffer=" + Arrays.toString(buffer) +
-                '}';
-    }
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/FloatBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/FloatBuffer.java
@@ -20,6 +20,8 @@
 package org.nd4j.linalg.api.buffer;
 
 
+import io.netty.buffer.ByteBuf;
+import org.nd4j.linalg.factory.Nd4j;
 
 /**
  * Data buffer for floats
@@ -37,10 +39,40 @@ public class FloatBuffer extends BaseDataBuffer {
         super(length);
     }
 
+
+
+    public FloatBuffer(ByteBuf buf,int length) {
+        super(buf,length);
+    }
+
+    public FloatBuffer(float[] data) {
+        this(data, Nd4j.copyOnOps);
+    }
+
+    public FloatBuffer(int[] data) {
+        this(data,Nd4j.copyOnOps);
+    }
+
+    public FloatBuffer(double[] data) {
+        this(data,Nd4j.copyOnOps);
+    }
+
+    public FloatBuffer(int[] data, boolean copyOnOps) {
+       super(data, copyOnOps);
+    }
+
+    public FloatBuffer(double[] data, boolean copyOnOps) {
+        super(data,copyOnOps);
+    }
+
+    @Override
+    public DataBuffer create(ByteBuf buf,int length) {
+        return new FloatBuffer(buf,length);
+    }
+
     public FloatBuffer(float[] floats, boolean copy) {
         super(floats, copy);
     }
-
 
     @Override
     public int getElementSize() {
@@ -55,6 +87,21 @@ public class FloatBuffer extends BaseDataBuffer {
         return DataBuffer.Type.FLOAT;
     }
 
+
+    @Override
+    public DataBuffer create(double[] data) {
+        return new FloatBuffer(data);
+    }
+
+    @Override
+    public DataBuffer create(float[] data) {
+        return new FloatBuffer(data);
+    }
+
+    @Override
+    public DataBuffer create(int[] data) {
+        return new FloatBuffer(data);
+    }
 
 
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/IntBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/IntBuffer.java
@@ -19,12 +19,6 @@
 
 package org.nd4j.linalg.api.buffer;
 
-import org.nd4j.linalg.util.ArrayUtil;
-
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
-import java.util.UUID;
 
 /**
  * Int buffer
@@ -33,60 +27,21 @@ import java.util.UUID;
  */
 public class IntBuffer extends BaseDataBuffer {
 
-    private int[] buffer;
-
-    public IntBuffer(int[] buffer, boolean copy) {
-        super(buffer.length);
-        if (!copy)
-            this.buffer = buffer;
-        else {
-            buffer = new int[buffer.length];
-            System.arraycopy(buffer, 0, this.buffer, 0, this.buffer.length);
-        }
-
-    }
-
-    public IntBuffer(int[] buffer) {
-        this(buffer, true);
-    }
 
     public IntBuffer(int length) {
         super(length);
     }
 
-    @Override
-    public void setData(int[] data) {
-        this.buffer = data;
+    public IntBuffer(int[] data, boolean copy) {
+        super(data, copy);
     }
 
-    @Override
-    public void setData(float[] data) {
-        this.buffer = ArrayUtil.toInts(data);
-    }
-
-    @Override
-    public void setData(double[] data) {
-        this.buffer = ArrayUtil.toInts(data);
-    }
-
-    @Override
-    public byte[] asBytes() {
-        return new byte[0];
-    }
 
     @Override
     public DataBuffer.Type dataType() {
         return DataBuffer.Type.INT;
     }
 
-    @Override
-    public float[] asFloat() {
-        float[] ret = new float[length];
-        for (int i = 0; i < ret.length; i++) {
-            ret[i] = (float) buffer[i];
-        }
-        return ret;
-    }
 
 
     @Override
@@ -94,105 +49,4 @@ public class IntBuffer extends BaseDataBuffer {
         return 4;
     }
 
-    @Override
-    public void assign(Number value, int offset) {
-        for (int i = offset; i < length(); i++) {
-            buffer[i] = value.intValue();
-        }
-    }
-
-
-    @Override
-    public double[] asDouble() {
-        double[] ret = new double[length];
-        for (int i = 0; i < ret.length; i++) {
-            ret[i] = (double) buffer[i];
-        }
-        return ret;
-    }
-
-    @Override
-    public int[] asInt() {
-        return buffer;
-    }
-
-
-    @Override
-    public double getDouble(int i) {
-        return buffer[i];
-    }
-
-    @Override
-    public float getFloat(int i) {
-        return buffer[i];
-    }
-
-    @Override
-    public Number getNumber(int i) {
-        return buffer[i];
-    }
-
-    @Override
-    public void put(int i, float element) {
-        buffer[i] = (int) element;
-    }
-
-    @Override
-    public void put(int i, double element) {
-        buffer[i] = (int) element;
-    }
-
-    @Override
-    public void put(int i, int element) {
-        buffer[i] = element;
-    }
-
-    @Override
-    public int getInt(int ix) {
-        return buffer[ix];
-    }
-
-    @Override
-    public DataBuffer dup() {
-        return new IntBuffer(ArrayUtil.copy(buffer));
-    }
-
-    @Override
-    public void flush() {
-        path = UUID.randomUUID().toString();
-        if (memoryMappedBuffer != null)
-            return;
-        try {
-            memoryMappedBuffer = new RandomAccessFile(path, "rw");
-            long size = 8L * length;
-            for (long offset = 0; offset < size; offset += MAPPING_SIZE) {
-                long size2 = Math.min(size - offset, MAPPING_SIZE);
-                mappings.add(memoryMappedBuffer.getChannel().map(FileChannel.MapMode.READ_WRITE, offset, size2));
-            }
-        } catch (IOException e) {
-            try {
-                if (memoryMappedBuffer != null)
-                    memoryMappedBuffer.close();
-            } catch (IOException e1) {
-                throw new RuntimeException(e);
-            }
-            throw new RuntimeException(e);
-        }
-
-        buffer = null;
-    }
-
-    public void destroy() {
-        if (buffer != null)
-            buffer = null;
-        if (memoryMappedBuffer != null) {
-            try {
-                this.mappings.clear();
-                this.memoryMappedBuffer.close();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-
-            }
-        }
-    }
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/IntBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/IntBuffer.java
@@ -20,6 +20,8 @@
 package org.nd4j.linalg.api.buffer;
 
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * Int buffer
  *
@@ -30,6 +32,42 @@ public class IntBuffer extends BaseDataBuffer {
 
     public IntBuffer(int length) {
         super(length);
+    }
+
+    public IntBuffer(int[] data) {
+        super(data);
+    }
+
+    public IntBuffer(double[] data) {
+        super(data);
+    }
+
+    public IntBuffer(float[] data) {
+        super(data);
+    }
+
+    @Override
+    public DataBuffer create(double[] data) {
+        return new IntBuffer(data);
+    }
+
+    @Override
+    public DataBuffer create(float[] data) {
+       return new IntBuffer(data);
+    }
+
+    @Override
+    public DataBuffer create(int[] data) {
+       return new IntBuffer(data);
+    }
+
+    public IntBuffer(ByteBuf buf,int length) {
+        super(buf,length);
+    }
+
+    @Override
+    public DataBuffer create(ByteBuf buf,int length) {
+        return new IntBuffer(buf,length);
     }
 
     public IntBuffer(int[] data, boolean copy) {

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/factory/DefaultDataBufferFactory.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/factory/DefaultDataBufferFactory.java
@@ -24,6 +24,7 @@ import org.nd4j.linalg.api.buffer.DoubleBuffer;
 import org.nd4j.linalg.api.buffer.FloatBuffer;
 import org.nd4j.linalg.api.buffer.IntBuffer;
 import org.nd4j.linalg.util.ArrayUtil;
+import sun.misc.Unsafe;
 
 /**
  * Normal data buffer creation
@@ -93,6 +94,7 @@ public class DefaultDataBufferFactory implements DataBufferFactory {
 
     @Override
     public DataBuffer createDouble(int[] data, boolean copy) {
+
         return new DoubleBuffer(ArrayUtil.toDoubles(data), copy);
     }
 

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -304,18 +304,18 @@ public abstract class BaseNDArray implements INDArray {
     }
 
     public BaseNDArray(double[] data, int[] shape, char ordering) {
-        this(new DoubleBuffer(data), shape, ordering);
+        this(Nd4j.createBuffer(data), shape, ordering);
     }
 
     public BaseNDArray(double[] data, int[] shape, int[] stride, int offset, char ordering) {
-        this(new DoubleBuffer(data), shape, stride, offset, ordering);
+        this(Nd4j.createBuffer(data), shape, stride, offset, ordering);
     }
 
     public BaseNDArray(float[] data, char order) {
-        this(new FloatBuffer(data), order);
+        this(Nd4j.createBuffer(data), order);
     }
 
-    public BaseNDArray(FloatBuffer floatBuffer, char order) {
+    public BaseNDArray(DataBuffer floatBuffer, char order) {
         this(floatBuffer, new int[]{floatBuffer.length()}, Nd4j.getStrides(new int[]{floatBuffer.length()}), 0, order);
     }
 

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -2874,7 +2874,7 @@ public abstract class BaseNDArray implements INDArray {
                     //enforce 1 x m
                     if(Shape.isRowVectorShape(sliceShape)) {
                         sliceShape = new int[] {1,sliceShape[0]};
-                        retStride = ArrayUtil.of(retStride[0],1);
+                        retStride = ArrayUtil.of(1,retStride[0]);
                     }
 
                     INDArray slice2 = create(data,

--- a/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -80,8 +80,11 @@ public class Nd4j {
     public final static String INSTRUMENTATION = "instrumentation";
     public final static String RESOURCE_MANAGER = "resourcemanager";
     public final static String RESOURCE_MANGER_ON = "resourcemanager_state";
-
+    public final static String ALLOC = "alloc";
+    //the datatype used for allocating buffers
     public static DataBuffer.Type dtype = DataBuffer.Type.FLOAT;
+    //the allocation mode for the heap
+    public static DataBuffer.AllocationMode alloc = DataBuffer.AllocationMode.HEAP;
     public static char ORDER = 'c';
     public static IComplexNumber UNIT;
     public static IComplexNumber ZERO;
@@ -116,6 +119,7 @@ public class Nd4j {
     protected static OpFactory OP_FACTORY_INSTANCE;
     protected static org.nd4j.linalg.api.rng.Random random;
     protected static Instrumentation instrumentation;
+
 
     protected static Properties props = new Properties();
     protected static ReferenceQueue<INDArray> referenceQueue = new ReferenceQueue<>();
@@ -557,7 +561,7 @@ public class Nd4j {
      * @return the buffer to create
      */
     public static DataBuffer createBuffer(int length) {
-    	DataBuffer ret;
+        DataBuffer ret;
         if (dataType() == DataBuffer.Type.FLOAT)
             ret = DATA_BUFFER_FACTORY_INSTANCE.createFloat(length);
         else
@@ -902,6 +906,12 @@ public class Nd4j {
         return INSTANCE.linspace(lower, upper, num);
     }
 
+    /**
+     * Create a long row vector of all of the given ndarrays
+     * @param matrices the matrices to create the flattened ndarray for
+     * @return the flattened representation of
+     * these ndarrays
+     */
     public static INDArray toFlattened(Collection<INDArray> matrices) {
         INDArray ret = INSTANCE.toFlattened(matrices);
         logCreationIfNecessary(ret);
@@ -909,18 +919,35 @@ public class Nd4j {
 
     }
 
+    /**
+     * Create a long row vector of all of the given ndarrays
+     * @param flatten the matrices to create the flattened ndarray for
+     * @return the flattened representation of
+     * these ndarrays
+     */
     public static IComplexNDArray complexFlatten(List<IComplexNDArray> flatten) {
         IComplexNDArray ret = INSTANCE.complexFlatten(flatten);
         logCreationIfNecessary(ret);
         return ret;
     }
-
+    /**
+     * Create a long row vector of all of the given ndarrays
+     * @param flatten the matrices to create the flattened ndarray for
+     * @return the flattened representation of
+     * these ndarrays
+     */
     public static IComplexNDArray complexFlatten(IComplexNDArray... flatten) {
         IComplexNDArray ret = INSTANCE.complexFlatten(flatten);
         logCreationIfNecessary(ret);
         return ret;
     }
 
+    /**
+     * Create a long row vector of all of the given ndarrays
+     * @param matrices the matrices to create the flattened ndarray for
+     * @return the flattened representation of
+     * these ndarrays
+     */
     public static INDArray toFlattened(int length, Iterator<? extends INDArray>... matrices) {
         INDArray ret = INSTANCE.toFlattened(length, matrices);
         logCreationIfNecessary(ret);
@@ -935,6 +962,12 @@ public class Nd4j {
         return INSTANCE.bilinearProducts(curr, in);
     }
 
+    /**
+     * Create a long row vector of all of the given ndarrays
+     * @param matrices the matrices to create the flattened ndarray for
+     * @return the flattened representation of
+     * these ndarrays
+     */
     public static INDArray toFlattened(INDArray... matrices) {
         return INSTANCE.toFlattened(matrices);
     }
@@ -1300,7 +1333,7 @@ public class Nd4j {
      * @return a drandom matrix of the specified shape and range
      */
     public static INDArray rand(int rows, int columns, double min, double max, org.nd4j.linalg.api.rng.Random rng) {
-    	if(min>max) throw new IllegalArgumentException("the maximum value supplied is smaller than the minimum");
+        if(min>max) throw new IllegalArgumentException("the maximum value supplied is smaller than the minimum");
         INDArray ret = INSTANCE.rand(rows, columns, min, max, rng);
         logCreationIfNecessary(ret);
         return ret;
@@ -2950,7 +2983,7 @@ public class Nd4j {
      * @return the instance
      */
     public static IComplexNDArray createComplex(int rows, int columns, int[] stride, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(rows, columns, stride, offset);
+        IComplexNDArray ret = INSTANCE.createComplex(new int[]{rows, columns}, stride, offset, ordering);
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -2965,7 +2998,7 @@ public class Nd4j {
      * @return the instance
      */
     public static INDArray create(int rows, int columns, int[] stride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(rows, columns, stride, offset);
+        INDArray ret = INSTANCE.create(new int[]{rows, columns}, stride, offset,ordering);
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -2979,7 +3012,7 @@ public class Nd4j {
      * @return the instance
      */
     public static IComplexNDArray createComplex(int[] shape, int[] stride, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(shape, stride, offset);
+        IComplexNDArray ret = INSTANCE.createComplex(shape, stride, offset,ordering);
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -2993,7 +3026,7 @@ public class Nd4j {
      * @return the instance
      */
     public static INDArray create(int[] shape, int[] stride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(shape, stride, offset);
+        INDArray ret = INSTANCE.create(shape, stride, offset,ordering);
         logCreationIfNecessary(ret);
         return ret;
 
@@ -3008,7 +3041,7 @@ public class Nd4j {
      * @return the instance
      */
     public static IComplexNDArray createComplex(int rows, int columns, int[] stride, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(new int[] {rows, columns}, stride);
+        IComplexNDArray ret = INSTANCE.createComplex(new int[] {rows, columns}, stride,ordering);
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -3112,7 +3145,7 @@ public class Nd4j {
      * @return
      */
     public static IComplexNDArray createComplex(float[] data, int[] shape, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, ArrayUtil.calcStrides(shape, 2), offset, ordering);
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, Nd4j.getComplexStrides(shape,ordering), offset, ordering);
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -3315,43 +3348,35 @@ public class Nd4j {
             for (String key : props.stringPropertyNames())
                 System.setProperty(key, props.getProperty(key));
             String otherDtype = System.getProperty(DTYPE, props.get(DTYPE).toString());
+            String otherAlloc = System.getProperty(ALLOC,props.getProperty(ALLOC));
             dtype = otherDtype.equals("float") ? DataBuffer.Type.FLOAT : DataBuffer.Type.DOUBLE;
+            alloc = otherAlloc.equals("heap") ? DataBuffer.AllocationMode.HEAP : DataBuffer.AllocationMode.DIRECT;
             copyOnOps = Boolean.parseBoolean(props.getProperty(COPY_OPS, "true"));
             shouldInstrument = Boolean.parseBoolean(props.getProperty(INSTRUMENTATION, "false"));
             resourceManagerOn = Boolean.parseBoolean(props.getProperty(RESOURCE_MANGER_ON,"false"));
 
             ORDER = System.getProperty(ORDER_KEY, props.getProperty(ORDER_KEY, "c").toString()).charAt(0);
-            if (opExecutionerClazz == null)
-                opExecutionerClazz = (Class<? extends OpExecutioner>) Class.forName(System.getProperty(OP_EXECUTIONER, DefaultOpExecutioner.class.getName()));
-            if (fftInstanceClazz == null)
-                fftInstanceClazz = (Class<? extends FFTInstance>) Class.forName(System.getProperty(FFT_OPS, DefaultFFTInstance.class.getName()));
-            if (ndArrayFactoryClazz == null)
-                ndArrayFactoryClazz = (Class<? extends NDArrayFactory>) Class.forName(System.getProperty(NDARRAY_FACTORY_CLASS, props.get(NDARRAY_FACTORY_CLASS).toString()));
-            if (convolutionInstanceClazz == null)
-                convolutionInstanceClazz = (Class<? extends ConvolutionInstance>) Class.forName(System.getProperty(CONVOLUTION_OPS, DefaultConvolutionInstance.class.getName()));
-            if (dataBufferFactoryClazz == null) {
-                String defaultName = props.getProperty(DATA_BUFFER_OPS, DefaultDataBufferFactory.class.getName());
-                dataBufferFactoryClazz = (Class<? extends DataBufferFactory>) Class.forName(System.getProperty(DATA_BUFFER_OPS, defaultName));
-            }
+            opExecutionerClazz = (Class<? extends OpExecutioner>) Class.forName(System.getProperty(OP_EXECUTIONER, DefaultOpExecutioner.class.getName()));
+            fftInstanceClazz = (Class<? extends FFTInstance>) Class.forName(System.getProperty(FFT_OPS, DefaultFFTInstance.class.getName()));
+            ndArrayFactoryClazz = (Class<? extends NDArrayFactory>) Class.forName(System.getProperty(NDARRAY_FACTORY_CLASS, props.get(NDARRAY_FACTORY_CLASS).toString()));
+            convolutionInstanceClazz = (Class<? extends ConvolutionInstance>) Class.forName(System.getProperty(CONVOLUTION_OPS, DefaultConvolutionInstance.class.getName()));
+            String defaultName = props.getProperty(DATA_BUFFER_OPS, DefaultDataBufferFactory.class.getName());
+            dataBufferFactoryClazz = (Class<? extends DataBufferFactory>) Class.forName(System.getProperty(DATA_BUFFER_OPS, defaultName));
 
-            if (randomClazz == null) {
-                String rand = props.getProperty(RANDOM, DefaultRandom.class.getName());
-                randomClazz = (Class<? extends org.nd4j.linalg.api.rng.Random>) Class.forName(rand);
-            }
 
-            if (instrumentationClazz == null)
-                instrumentationClazz = (Class<? extends Instrumentation>) Class.forName(props.getProperty(INSTRUMENTATION, InMemoryInstrumentation.class.getName()));
+            String rand = props.getProperty(RANDOM, DefaultRandom.class.getName());
+            randomClazz = (Class<? extends org.nd4j.linalg.api.rng.Random>) Class.forName(rand);
 
-            if (opFactoryClazz == null)
-                opFactoryClazz = (Class<? extends OpFactory>) Class.forName(System.getProperty(OP_FACTORY, DefaultOpFactory.class.getName()));
 
-            if (blasWrapperClazz == null)
-                blasWrapperClazz = (Class<? extends BlasWrapper>) Class.forName(System.getProperty(BLAS_OPS, props.get(BLAS_OPS).toString()));
-            if (distributionFactoryClazz == null) {
-                String clazzName = props.getProperty(DISTRIBUTION, DefaultDistributionFactory.class.getName());
-                distributionFactoryClazz = (Class<? extends DistributionFactory>) Class.forName(clazzName);
+            instrumentationClazz = (Class<? extends Instrumentation>) Class.forName(props.getProperty(INSTRUMENTATION, InMemoryInstrumentation.class.getName()));
 
-            }
+            opFactoryClazz = (Class<? extends OpFactory>) Class.forName(System.getProperty(OP_FACTORY, DefaultOpFactory.class.getName()));
+
+            blasWrapperClazz = (Class<? extends BlasWrapper>) Class.forName(System.getProperty(BLAS_OPS, props.get(BLAS_OPS).toString()));
+            String clazzName = props.getProperty(DISTRIBUTION, DefaultDistributionFactory.class.getName());
+            distributionFactoryClazz = (Class<? extends DistributionFactory>) Class.forName(clazzName);
+
+
 
             instrumentation = instrumentationClazz.newInstance();
             OP_EXECUTIONER_INSTANCE = opExecutionerClazz.newInstance();

--- a/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -3348,7 +3348,7 @@ public class Nd4j {
             for (String key : props.stringPropertyNames())
                 System.setProperty(key, props.getProperty(key));
             String otherDtype = System.getProperty(DTYPE, props.get(DTYPE).toString());
-            String otherAlloc = System.getProperty(ALLOC,props.getProperty(ALLOC));
+            String otherAlloc = System.getProperty(ALLOC,props.getProperty(ALLOC,"heap"));
             dtype = otherDtype.equals("float") ? DataBuffer.Type.FLOAT : DataBuffer.Type.DOUBLE;
             alloc = otherAlloc.equals("heap") ? DataBuffer.AllocationMode.HEAP : DataBuffer.AllocationMode.DIRECT;
             copyOnOps = Boolean.parseBoolean(props.getProperty(COPY_OPS, "true"));

--- a/nd4j-api/src/main/java/org/nd4j/linalg/util/ArrayUtil.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/util/ArrayUtil.java
@@ -497,7 +497,7 @@ public class ArrayUtil {
      */
     public static int[] valueStartingAt(int valueStarting,int[] copy,int idxFrom,int idxAt,int length) {
         int[] ret = new int[length];
-        Arrays.fill(ret,valueStarting);
+        Arrays.fill(ret, valueStarting);
         for(int i = 0; i < length; i++) {
             if(i + idxFrom >= copy.length || i + idxAt >= ret.length)
                 break;
@@ -784,6 +784,12 @@ public class ArrayUtil {
         return ret;
     }
 
+    /**
+     * Convert a 2darray in to a flat
+     * array (row wise)
+     * @param arr the array to flatten
+     * @return a flattened representation of the array
+     */
     public static double[] flatten(double[][] arr) {
         double[] ret = new double[arr.length * arr[0].length];
         int count = 0;
@@ -793,6 +799,12 @@ public class ArrayUtil {
         return ret;
     }
 
+    /**
+     * Cast an int array to a double array
+     * @param arr the array to cast
+     * @return the elements of this
+     * array cast as an int
+     */
     public static double[][] toDouble(int[][] arr) {
         double[][] ret = new double[arr.length][arr[0].length];
         for (int i = 0; i < arr.length; i++) {
@@ -826,7 +838,7 @@ public class ArrayUtil {
 
 
     /**
-     * Combines a applyTransformToDestination of int arrays in to one flat int array
+     * Combines a apply of int arrays in to one flat int array
      *
      * @param nums the int arrays to combineDouble
      * @return one combined int array
@@ -847,7 +859,7 @@ public class ArrayUtil {
     }
 
     /**
-     * Combines a applyTransformToDestination of int arrays in to one flat int array
+     * Combines a apply of int arrays in to one flat int array
      *
      * @param nums the int arrays to combineDouble
      * @return one combined int array
@@ -868,7 +880,7 @@ public class ArrayUtil {
     }
 
     /**
-     * Combines a applyTransformToDestination of int arrays in to one flat int array
+     * Combines a apply of int arrays in to one flat int array
      *
      * @param ints the int arrays to combineDouble
      * @return one combined int array
@@ -889,7 +901,7 @@ public class ArrayUtil {
     }
 
     /**
-     * Combines a applyTransformToDestination of int arrays in to one flat int array
+     * Combines a apply of int arrays in to one flat int array
      *
      * @param ints the int arrays to combineDouble
      * @return one combined int array
@@ -941,6 +953,12 @@ public class ArrayUtil {
 
     public static float[] copy(float[] data) {
         float[] result = new float[data.length];
+        System.arraycopy(data, 0, result, 0, data.length);
+        return result;
+    }
+
+    public static double[] copy(double[] data) {
+        double[] result = new double[data.length];
         System.arraycopy(data, 0, result, 0, data.length);
         return result;
     }

--- a/nd4j-java/src/main/resources/nd4j-netlib.properties
+++ b/nd4j-java/src/main/resources/nd4j-netlib.properties
@@ -24,3 +24,5 @@ complex.double.class = org.nd4j.linalg.netlib.complex.ComplexDouble
 blas.ops = org.nd4j.linalg.netlib.NetlibBlasWrapper
 ndarrayfactory.class = org.nd4j.linalg.netlib.NetlibBlasNDArrayFactory
 ndarray.order = f
+alloc = heap
+databufferfactory = org.nd4j.linalg.api.buffer.factory.DefaultDataBufferFactory

--- a/nd4j-jblas/src/main/java/org/nd4j/linalg/jblas/JblasNDArrayFactory.java
+++ b/nd4j-jblas/src/main/java/org/nd4j/linalg/jblas/JblasNDArrayFactory.java
@@ -230,7 +230,7 @@ public class JblasNDArrayFactory extends BaseNDArrayFactory {
 
     @Override
     public INDArray create(double[] data, int[] shape, char ordering) {
-        return new NDArray(new DoubleBuffer(data), shape, ordering);
+        return new NDArray(Nd4j.createBuffer(data), shape, ordering);
     }
 
     @Override
@@ -240,12 +240,12 @@ public class JblasNDArrayFactory extends BaseNDArrayFactory {
 
     @Override
     public INDArray create(double[] data, int[] shape, int offset) {
-        return new NDArray(new DoubleBuffer(data), shape, offset);
+        return new NDArray(Nd4j.createBuffer(data), shape, offset);
     }
 
     @Override
     public INDArray create(double[] data, int[] shape, int[] stride, int offset, char ordering) {
-        return new NDArray(new DoubleBuffer(data), shape, stride, offset, ordering);
+        return new NDArray(Nd4j.createBuffer(data), shape, stride, offset, ordering);
     }
 
 

--- a/nd4j-jblas/src/main/resources/nd4j-jblas.properties
+++ b/nd4j-jblas/src/main/resources/nd4j-jblas.properties
@@ -25,3 +25,5 @@ blas.ops = org.nd4j.linalg.jblas.BlasWrapper
 ndarrayfactory.class = org.nd4j.linalg.jblas.JblasNDArrayFactory
 ndarray.order = f
 resourcemanager_state = false
+databufferfactory = org.nd4j.linalg.api.buffer.factory.DefaultDataBufferFactory
+alloc = heap

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/CublasPointer.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/CublasPointer.java
@@ -106,23 +106,47 @@ public class CublasPointer  implements AutoCloseable {
      */
     public CublasPointer(INDArray array) {
         buffer = (JCudaBuffer) array.data();
-        this.devicePointer = buffer
-                .getDevicePointer(array.majorStride(),array.offset(),array instanceof IComplexNDArray ? 2 * array.length() : array.length());
+        if(array instanceof IComplexNDArray) {
+           IComplexNDArray arr2 = (IComplexNDArray) array;
+            this.devicePointer = buffer
+                    .getDevicePointer(array.majorStride(),array.offset(),2 * array.length());
 
-        // Copy the data to the device
-        JCublas2.cublasSetVectorAsync(
-                array instanceof IComplexNDArray ? array.length() * 2 : array.length()
-                , array.data().getElementSize()
-                , buffer.getHostPointer().withByteOffset(array.offset() * array.data().getElementSize())
-                , array.majorStride()
-                , devicePointer
-                , 1
-                , ContextHolder.getInstance().getCudaStream());
+            // Copy the data to the device
+            JCublas2.cublasSetVectorAsync(
+                    array instanceof IComplexNDArray ? array.length() * 2 : array.length()
+                    , array.data().getElementSize()
+                    , buffer.getHostPointer().withByteOffset(arr2.blasOffset() * array.data().getElementSize())
+                    , array.majorStride()
+                    , devicePointer
+                    , 1
+                    , ContextHolder.getInstance().getCudaStream());
+
+        }
+        else {
+            this.devicePointer = buffer
+                    .getDevicePointer(array.majorStride(),array.offset(),array instanceof IComplexNDArray ? 2 * array.length() : array.length());
+
+            // Copy the data to the device
+            JCublas2.cublasSetVectorAsync(
+                    array instanceof IComplexNDArray ? array.length() * 2 : array.length()
+                    , array.data().getElementSize()
+                    , buffer.getHostPointer().withByteOffset(array.offset() * array.data().getElementSize())
+                    , array.majorStride()
+                    , devicePointer
+                    , 1
+                    , ContextHolder.getInstance().getCudaStream());
+
+        }
+
 
         ContextHolder.syncStream();
 
     }
 
+
+    public boolean isClosed() {
+        return closed;
+    }
 
 
 

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
@@ -327,7 +327,7 @@ public class JCublasNDArray extends BaseNDArray {
     }
 
     public JCublasNDArray(double[] data, int[] shape, char ordering) {
-        this(new DoubleBuffer(data), shape, 0,ordering);
+        this(Nd4j.createBuffer(data), shape, 0,ordering);
     }
 
     public JCublasNDArray(double[] data, int[] shape, int[] stride, int offset, char ordering) {

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -606,12 +606,21 @@ public abstract class BaseCudaDataBuffer implements JCudaBuffer {
         final private long length;
         final private int stride;
         final private int offset;
+        private boolean freed = false;
 
         public DevicePointerInfo(Pointer pointer, long length,int stride,int offset) {
             this.pointer = pointer;
             this.length = length;
             this.stride = stride;
             this.offset = offset;
+        }
+
+        public boolean isFreed() {
+            return freed;
+        }
+
+        public void setFreed(boolean freed) {
+            this.freed = freed;
         }
 
         public int getOffset() {

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -71,6 +71,7 @@ public abstract class BaseCudaDataBuffer implements JCudaBuffer {
     protected boolean isPersist = false;
     protected AtomicBoolean freed = new AtomicBoolean(false);
     protected AtomicInteger referenceCount = new AtomicInteger(0);
+    protected AllocationMode allocationMode;
     private Pointer hostPointer;
 
     /**
@@ -84,11 +85,16 @@ public abstract class BaseCudaDataBuffer implements JCudaBuffer {
             throw new IllegalArgumentException("Length was " + length + " but should have been > 0. Element size was " + elementSize + " but should have been >= 4");
         this.length = length;
         this.elementSize = elementSize;
+        allocationMode = Nd4j.alloc;
         hostBuffer = ByteBuffer.allocateDirect(getElementSize() * length());
         hostBuffer.order(ByteOrder.nativeOrder());
     }
 
 
+    @Override
+    public AllocationMode allocationMode() {
+        return allocationMode;
+    }
 
     @Override
     public ByteBuffer getHostBuffer() {

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/buffer/allocation/PinnedMemoryStrategy.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/buffer/allocation/PinnedMemoryStrategy.java
@@ -57,6 +57,9 @@ public class PinnedMemoryStrategy implements MemoryStrategy {
         JCudaBuffer buf2 = (JCudaBuffer) buffer;
         Map<String,BaseCudaDataBuffer.DevicePointerInfo> pointers = buf2.getPointersToContexts();
         BaseCudaDataBuffer.DevicePointerInfo devicePointerInfo = pointers.get(Thread.currentThread().getName());
-        JCuda.cudaFreeHost(devicePointerInfo.getPointer());
+        if(!devicePointerInfo.isFreed()) {
+            JCuda.cudaFreeHost(devicePointerInfo.getPointer());
+            devicePointerInfo.setFreed(true);
+        }
     }
 }

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/buffer/factory/CudaDataBufferFactory.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/buffer/factory/CudaDataBufferFactory.java
@@ -73,7 +73,7 @@ public class CudaDataBufferFactory implements DataBufferFactory {
 
     @Override
     public DataBuffer createInt(double[] data) {
-        return new IntBuffer(ArrayUtil.toInts(data));
+        return new CudaIntDataBuffer(ArrayUtil.toInts(data));
     }
 
     @Override
@@ -88,7 +88,7 @@ public class CudaDataBufferFactory implements DataBufferFactory {
 
     @Override
     public DataBuffer createInt(float[] data) {
-        return new IntBuffer(ArrayUtil.toInts(data));
+        return new CudaIntDataBuffer(ArrayUtil.toInts(data));
     }
 
     @Override

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/resources/nd4j-jcublas.properties
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/resources/nd4j-jcublas.properties
@@ -29,3 +29,4 @@ databufferfactory = org.nd4j.linalg.jcublas.buffer.factory.CudaDataBufferFactory
 ndarray.copyops = true
 opexec= org.nd4j.linalg.jcublas.ops.executioner.JCudaExecutioner
 resourcemanager_state = true
+alloc = direct

--- a/nd4j-netlib-blas/src/main/resources/nd4j-netlib.properties
+++ b/nd4j-netlib-blas/src/main/resources/nd4j-netlib.properties
@@ -24,3 +24,5 @@ complex.double.class = org.nd4j.linalg.netlib.complex.ComplexDouble
 blas.ops = org.nd4j.linalg.netlib.NetlibBlasWrapper
 ndarrayfactory.class = org.nd4j.linalg.netlib.NetlibBlasNDArrayFactory
 ndarray.order = f
+alloc = heap
+databufferfactory = org.nd4j.linalg.api.buffer.factory.DefaultDataBufferFactory

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ComplexNDArrayTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ComplexNDArrayTestsC.java
@@ -586,7 +586,7 @@ public  class ComplexNDArrayTestsC extends BaseComplexNDArrayTests  {
 
     @Test
     public void testGetComplex() {
-        IComplexNDArray arr = Nd4j.createComplex(Nd4j.create(new DoubleBuffer(new double[]{
+        IComplexNDArray arr = Nd4j.createComplex(Nd4j.create(Nd4j.createBuffer(new double[]{
                 1,2,3,4,5
         })));
 

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ComplexNDArrayTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ComplexNDArrayTestsC.java
@@ -602,11 +602,7 @@ public  class ComplexNDArrayTestsC extends BaseComplexNDArrayTests  {
 
     }
 
-    @Test
-    public void testNdArrayConstructor() {
-        IComplexNDArray result = Nd4j.createComplex(Nd4j.create(new double[]{2, 6}, new int[]{1, 2}));
-        result.toString();
-    }
+
 
     @Test
     public void testGetColumn() {
@@ -624,7 +620,7 @@ public  class ComplexNDArrayTestsC extends BaseComplexNDArrayTests  {
         assertEquals(column, firstColumn);
 
 
-        IComplexNDArray column1 = Nd4j.createComplex(new double[]{5, 0, 6, 0}, new int[]{2});
+        IComplexNDArray column1 = Nd4j.createComplex(new double[]{5, 0, 6, 0}, new int[]{1,2});
         arr.putColumn(1, column1);
         assertEquals(true, Shape.shapeEquals(new int[]{2}, arr.getColumn(1).shape()));
         IComplexNDArray testC = arr.getColumn(1);

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/NDArrayTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/NDArrayTestsC.java
@@ -56,6 +56,7 @@ public  class NDArrayTestsC extends BaseNDArrayTests {
 
 
     public NDArrayTestsC() {
+        System.out.println();
     }
 
     public NDArrayTestsC(String name) {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ops/OpExecutionerTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ops/OpExecutionerTests.java
@@ -292,7 +292,7 @@ public  class OpExecutionerTests extends BaseNd4jTest {
         INDArray slice = arr.slice(0);
         Log exp = new Log(slice);
         opExecutioner.exec(exp);
-        assertEquals(Nd4j.create(new FloatBuffer(new float[]{0.f, 1.09861229f, 1.60943791f})), slice);
+        assertEquals(Nd4j.create(Nd4j.createBuffer(new float[]{0.f, 1.09861229f, 1.60943791f})), slice);
     }
 
     @Test
@@ -302,7 +302,7 @@ public  class OpExecutionerTests extends BaseNd4jTest {
         INDArray slice = arr.slice(0);
         Exp exp = new Exp(slice);
         opExecutioner.exec(exp);
-        assertEquals(Nd4j.create(new FloatBuffer(new float[]{2.7182817459106445f, 20.08553695678711f, 148.4131622314453f})), slice);
+        assertEquals(Nd4j.create(Nd4j.createBuffer(new float[]{2.7182817459106445f, 20.08553695678711f, 148.4131622314453f})), slice);
     }
 
     @Test


### PR DESCRIPTION
Use netty off heap buffers or normal arrays. This makes the storage configurable at the byte buffer level allowing flexibility for backends to be more easily extendable by JNI.

Netty has already been highly optimized in the field and works great for a simple storage abstraction.

This introduces a new knob: An allocation type.

The allocation type can be heap or direct.

Heap is used for direct array allocation where asDouble() needs to be called often (allowing constant time behavior). This needs to happen in jblas to leverage the blas operations. Net lib blas also does not expose an NIO interface.

This will open up room for future tuning as well as the ability to tune different kinds of backends.