### PR TITLE
Fixed RNG and decoupled SplitTestAndTrain random from weights.

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/rng/DefaultRandom.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/rng/DefaultRandom.java
@@ -19,9 +19,9 @@
 
 package org.nd4j.linalg.api.rng;
 
-import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.apache.commons.math3.random.MersenneTwister;
 import org.apache.commons.math3.random.RandomGenerator;
+import org.apache.commons.math3.random.SynchronizedRandomGenerator;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -32,44 +32,36 @@ import org.nd4j.linalg.factory.Nd4j;
  */
 public class DefaultRandom implements Random, RandomGenerator {
     protected RandomGenerator randomGenerator;
-
+    protected long seed;
     /**
      * Initialize with a System.currentTimeMillis()
      * seed
      */
-    public DefaultRandom() {
-        this(System.currentTimeMillis());
-    }
+    public DefaultRandom() { this(System.currentTimeMillis()); }
 
     public DefaultRandom(long seed) {
-        RandomGenerator gen = new JDKRandomGenerator();
-        gen.setSeed(seed);
-        this.randomGenerator = gen;
+        this.seed = seed;
+        this.randomGenerator = new SynchronizedRandomGenerator(new MersenneTwister(seed));
     }
-
 
     public DefaultRandom(RandomGenerator randomGenerator) {
         this.randomGenerator = randomGenerator;
     }
 
     @Override
-    public java.util.Random asRandom() {
-        JDKRandomGenerator rng = (JDKRandomGenerator) randomGenerator;
-        return rng;
-    }
-
-    @Override
     public void setSeed(int seed) {
+        this.seed = (long) seed;
         getRandomGenerator().setSeed(seed);
     }
 
     @Override
     public void setSeed(int[] seed) {
-        getRandomGenerator().setSeed(seed);
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setSeed(long seed) {
+        this.seed= seed;
         getRandomGenerator().setSeed(seed);
     }
 
@@ -166,6 +158,10 @@ public class DefaultRandom implements Random, RandomGenerator {
 
     public synchronized RandomGenerator getRandomGenerator() {
         return randomGenerator;
+    }
+
+    public synchronized long getSeed(){
+        return this.seed;
     }
 
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/rng/Random.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/rng/Random.java
@@ -30,12 +30,6 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 public interface Random {
 
     /**
-     * Convert generator to java.util.Random
-     * @return this as java.util.Random
-     */
-    java.util.Random asRandom();
-
-    /**
      * Sets the seed of the underlying random number generator using an
      * <code>int</code> seed.
      * <p>Sequences of values generated starting with the same seeds
@@ -48,7 +42,7 @@ public interface Random {
 
     /**
      * Sets the seed of the underlying random number generator using an
-     * <code>int</code> array seed.
+     * <code>int</code> seed.
      * <p>Sequences of values generated starting with the same seeds
      * should be identical.
      * </p>
@@ -56,6 +50,7 @@ public interface Random {
      * @param seed the seed value
      */
     void setSeed(int[] seed);
+
 
     /**
      * Sets the seed of the underlying random number generator using a
@@ -67,6 +62,14 @@ public interface Random {
      * @param seed the seed value
      */
     void setSeed(long seed);
+
+    /**
+     * Gets the  <code>long</code> seed of the underlying
+     * random number generator.
+     *
+     * @return the seed value
+     */
+    long getSeed();
 
     /**
      * Generates random bytes and places them into a user-supplied

--- a/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -22,7 +22,6 @@ package org.nd4j.linalg.dataset;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.BooleanIndexing;
 import org.nd4j.linalg.indexing.conditions.Condition;
@@ -501,7 +500,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      * @return the pair of datasets for the train test split
      */
     @Override
-    public SplitTestAndTrain splitTestAndTrain(int numHoldout, Random rnd) {
+    public SplitTestAndTrain splitTestAndTrain(int numHoldout, Random rng) {
 
         if (numHoldout >= numExamples())
             throw new IllegalArgumentException("Unable to split on size larger than the number of rows");
@@ -509,7 +508,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
         List<DataSet> list = asList();
 
         Collections.rotate(list, 3);
-        Collections.shuffle(list, rnd.asRandom());
+        Collections.shuffle(list, rng);
         List<List<DataSet>> partition = new ArrayList<>();
         partition.add(list.subList(0, numHoldout));
         partition.add(list.subList(numHoldout, list.size()));
@@ -520,8 +519,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
 
     @Override
     public SplitTestAndTrain splitTestAndTrain(int numHoldout) {
-        Random rnd = Nd4j.getRandom();
-        return splitTestAndTrain(numHoldout, rnd);
+        return splitTestAndTrain(numHoldout, new Random());
     }
 
 

--- a/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
@@ -20,7 +20,6 @@
 package org.nd4j.linalg.dataset.api;
 
 import com.google.common.base.Function;
-import org.apache.commons.math3.random.RandomGenerator;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.dataset.SplitTestAndTrain;
@@ -99,9 +98,9 @@ public interface DataSet extends Iterable<org.nd4j.linalg.dataset.DataSet>, Seri
 
     List<org.nd4j.linalg.dataset.DataSet> asList();
 
-    SplitTestAndTrain splitTestAndTrain(int numHoldout);
+    SplitTestAndTrain splitTestAndTrain(int numHoldout, java.util.Random rnd);
 
-    SplitTestAndTrain splitTestAndTrain(int numHoldout, Random rnd);
+    SplitTestAndTrain splitTestAndTrain(int numHoldout);
 
     INDArray getLabels();
 

--- a/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -139,6 +139,7 @@ public class Nd4j {
     public static ReferenceQueue<INDArray> refQueue() {
         return referenceQueue;
     }
+
     /**
      * The reference queue used for cleaning up
      * databuffers
@@ -148,8 +149,6 @@ public class Nd4j {
     public static ReferenceQueue<DataBuffer> bufferRefQueue() {
         return bufferQueue;
     }
-
-
 
     /**
      * Gets the instrumentation instance
@@ -184,7 +183,6 @@ public class Nd4j {
             throw new IllegalStateException("Illegal random not found");
         return random;
     }
-
 
     /**
      * Get the convolution singleton
@@ -301,7 +299,6 @@ public class Nd4j {
                 }
             }
         }
-
 
         if (index != theta.length()) {
             throw new AssertionError("Did not entirely use the theta vector");
@@ -636,27 +633,6 @@ public class Nd4j {
      */
     public static void setBlasWrapper(BlasWrapper factory) {
         BLAS_WRAPPER_INSTANCE = factory;
-    }
-
-    /**
-     * Create a complex ndarray based on the
-     * real and imaginary
-     *
-     * @param real the real numbers
-     * @param imag the imaginary components
-     * @return the complex
-     */
-    public static IComplexNDArray createComplex(INDArray real, INDArray imag) {
-        assert Shape.shapeEquals(real.shape(), imag.shape());
-        IComplexNDArray ret = Nd4j.createComplex(real.shape());
-        INDArray realLinear = real.linearView();
-        INDArray imagLinear = imag.linearView();
-        IComplexNDArray retLinear = ret.linearView();
-        for (int i = 0; i < ret.length(); i++) {
-            retLinear.putScalar(i, Nd4j.createComplexNumber(realLinear.getDouble(i), imagLinear.getDouble(i)));
-        }
-        logCreationIfNecessary(ret);
-        return ret;
     }
 
     /**
@@ -1159,16 +1135,6 @@ public class Nd4j {
     }
 
     /**
-     * Create an ndarray based on the given data layout
-     *
-     * @param data the data to use
-     * @return an ndarray with the given data layout
-     */
-    public static INDArray create(double[][] data) {
-        return INSTANCE.create(data);
-    }
-
-    /**
      * Read in an ndarray from a data input stream
      *
      * @param dis the data input stream to read from
@@ -1261,19 +1227,6 @@ public class Nd4j {
         return ret;
     }
 
-    /**
-     * Create double
-     *
-     * @param real real component
-     * @param imag imag component
-     * @return
-     */
-    public static IComplexNumber createComplexNumber(Number real, Number imag) {
-        if (dataType() == DataBuffer.Type.FLOAT)
-            return INSTANCE.createFloat(real.floatValue(), imag.floatValue());
-        return INSTANCE.createDouble(real.doubleValue(), imag.doubleValue());
-
-    }
 
     /**
      * Create double
@@ -1305,38 +1258,6 @@ public class Nd4j {
      */
     public static void copy(INDArray a, INDArray b) {
         INSTANCE.copy(a, b);
-    }
-
-    /**
-     * Generates a random matrix between min and max
-     *
-     * @param shape the number of rows of the matrix
-     * @param min   the minimum number
-     * @param max   the maximum number
-     * @param rng   the rng to use
-     * @return a drandom matrix of the specified shape and range
-     */
-    public static INDArray rand(int[] shape, double min, double max, org.nd4j.linalg.api.rng.Random rng) {
-        INDArray ret = INSTANCE.rand(shape, min, max, rng);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Generates a random matrix between min and max
-     *
-     * @param rows    the number of rows of the matrix
-     * @param columns the number of columns in the matrix
-     * @param min     the minimum number
-     * @param max     the maximum number
-     * @param rng     the rng to use
-     * @return a drandom matrix of the specified shape and range
-     */
-    public static INDArray rand(int rows, int columns, double min, double max, org.nd4j.linalg.api.rng.Random rng) {
-        if(min>max) throw new IllegalArgumentException("the maximum value supplied is smaller than the minimum");
-        INDArray ret = INSTANCE.rand(rows, columns, min, max, rng);
-        logCreationIfNecessary(ret);
-        return ret;
     }
 
     /**
@@ -1466,6 +1387,280 @@ public class Nd4j {
                 x.putScalar(i, i, func.apply(x.getComplex(i, i)));
     }
 
+
+    ////////////////////// RANDOM ///////////////////////////////
+    /**
+     * Create a random ndarray with the given shape using
+     * the current time as the seed
+     *
+     * @param shape the shape of the ndarray
+     * @return the random ndarray with the specified shape
+     */
+    public static INDArray rand(int[] shape) {
+        INDArray ret = INSTANCE.rand(shape);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+
+    /**
+     * Create a random ndarray with the given shape using
+     * the current time as the seed
+     *
+     * @param rows    the number of rows in the matrix
+     * @param columns the number of columns in the matrix
+     * @return the random ndarray with the specified shape
+     */
+    public static INDArray rand(int rows, int columns) {
+        INDArray ret = INSTANCE.rand(rows, columns);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create a random ndarray with the given shape using given seed
+     *
+     * @param shape the shape of the ndarray
+     * @param seed  the  seed to use
+     * @return the random ndarray with the specified shape
+     */
+    public static INDArray rand(int[] shape, long seed) {
+        INDArray ret = INSTANCE.rand(shape, seed);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create a random ndarray with the given shape using the given seed
+     *
+     * @param seed the seed
+     * @param shape  the shape
+     * @return the random ndarray with the specified shape
+     */
+    public static INDArray rand(long seed,int...shape) {
+        INDArray ret = INSTANCE.rand(shape, seed);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create a random ndarray with the given shape using the given seed
+     *
+     * @param rows    the number of rows in the matrix
+     * @param columns the columns of the ndarray
+     * @param seed    the  seed to use
+     * @return the random ndarray with the specified shape
+     */
+    public static INDArray rand(int rows, int columns, long seed) {
+        INDArray ret = INSTANCE.rand(rows, columns, seed);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create a random ndarray with the given shape using the given RandomGenerator
+     *
+     * @param shape the shape of the ndarray
+     * @param rng     the random generator to use
+     * @return the random ndarray with the specified shape
+     */
+    public static INDArray rand(int[] shape, org.nd4j.linalg.api.rng.Random rng) {
+        INDArray ret = INSTANCE.rand(shape, rng);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create a random ndarray with the given shape using the given rng
+     *
+     * @param shape the shape of the ndarray
+     * @param dist  distribution to use
+     * @return the random ndarray with the specified shape
+     */
+    public static INDArray rand(int[] shape, Distribution dist) {
+        INDArray ret = INSTANCE.rand(shape, dist);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create a random ndarray with the given shape using the given rng
+     *
+     * @param rows    the number of rows in the matrix
+     * @param columns the number of columns in the matrix
+     * @param rng       the random generator to use
+     * @return the random ndarray with the specified shape
+     */
+    @Deprecated
+    public static INDArray rand(int rows, int columns, org.nd4j.linalg.api.rng.Random rng) {
+        INDArray ret = INSTANCE.rand(rows, columns, rng);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Generates a random matrix between min and max
+     *
+     * @param shape the number of rows of the matrix
+     * @param min   the minimum number
+     * @param max   the maximum number
+     * @param rng   the rng to use
+     * @return a drandom matrix of the specified shape and range
+     */
+    public static INDArray rand(int[] shape, double min, double max, org.nd4j.linalg.api.rng.Random rng) {
+        INDArray ret = INSTANCE.rand(shape, min, max, rng);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Generates a random matrix between min and max
+     *
+     * @param rows    the number of rows of the matrix
+     * @param columns the number of columns in the matrix
+     * @param min     the minimum number
+     * @param max     the maximum number
+     * @param rng     the rng to use
+     * @return a drandom matrix of the specified shape and range
+     */
+    public static INDArray rand(int rows, int columns, double min, double max, org.nd4j.linalg.api.rng.Random rng) {
+        if(min>max) throw new IllegalArgumentException("the maximum value supplied is smaller than the minimum");
+        INDArray ret = INSTANCE.rand(rows, columns, min, max, rng);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Random normal using the current time stamp
+     * as the seed
+     *
+     * @param shape the shape of the ndarray
+     * @return
+     */
+    public static INDArray randn(int[] shape) {
+        INDArray ret = INSTANCE.randn(shape);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Random normal using the specified seed
+     *
+     * @param shape the shape of the ndarray
+     * @return
+     */
+    public static INDArray randn(int[] shape, long seed) {
+        Nd4j.getRandom().setSeed(seed);
+        return randn(shape, Nd4j.getRandom());
+    }
+
+    /**
+     * Random normal using the current time stamp
+     * as the seed
+     *
+     * @param rows    the number of rows in the matrix
+     * @param columns the number of columns in the matrix
+     * @return
+     */
+    public static INDArray randn(int rows, int columns) {
+        INDArray ret = INSTANCE.randn(rows, columns);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Random normal using the specified seed
+     *
+     * @param rows    the number of rows in the matrix
+     * @param columns the number of columns in the matrix
+     * @return
+     */
+    public static INDArray randn(int rows, int columns, long seed) {
+        INDArray ret = INSTANCE.randn(rows, columns, seed);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Random normal using the given rng
+     *
+     * @param rows    the number of rows in the matrix
+     * @param columns the number of columns in the matrix
+     * @param r       the random generator to use
+     * @return
+     */
+    public static INDArray randn(int rows, int columns, org.nd4j.linalg.api.rng.Random r) {
+        INDArray ret = INSTANCE.randn(rows, columns, r);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Random normal using the given rng
+     *
+     * @param shape the shape of the ndarray
+     * @param r     the random generator to use
+     * @return
+     */
+    public static INDArray randn(int[] shape, org.nd4j.linalg.api.rng.Random r) {
+        INDArray ret = INSTANCE.randn(shape, r);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+
+    ////////////////////// CREATE ///////////////////////////////
+
+    /**
+     * Creates a row vector with the data
+     *
+     * @param data the columns of the ndarray
+     * @return the created ndarray
+     */
+    public static INDArray create(float[] data) {
+        return create(data, order());
+    }
+
+    /**
+     * Creates an ndarray with the specified data
+     *
+     * @param data the number of columns in the row vector
+     * @return ndarray
+     */
+    public static IComplexNDArray createComplex(float[] data) {
+        return createComplex(data, Nd4j.order());
+
+    }
+
+    /**
+     * Creates a row vector with the data
+     *
+     * @param data the columns of the ndarray
+     * @return the created ndarray
+     */
+    public static INDArray create(double[] data) {
+        return create(data, order());
+    }
+
+    /**
+     *
+     * @param doubles
+     * @return
+     */
+    public static INDArray create(float[][] doubles) {
+        return INSTANCE.create(doubles);
+    }
+
+    /**
+     * Create an ndarray based on the given data layout
+     *
+     * @param data the data to use
+     * @return an ndarray with the given data layout
+     */
+    public static INDArray create(double[][] data) {
+        return INSTANCE.create(data);
+    }
+
     /**
      * Create a complex ndarray from the passed in indarray
      *
@@ -1477,6 +1672,61 @@ public class Nd4j {
         if (arr instanceof IComplexNDArray)
             return (IComplexNDArray) arr;
         IComplexNDArray ret = INSTANCE.createComplex(arr);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a row vector with the specified number of columns
+     *
+     * @param columns the columns of the ndarray
+     * @return the created ndarray
+     */
+    public static INDArray create(int columns) {
+        return create(columns, order());
+    }
+
+    /**
+     * Creates an ndarray
+     *
+     * @param columns the number of columns in the row vector
+     * @return ndarray
+     */
+    public static IComplexNDArray createComplex(int columns) {
+        return createComplex(columns, order());
+    }
+
+
+    /**
+     * Create double based on real and imaginary
+     *
+     * @param real real component
+     * @param imag imag component
+     * @return
+     */
+    public static IComplexNumber createComplexNumber(Number real, Number imag) {
+        if (dataType() == DataBuffer.Type.FLOAT)
+            return INSTANCE.createFloat(real.floatValue(), imag.floatValue());
+        return INSTANCE.createDouble(real.doubleValue(), imag.doubleValue());
+
+    }
+    /**
+     * Create a complex ndarray based on the
+     * real and imaginary
+     *
+     * @param real the real numbers
+     * @param imag the imaginary components
+     * @return the complex
+     */
+    public static IComplexNDArray createComplex(INDArray real, INDArray imag) {
+        assert Shape.shapeEquals(real.shape(), imag.shape());
+        IComplexNDArray ret = Nd4j.createComplex(real.shape());
+        INDArray realLinear = real.linearView();
+        INDArray imagLinear = imag.linearView();
+        IComplexNDArray retLinear = ret.linearView();
+        for (int i = 0; i < ret.length(); i++) {
+            retLinear.putScalar(i, Nd4j.createComplexNumber(realLinear.getDouble(i), imagLinear.getDouble(i)));
+        }
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -1497,19 +1747,6 @@ public class Nd4j {
     /**
      * Create a complex ndarray from the passed in indarray
      *
-     * @param data the data to wrap
-     * @return the complex ndarray with the specified ndarray as the
-     * real components
-     */
-    public static IComplexNDArray createComplex(IComplexNumber[] data, int[] shape, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create a complex ndarray from the passed in indarray
-     *
      * @param arrs the arr to wrap
      * @return the complex ndarray with the specified ndarray as the
      * real components
@@ -1521,192 +1758,6 @@ public class Nd4j {
     }
 
     /**
-     * Create a random ndarray with the given shape using the given rng
-     *
-     * @param rows    the number of rows in the matrix
-     * @param columns the number of columns in the matrix
-     * @param r       the random generator to use
-     * @return the random ndarray with the specified shape
-     */
-    @Deprecated
-    public static INDArray rand(int rows, int columns, org.nd4j.linalg.api.rng.Random r) {
-        INDArray ret = INSTANCE.rand(rows, columns, r);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create a random ndarray with the given shape using the given rng
-     *
-     * @param seed the seed
-     * @param shape  the shape
-     * @return the random ndarray with the specified shape
-     */
-    public static INDArray rand(long seed,int...shape) {
-        INDArray ret = INSTANCE.rand(shape, seed);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create a random ndarray with the given shape using the given rng
-     *
-     * @param rows    the number of rows in the matrix
-     * @param columns the columns of the ndarray
-     * @param seed    the  seed to use
-     * @return the random ndarray with the specified shape
-     */
-    public static INDArray rand(int rows, int columns, long seed) {
-        INDArray ret = INSTANCE.rand(rows, columns, seed);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create a random ndarray with the given shape using
-     * the current time as the seed
-     *
-     * @param rows    the number of rows in the matrix
-     * @param columns the number of columns in the matrix
-     * @return the random ndarray with the specified shape
-     */
-    public static INDArray rand(int rows, int columns) {
-        INDArray ret = INSTANCE.rand(rows, columns,Nd4j.getRandom());
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Random normal using the given rng
-     *
-     * @param rows    the number of rows in the matrix
-     * @param columns the number of columns in the matrix
-     * @param r       the random generator to use
-     * @return
-     */
-    public static INDArray randn(int rows, int columns, org.nd4j.linalg.api.rng.Random r) {
-        INDArray ret = INSTANCE.randn(rows, columns, r);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Random normal using the current time stamp
-     * as the seed
-     *
-     * @param rows    the number of rows in the matrix
-     * @param columns the number of columns in the matrix
-     * @return
-     */
-    public static INDArray randn(int rows, int columns) {
-        INDArray ret = INSTANCE.randn(rows, columns,Nd4j.getRandom());
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Random normal using the specified seed
-     *
-     * @param rows    the number of rows in the matrix
-     * @param columns the number of columns in the matrix
-     * @return
-     */
-    public static INDArray randn(int rows, int columns, long seed) {
-        INDArray ret = INSTANCE.randn(rows, columns, seed);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create a random ndarray with the given shape using the given rng
-     *
-     * @param shape the shape of the ndarray
-     * @param r     the random generator to use
-     * @return the random ndarray with the specified shape
-     */
-    public static INDArray rand(int[] shape, Distribution r) {
-        INDArray ret = INSTANCE.rand(shape, r);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create a random ndarray with the given shape using the given rng
-     *
-     * @param shape the shape of the ndarray
-     * @param r     the random generator to use
-     * @return the random ndarray with the specified shape
-     */
-    public static INDArray rand(int[] shape, org.nd4j.linalg.api.rng.Random r) {
-        INDArray ret = INSTANCE.rand(shape, r);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create a random ndarray with the given shape using the given rng
-     *
-     * @param shape the shape of the ndarray
-     * @param seed  the  seed to use
-     * @return the random ndarray with the specified shape
-     */
-    public static INDArray rand(int[] shape, long seed) {
-        INDArray ret = INSTANCE.rand(shape, seed);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create a random ndarray with the given shape using
-     * the current time as the seed
-     *
-     * @param shape the shape of the ndarray
-     * @return the random ndarray with the specified shape
-     */
-    public static INDArray rand(int[] shape) {
-        INDArray ret = INSTANCE.rand(shape,Nd4j.getRandom());
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Random normal using the given rng
-     *
-     * @param shape the shape of the ndarray
-     * @param r     the random generator to use
-     * @return
-     */
-    public static INDArray randn(int[] shape, org.nd4j.linalg.api.rng.Random r) {
-        INDArray ret = INSTANCE.randn(shape, r);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Random normal using the current time stamp
-     * as the seed
-     *
-     * @param shape the shape of the ndarray
-     * @return
-     */
-    public static INDArray randn(int[] shape) {
-        INDArray ret = INSTANCE.randn(shape,Nd4j.getRandom());
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Random normal using the specified seed
-     *
-     * @param shape the shape of the ndarray
-     * @return
-     */
-    public static INDArray randn(int[] shape, long seed) {
-        Nd4j.getRandom().setSeed(seed);
-        return randn(shape, Nd4j.getRandom());
-    }
-
-    /**
      * Creates a row vector with the data
      *
      * @param data the columns of the ndarray
@@ -1714,6 +1765,12 @@ public class Nd4j {
      */
     public static INDArray create(float[] data, char order) {
         INDArray ret = INSTANCE.create(data, order);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    private static IComplexNDArray createComplex(float[] data, char order) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, order);
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -1737,7 +1794,7 @@ public class Nd4j {
      * @return ndarray
      */
     public static IComplexNDArray createComplex(double[] data, char order) {
-        IComplexNDArray ret = INSTANCE.createComplex(data,Nd4j.getComplexStrides(new int[]{1,data.length},order),0,order);
+        IComplexNDArray ret = INSTANCE.createComplex(data);
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -1767,61 +1824,979 @@ public class Nd4j {
     }
 
     /**
-     * Creates a row vector with the data
+     * Create a complex ndarray from the passed in indarray
      *
-     * @param data the columns of the ndarray
-     * @return the created ndarray
+     * @param data the data to wrap
+     * @return the complex ndarray with the specified ndarray as the
+     * real components
      */
-    public static INDArray create(float[] data) {
-        return create(data, order());
+    public static IComplexNDArray createComplex(IComplexNumber[] data, int[] shape, int offset, char order) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, offset, order);
+        logCreationIfNecessary(ret);
+        return ret;
     }
+
 
     /**
-     * Creates a row vector with the data
+     * Create an ndrray with the specified shape
      *
-     * @param data the columns of the ndarray
+     * @param data  the data to use with tne ndarray
+     * @param shape the shape of the ndarray
      * @return the created ndarray
      */
-    public static INDArray create(double[] data) {
-        return create(data, order());
-    }
-
-    /**
-     * Creates an ndarray with the specified data
-     *
-     * @param data the number of columns in the row vector
-     * @return ndarray
-     */
-    public static IComplexNDArray createComplex(float[] data) {
-        return createComplex(data, Nd4j.order());
-
-    }
-
-    private static IComplexNDArray createComplex(float[] data, Character order) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, order);
+    public static INDArray create(float[] data, int[] shape) {
+        INDArray ret = INSTANCE.create(data, shape);
         logCreationIfNecessary(ret);
         return ret;
     }
 
     /**
-     * Creates a row vector with the specified number of columns
+     * Create an ndrray with the specified shape
      *
-     * @param columns the columns of the ndarray
+     * @param data  the data to use with tne ndarray
+     * @param shape the shape of the ndarray
      * @return the created ndarray
      */
-    public static INDArray create(int columns) {
-        return create(columns, order());
+    public static IComplexNDArray createComplex(float[] data, int[] shape) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape);
+        logCreationIfNecessary(ret);
+        return ret;
     }
 
     /**
-     * Creates an ndarray
+     * Create an ndrray with the specified shape
      *
-     * @param columns the number of columns in the row vector
-     * @return ndarray
+     * @param data  the data to use with tne ndarray
+     * @param shape the shape of the ndarray
+     * @return the created ndarray
      */
-    public static IComplexNDArray createComplex(int columns) {
-        return createComplex(columns, order());
+    public static INDArray create(double[] data, int[] shape) {
+        INDArray ret = INSTANCE.create(data, shape);
+        logCreationIfNecessary(ret);
+        return ret;
     }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data  the data to use with tne ndarray
+     * @param shape the shape of the ndarray
+     * @return the created ndarray
+     */
+    public static IComplexNDArray createComplex(double[] data, int[] shape) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data   the data to use with tne ndarray
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @return the created ndarray
+     */
+    public static IComplexNDArray createComplex(float[] data, int[] shape, int[] stride) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data   the data to use with tne ndarray
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @return the created ndarray
+     */
+    public static IComplexNDArray createComplex(double[] data, int[] shape, int[] stride) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(float[] data, int[] shape, int[] stride, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(double[] data, int[] shape, int[] stride, int offset) {
+        INDArray ret = INSTANCE.create(data, shape, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param data   the data to use with the ndarray
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(double[] data, int[] shape, int[] stride, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param data    the data to use with the ndarray
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(float[] data, int rows, int columns, int[] stride, int offset) {
+        INDArray ret = INSTANCE.create(data, rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param data    the data to use with the ndarray
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(float[] data, int rows, int columns, int[] stride, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param data    the data to use with tne ndarray
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(double[] data, int rows, int columns, int[] stride, int offset) {
+        INDArray ret = INSTANCE.create(data, rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(double[] data, int rows, int columns, int[] stride, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(float[] data, int[] shape, int offset) {
+        INDArray ret = INSTANCE.create(data, shape, offset, Nd4j.order());
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(double[] data, int[] shape, int offset, char ordering) {
+        INDArray ret = INSTANCE.create(data, shape, Nd4j.getStrides(shape), offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(float[] data, int[] shape, int[] stride, int offset) {
+        INDArray ret = INSTANCE.create(data, shape, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape the shape of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(List<INDArray> list, int[] shape) {
+        INDArray ret = INSTANCE.create(list, shape);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int rows, int columns, int[] stride, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int rows, int columns, int[] stride, int offset) {
+        INDArray ret = INSTANCE.create(rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int[] shape, int[] stride, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(shape, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int[] shape, int[] stride, int offset) {
+        INDArray ret = INSTANCE.create(shape, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int rows, int columns, int[] stride) {
+        return createComplex(rows, columns, stride, order());
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int rows, int columns, int[] stride) {
+        return create(rows, columns, stride, order());
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int[] shape, int[] stride) {
+        return createComplex(shape, stride, order());
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int[] shape, int[] stride) {
+        return create(shape, stride, order());
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int rows, int columns) {
+        return createComplex(rows, columns, order());
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int rows, int columns) {
+        return create(rows, columns, order());
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param shape the shape of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int... shape) {
+        return createComplex(shape, order());
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape the shape of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int... shape) {
+        return create(shape, order());
+    }
+
+
+    public static INDArray create(float[] data, int[] shape, int[] stride, char ordering, int offset) {
+        INDArray ret = INSTANCE.create(data, shape, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    public static INDArray create(float[] data, int[] shape, char ordering, int offset) {
+        INDArray ret = INSTANCE.create(data, shape, getStrides(shape, ordering), offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    public static INDArray create(DataBuffer data, int[] shape, int[] strides, int offset) {
+        INDArray ret = INSTANCE.create(data, shape, strides, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    public static INDArray create(DataBuffer data, int[] shape, int offset) {
+        INDArray ret = INSTANCE.create(data, shape, getStrides(shape), offset);
+        logCreationIfNecessary(ret);
+        return ret;
+
+    }
+
+    public static INDArray create(DataBuffer data, int[] newShape, int[] newStride, int offset, char ordering) {
+        INDArray ret = INSTANCE.create(data, newShape, newStride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    public static IComplexNDArray createComplex(DataBuffer data, int[] newShape, int[] newStrides, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, newShape, newStrides, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    public static IComplexNDArray createComplex(DataBuffer data, int[] shape, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    public static IComplexNDArray createComplex(DataBuffer data, int[] newDims, int[] newStrides, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, newDims, newStrides, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    public static IComplexNDArray createComplex(DataBuffer data, int[] shape, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     *
+     * @param data
+     * @param shape
+     * @return
+     */
+    public static INDArray create(DataBuffer data, int[] shape) {
+        INDArray ret = INSTANCE.create(data, shape);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     *
+     * @param data
+     * @param shape
+     * @return
+     */
+    public static IComplexNDArray createComplex(DataBuffer data, int[] shape) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     *
+     * @param buffer
+     * @return
+     */
+    public static INDArray create(DataBuffer buffer) {
+        INDArray ret = INSTANCE.create(buffer);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create a complex array from the given numbers
+     * @param iComplexNumbers the numbers to use
+     * @return the complex numbers
+     */
+    public static IComplexNDArray createComplex(IComplexNumber[] iComplexNumbers) {
+        return createComplex(iComplexNumbers,new int[]{1,iComplexNumbers.length});
+    }
+
+    /**
+     * Create a complex ndarray based on the specified matrices
+     * @param iComplexNumbers the complex numbers
+     * @return the complex numbers
+     */
+    public static IComplexNDArray createComplex(IComplexNumber[][] iComplexNumbers) {
+        IComplexNDArray shape = Nd4j.createComplex(iComplexNumbers.length, iComplexNumbers[0].length);
+        for(int i = 0; i < iComplexNumbers.length; i++) {
+            for(int j = 0; j < iComplexNumbers[i].length; j++) {
+                shape.putScalar(i, j, iComplexNumbers[i][j]);
+            }
+        }
+        return shape;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param data    the data to use with the ndarray
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(float[] data, int rows, int columns, int[] stride, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param data    the data to use with the ndarray
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(float[] data, int rows, int columns, int[] stride, int offset, char ordering) {
+        INDArray ret = INSTANCE.create(data, rows, columns, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    public static INDArray create(int[] shape, DataBuffer.Type dataType) {
+        INDArray ret = INSTANCE.create(shape, dataType);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param data   the data to use with the ndarray
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(float[] data, int[] shape, int[] stride, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(double[] data, int[] shape, int[] stride, int offset, char ordering) {
+        INDArray ret = INSTANCE.create(data, shape, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data  the data to use with tne ndarray
+     * @param shape the shape of the ndarray
+     * @return the created ndarray
+     */
+    public static INDArray create(double[] data, int[] shape, char ordering) {
+        INDArray ret = INSTANCE.create(data, shape, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data  the data to use with tne ndarray
+     * @param shape the shape of the ndarray
+     * @return the created ndarray
+     */
+    public static INDArray create(float[] data, int[] shape, char ordering) {
+        INDArray ret = INSTANCE.create(data, shape, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data  the data to use with tne ndarray
+     * @param shape the shape of the ndarray
+     * @return the created ndarray
+     */
+    public static IComplexNDArray createComplex(float[] data, int[] shape, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data  the data to use with tne ndarray
+     * @param shape the shape of the ndarray
+     * @return the created ndarray
+     */
+    public static IComplexNDArray createComplex(double[] data, int[] shape, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data   the data to use with tne ndarray
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @return the created ndarray
+     */
+    public static IComplexNDArray createComplex(float[] data, int[] shape, int[] stride, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create an ndrray with the specified shape
+     *
+     * @param data   the data to use with tne ndarray
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @return the created ndarray
+     */
+    public static IComplexNDArray createComplex(double[] data, int[] shape, int[] stride, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(double[] data, int rows, int columns, int[] stride, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param data    the data to use with tne ndarray
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(double[] data, int rows, int columns, int[] stride, int offset, char ordering) {
+        INDArray ret = INSTANCE.create(data, rows, columns, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(double[] data, int[] shape, int[] stride, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(float[] data, int[] shape, int[] stride, int offset, char ordering) {
+        INDArray ret = INSTANCE.create(data, shape, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape the shape of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(List<INDArray> list, int[] shape, char ordering) {
+        INDArray ret = INSTANCE.create(list, shape, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int rows, int columns, int[] stride, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(new int[]{rows, columns}, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @param offset  the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int rows, int columns, int[] stride, int offset, char ordering) {
+        INDArray ret = INSTANCE.create(new int[]{rows, columns}, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int[] shape, int[] stride, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(shape, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @param offset the offset of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int[] shape, int[] stride, int offset, char ordering) {
+        INDArray ret = INSTANCE.create(shape, stride, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int rows, int columns, int[] stride, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(new int[]{rows, columns}, stride, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @param stride  the stride for the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int rows, int columns, int[] stride, char ordering) {
+        INDArray ret = INSTANCE.create(new int[]{rows, columns}, stride, 0, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int[] shape, int[] stride, char ordering) {
+        return createComplex(shape, stride, 0,ordering);
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape  the shape of the ndarray
+     * @param stride the stride for the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int[] shape, int[] stride, char ordering) {
+        INDArray ret = INSTANCE.create(shape, stride, 0, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int rows, int columns, char ordering) {
+        int[] shape = new int[]{rows, columns};
+        IComplexNDArray ret = INSTANCE.createComplex(shape, Nd4j.getComplexStrides(shape, ordering), 0, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param rows    the rows of the ndarray
+     * @param columns the columns of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int rows, int columns, char ordering) {
+        INDArray ret = INSTANCE.create(rows, columns, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates a complex ndarray with the specified shape
+     *
+     * @param shape the shape of the ndarray
+     * @return the instance
+     */
+    public static IComplexNDArray createComplex(int[] shape, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(createBuffer(ArrayUtil.prod(shape) * 2), shape, 0, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Creates an ndarray with the specified shape
+     *
+     * @param shape the shape of the ndarray
+     * @return the instance
+     */
+    public static INDArray create(int[] shape, char ordering) {
+        INDArray ret = INSTANCE.create(shape, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     * Create complex ndarray
+     *
+     * @param data
+     * @param shape
+     * @param offset
+     * @param ordering
+     * @return
+     */
+    public static IComplexNDArray createComplex(float[] data, int[] shape, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, Nd4j.getComplexStrides(shape, ordering), offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     *
+     * @param data
+     * @param shape
+     * @param offset
+     * @return
+     */
+    public static IComplexNDArray createComplex(double[] data, int[] shape, int offset) {
+        return createComplex(data, shape, offset, Nd4j.order());
+    }
+
+    /**
+     *
+     * @param data
+     * @param shape
+     * @param offset
+     * @return
+     */
+    public static INDArray create(double[] data, int[] shape, int offset) {
+        INDArray ret = INSTANCE.create(data, shape, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     *
+     * @param data
+     * @param ints
+     * @param offset
+     * @param ordering
+     * @return
+     */
+    public static IComplexNDArray createComplex(double[] data, int[] ints, int offset, char ordering) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, ints, offset, ordering);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     *
+     * @param dim
+     * @return
+     */
+    public static IComplexNDArray createComplex(double[] dim) {
+        IComplexNDArray ret = INSTANCE.createComplex(dim, new int[]{1, dim.length / 2});
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
+     *
+     * @param data
+     * @param shape
+     * @param offset
+     * @return
+     */
+    public static IComplexNDArray createComplex(float[] data, int[] shape, int offset) {
+        IComplexNDArray ret = INSTANCE.createComplex(data, shape, offset);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    ////////////////////// OTHER ///////////////////////////////
+
 
     /**
      * Returns true if the given ndarray has either
@@ -2136,391 +3111,6 @@ public class Nd4j {
     }
 
     /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param data    the data to use with the ndarray
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(float[] data, int rows, int columns, int[] stride, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param data    the data to use with the ndarray
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(float[] data, int rows, int columns, int[] stride, int offset) {
-        INDArray ret = INSTANCE.create(data, rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param data   the data to use with the ndarray
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(double[] data, int[] shape, int[] stride, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(double[] data, int[] shape, int[] stride, int offset) {
-        INDArray ret = INSTANCE.create(data, shape, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data  the data to use with tne ndarray
-     * @param shape the shape of the ndarray
-     * @return the created ndarray
-     */
-    public static INDArray create(double[] data, int[] shape) {
-        INDArray ret = INSTANCE.create(data, shape);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data  the data to use with tne ndarray
-     * @param shape the shape of the ndarray
-     * @return the created ndarray
-     */
-    public static INDArray create(float[] data, int[] shape) {
-        INDArray ret = INSTANCE.create(data, shape);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data  the data to use with tne ndarray
-     * @param shape the shape of the ndarray
-     * @return the created ndarray
-     */
-    public static IComplexNDArray createComplex(float[] data, int[] shape) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data  the data to use with tne ndarray
-     * @param shape the shape of the ndarray
-     * @return the created ndarray
-     */
-    public static IComplexNDArray createComplex(double[] data, int[] shape) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data   the data to use with tne ndarray
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @return the created ndarray
-     */
-    public static IComplexNDArray createComplex(float[] data, int[] shape, int[] stride) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data   the data to use with tne ndarray
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @return the created ndarray
-     */
-    public static IComplexNDArray createComplex(double[] data, int[] shape, int[] stride) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(double[] data, int rows, int columns, int[] stride, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param data    the data to use with tne ndarray
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(double[] data, int rows, int columns, int[] stride, int offset) {
-        INDArray ret = INSTANCE.create(data, rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(float[] data, int[] shape, int[] stride, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(float[] data, int[] shape, int offset) {
-        INDArray ret = INSTANCE.create(data, shape, offset, Nd4j.order());
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(double[] data, int[] shape, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(data, shape, Nd4j.getStrides(shape), offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(float[] data, int[] shape, int[] stride, int offset) {
-        INDArray ret = INSTANCE.create(data, shape, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape the shape of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(List<INDArray> list, int[] shape) {
-        INDArray ret = INSTANCE.create(list, shape);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int rows, int columns, int[] stride, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int rows, int columns, int[] stride, int offset) {
-        INDArray ret = INSTANCE.create(rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int[] shape, int[] stride, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(shape, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int[] shape, int[] stride, int offset) {
-        INDArray ret = INSTANCE.create(shape, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int rows, int columns, int[] stride) {
-        return createComplex(rows, columns, stride, order());
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int rows, int columns, int[] stride) {
-        return create(rows, columns, stride, order());
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int[] shape, int[] stride) {
-        return createComplex(shape, stride, order());
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int[] shape, int[] stride) {
-        return create(shape, stride, order());
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int rows, int columns) {
-        return createComplex(rows, columns, order());
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int rows, int columns) {
-        return create(rows, columns, order());
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param shape the shape of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int... shape) {
-        return createComplex(shape, order());
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape the shape of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int... shape) {
-        return create(shape, order());
-    }
-
-    /**
      * Create a scalar ndarray with the specified offset
      *
      * @param value  the value to initialize the scalar with
@@ -2755,471 +3345,6 @@ public class Nd4j {
         return getComplexStrides(shape, Nd4j.order());
     }
 
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param data    the data to use with the ndarray
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(float[] data, int rows, int columns, int[] stride, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param data    the data to use with the ndarray
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(float[] data, int rows, int columns, int[] stride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(data, rows, columns, stride, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    public static INDArray create(int[] shape, DataBuffer.Type dataType) {
-        INDArray ret = INSTANCE.create(shape, dataType);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param data   the data to use with the ndarray
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(float[] data, int[] shape, int[] stride, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(double[] data, int[] shape, int[] stride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(data, shape, stride, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data  the data to use with tne ndarray
-     * @param shape the shape of the ndarray
-     * @return the created ndarray
-     */
-    public static INDArray create(double[] data, int[] shape, char ordering) {
-        INDArray ret = INSTANCE.create(data, shape, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data  the data to use with tne ndarray
-     * @param shape the shape of the ndarray
-     * @return the created ndarray
-     */
-    public static INDArray create(float[] data, int[] shape, char ordering) {
-        INDArray ret = INSTANCE.create(data, shape, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data  the data to use with tne ndarray
-     * @param shape the shape of the ndarray
-     * @return the created ndarray
-     */
-    public static IComplexNDArray createComplex(float[] data, int[] shape, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data  the data to use with tne ndarray
-     * @param shape the shape of the ndarray
-     * @return the created ndarray
-     */
-    public static IComplexNDArray createComplex(double[] data, int[] shape, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data   the data to use with tne ndarray
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @return the created ndarray
-     */
-    public static IComplexNDArray createComplex(float[] data, int[] shape, int[] stride, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create an ndrray with the specified shape
-     *
-     * @param data   the data to use with tne ndarray
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @return the created ndarray
-     */
-    public static IComplexNDArray createComplex(double[] data, int[] shape, int[] stride, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(double[] data, int rows, int columns, int[] stride, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param data    the data to use with tne ndarray
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(double[] data, int rows, int columns, int[] stride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(data, rows, columns, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(double[] data, int[] shape, int[] stride, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, stride, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(float[] data, int[] shape, int[] stride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(data, shape, stride, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape the shape of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(List<INDArray> list, int[] shape, char ordering) {
-        INDArray ret = INSTANCE.create(list, shape, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int rows, int columns, int[] stride, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(new int[]{rows, columns}, stride, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @param offset  the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int rows, int columns, int[] stride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(new int[]{rows, columns}, stride, offset,ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int[] shape, int[] stride, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(shape, stride, offset,ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @param offset the offset of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int[] shape, int[] stride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(shape, stride, offset,ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int rows, int columns, int[] stride, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(new int[] {rows, columns}, stride,ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @param stride  the stride for the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int rows, int columns, int[] stride, char ordering) {
-        INDArray ret = INSTANCE.create(new int[]{rows, columns}, stride, 0, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int[] shape, int[] stride, char ordering) {
-        return createComplex(shape, stride, 0,ordering);
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape  the shape of the ndarray
-     * @param stride the stride for the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int[] shape, int[] stride, char ordering) {
-        INDArray ret = INSTANCE.create(shape, stride,0,ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int rows, int columns, char ordering) {
-        int[] shape = new int[]{rows, columns};
-        IComplexNDArray ret = INSTANCE.createComplex(shape,Nd4j.getComplexStrides(shape,ordering),0,ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param rows    the rows of the ndarray
-     * @param columns the columns of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int rows, int columns, char ordering) {
-        INDArray ret = INSTANCE.create(rows, columns, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates a complex ndarray with the specified shape
-     *
-     * @param shape the shape of the ndarray
-     * @return the instance
-     */
-    public static IComplexNDArray createComplex(int[] shape, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(createBuffer(ArrayUtil.prod(shape) * 2), shape, 0, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Creates an ndarray with the specified shape
-     *
-     * @param shape the shape of the ndarray
-     * @return the instance
-     */
-    public static INDArray create(int[] shape, char ordering) {
-        INDArray ret = INSTANCE.create(shape, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     * Create complex ndarray
-     *
-     * @param data
-     * @param shape
-     * @param offset
-     * @param ordering
-     * @return
-     */
-    public static IComplexNDArray createComplex(float[] data, int[] shape, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, Nd4j.getComplexStrides(shape,ordering), offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     *
-     * @param data
-     * @param shape
-     * @param offset
-     * @return
-     */
-    public static IComplexNDArray createComplex(double[] data, int[] shape, int offset) {
-        return createComplex(data, shape, offset, Nd4j.order());
-    }
-
-    /**
-     *
-     * @param data
-     * @param shape
-     * @param offset
-     * @return
-     */
-    public static INDArray create(double[] data, int[] shape, int offset) {
-        INDArray ret = INSTANCE.create(data, shape, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     *
-     * @param data
-     * @param ints
-     * @param offset
-     * @param ordering
-     * @return
-     */
-    public static IComplexNDArray createComplex(double[] data, int[] ints, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, ints, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     *
-     * @param dim
-     * @return
-     */
-    public static IComplexNDArray createComplex(double[] dim) {
-        IComplexNDArray ret = INSTANCE.createComplex(dim, new int[]{1, dim.length / 2});
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     *
-     * @param data
-     * @param shape
-     * @param offset
-     * @return
-     */
-    public static IComplexNDArray createComplex(float[] data, int[] shape, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     *
-     * @param doubles
-     * @return
-     */
-    public static INDArray create(float[][] doubles) {
-        return INSTANCE.create(doubles);
-    }
 
     /**
      * Linspace with complex numbers
@@ -3232,97 +3357,6 @@ public class Nd4j {
         return Nd4j.createComplex(Nd4j.linspace(i, i1, i2));
 
     }
-
-    public static INDArray create(float[] data, int[] shape, int[] stride, char ordering, int offset) {
-        INDArray ret = INSTANCE.create(data, shape, stride, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    public static INDArray create(float[] data, int[] shape, char ordering, int offset) {
-        INDArray ret = INSTANCE.create(data, shape, getStrides(shape, ordering), offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    public static INDArray create(DataBuffer data, int[] shape, int[] strides, int offset) {
-        INDArray ret = INSTANCE.create(data, shape, strides, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    public static INDArray create(DataBuffer data, int[] shape, int offset) {
-        INDArray ret = INSTANCE.create(data, shape, getStrides(shape), offset);
-        logCreationIfNecessary(ret);
-        return ret;
-
-    }
-
-    public static INDArray create(DataBuffer data, int[] newShape, int[] newStride, int offset, char ordering) {
-        INDArray ret = INSTANCE.create(data, newShape, newStride, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    public static IComplexNDArray createComplex(DataBuffer data, int[] newShape, int[] newStrides, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, newShape, newStrides, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    public static IComplexNDArray createComplex(DataBuffer data, int[] shape, int offset) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, offset);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    public static IComplexNDArray createComplex(DataBuffer data, int[] newDims, int[] newStrides, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, newDims, newStrides, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    public static IComplexNDArray createComplex(DataBuffer data, int[] shape, int offset, char ordering) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape, offset, ordering);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     *
-     * @param data
-     * @param shape
-     * @return
-     */
-    public static INDArray create(DataBuffer data, int[] shape) {
-        INDArray ret = INSTANCE.create(data, shape);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     *
-     * @param data
-     * @param shape
-     * @return
-     */
-    public static IComplexNDArray createComplex(DataBuffer data, int[] shape) {
-        IComplexNDArray ret = INSTANCE.createComplex(data, shape);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
-    /**
-     *
-     * @param buffer
-     * @return
-     */
-    public static INDArray create(DataBuffer buffer) {
-        INDArray ret = INSTANCE.create(buffer);
-        logCreationIfNecessary(ret);
-        return ret;
-    }
-
 
     /**
      * Initializes nd4j
@@ -3400,28 +3434,4 @@ public class Nd4j {
 
     }
 
-
-    /**
-     * Create a complex array from the given numbers
-     * @param iComplexNumbers the numbers to use
-     * @return the complex numbers
-     */
-    public static IComplexNDArray createComplex(IComplexNumber[] iComplexNumbers) {
-        return createComplex(iComplexNumbers,new int[]{1,iComplexNumbers.length});
-    }
-
-    /**
-     * Create a complex ndarray based on the specified matrices
-     * @param iComplexNumbers the complex numbers
-     * @return the complex numbers
-     */
-    public static IComplexNDArray createComplex(IComplexNumber[][] iComplexNumbers) {
-        IComplexNDArray shape = Nd4j.createComplex(iComplexNumbers.length,iComplexNumbers[0].length);
-        for(int i = 0; i < iComplexNumbers.length; i++) {
-            for(int j = 0; j < iComplexNumbers[i].length; j++) {
-                shape.putScalar(i, j, iComplexNumbers[i][j]);
-            }
-        }
-        return shape;
-    }
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -1397,7 +1397,7 @@ public class Nd4j {
      * @return the random ndarray with the specified shape
      */
     public static INDArray rand(int[] shape) {
-        INDArray ret = INSTANCE.rand(shape);
+        INDArray ret = INSTANCE.rand(shape, Nd4j.getRandom());
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -1412,7 +1412,7 @@ public class Nd4j {
      * @return the random ndarray with the specified shape
      */
     public static INDArray rand(int rows, int columns) {
-        INDArray ret = INSTANCE.rand(rows, columns);
+        INDArray ret = INSTANCE.rand(rows, columns, Nd4j.getRandom());
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -1538,7 +1538,7 @@ public class Nd4j {
      * @return
      */
     public static INDArray randn(int[] shape) {
-        INDArray ret = INSTANCE.randn(shape);
+        INDArray ret = INSTANCE.randn(shape, Nd4j.getRandom());
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -1563,7 +1563,7 @@ public class Nd4j {
      * @return
      */
     public static INDArray randn(int rows, int columns) {
-        INDArray ret = INSTANCE.randn(rows, columns);
+        INDArray ret = INSTANCE.randn(rows, columns, Nd4j.getRandom());
         logCreationIfNecessary(ret);
         return ret;
     }
@@ -1794,7 +1794,7 @@ public class Nd4j {
      * @return ndarray
      */
     public static IComplexNDArray createComplex(double[] data, char order) {
-        IComplexNDArray ret = INSTANCE.createComplex(data);
+        IComplexNDArray ret = INSTANCE.createComplex(data,Nd4j.getComplexStrides(new int[]{1,data.length},order),0,order);
         logCreationIfNecessary(ret);
         return ret;
     }

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/DataSetTest.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/DataSetTest.java
@@ -20,16 +20,15 @@ package org.nd4j.linalg.dataset;
 
 import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
-import org.nd4j.linalg.api.ndarray.BaseNDArray;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.rng.DefaultRandom;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.util.FeatureUtil;
 
 import java.util.List;
+import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class DataSetTest extends BaseNd4jTest {
 	public DataSetTest() {
@@ -55,11 +54,11 @@ public class DataSetTest extends BaseNd4jTest {
 		INDArray data = Nd4j.rand(10,10);
 		INDArray labels = FeatureUtil.toOutcomeMatrix(new int[]{0, 0, 1, 1, 2, 2, 3, 3, 3, 3}, 4);
 		DataSet d = new DataSet(data,labels);
-		DataSet filtered = d.filterBy(new int[]{2,3});
+		DataSet filtered = d.filterBy(new int[]{2, 3});
 		d.filterAndStrip(new int[]{2,3});
 		assertEquals(2,d.numOutcomes());
 		assertEquals(filtered.numExamples(),d.numExamples());
-		assertEquals(filtered.getFeatureMatrix(),d.getFeatureMatrix());
+		assertEquals(filtered.getFeatureMatrix(), d.getFeatureMatrix());
         assertEquals(filtered.numExamples(), d.getLabels().rows());
 
 
@@ -74,7 +73,7 @@ public class DataSetTest extends BaseNd4jTest {
         //Get first Iris example
         DataSet x0 = new IrisDataSetIterator(1,1).next();
         INDArray example0 = x0.getFeatureMatrix();
-        checkMMultDotProduct(example0,colVector);
+        checkMMultDotProduct(example0, colVector);
 
         System.out.println("/////////////");
 
@@ -124,13 +123,16 @@ public class DataSetTest extends BaseNd4jTest {
         INDArray labels = FeatureUtil.toOutcomeMatrix(new int[]{0,0,0,0,0,0,0,0},1);
         DataSet data = new DataSet(Nd4j.rand(8,1),labels);
 
-        SplitTestAndTrain train = data.splitTestAndTrain(6, new DefaultRandom(1));
+        SplitTestAndTrain train = data.splitTestAndTrain(6, new Random(123));
         assertEquals(train.getTrain().getLabels().length(),6);
 
-        SplitTestAndTrain train2 = data.splitTestAndTrain(6, new DefaultRandom(1));
+        SplitTestAndTrain train2 = data.splitTestAndTrain(6, new Random(123));
         assertEquals(train.getTrain().getFeatureMatrix(), train2.getTrain().getFeatureMatrix());
-    }
 
+        SplitTestAndTrain train3 = data.splitTestAndTrain(6, new Random(20));
+        assertNotEquals(train.getTrain().getFeatureMatrix(), train3.getTrain().getFeatureMatrix());
+
+    }
 
     @Override
     public char ordering() {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/factory/Nd4jTest.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/factory/Nd4jTest.java
@@ -1,7 +1,57 @@
 package org.nd4j.linalg.factory;
 
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.rng.DefaultRandom;
+import org.nd4j.linalg.api.rng.Random;
+
+import static org.junit.Assert.assertEquals;
+
 /**
  * Created by willow on 6/16/15.
  */
 public class Nd4jTest {
+
+    @Test
+    public void testRandShapeAndRNG() {
+        INDArray ret = Nd4j.rand(new int[]{4, 2}, new DefaultRandom(123));
+        INDArray ret2 = Nd4j.rand(new int[]{4, 2}, new DefaultRandom(123));
+
+        assertEquals(ret, ret2);
+    }
+
+    @Test
+    public void testRandShapeAndMinMax() {
+        INDArray ret = Nd4j.rand(new int[]{4, 2}, -0.125f, 0.125f, new DefaultRandom(123));
+        INDArray ret2 = Nd4j.rand(new int[]{4, 2}, -0.125f, 0.125f, new DefaultRandom(123));
+
+        assertEquals(ret, ret2);
+    }
+
+    @Test
+    public void testCreateShape() {
+        INDArray ret = Nd4j.create(new int[]{4, 2});
+
+        assertEquals(ret.length(), 8);
+    }
+
+    @Test
+    public void testGetRandom() {
+        Random r = Nd4j.getRandom();
+        Random t = Nd4j.getRandom();
+
+        assertEquals(r, t);
+    }
+
+    @Test
+    public void testGetRandomSetSeed() {
+        Random r = Nd4j.getRandom();
+        Random t = Nd4j.getRandom();
+
+        assertEquals(r, t);
+        r.setSeed(123);
+        assertEquals(r, t);
+    }
+
+
 }

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/factory/Nd4jTest.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/factory/Nd4jTest.java
@@ -1,0 +1,7 @@
+package org.nd4j.linalg.factory;
+
+/**
+ * Created by willow on 6/16/15.
+ */
+public class Nd4jTest {
+}


### PR DESCRIPTION
Two key fixes. Applied getSeeed in Default and Random to have centeral place to track a random or set seed. Ensures if generator resets that the nd4j object is single source of truth for existing seed when using models. This is combined with dl4j fixes to set seed. Second change is put back MersenneTwister and decoupled the SplitTestAndTrain to take random number passed in from user.