### PR TITLE
fix serialization bug (long->int)

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -730,7 +730,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
     protected void doWriteObject(java.io.ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
         out.writeUTF(allocationMode.name());
-        out.writeLong(length());
+        out.writeInt(length());
         out.writeUTF(dataType().name());
         if(dataType() == Type.DOUBLE) {
             for(int i = 0; i < length(); i++)


### PR DESCRIPTION
Fixes regression from 1efb7ae5e78600401e3c0fed79ffc7425a2b4471 which rendered nd4j arrays not serializable.