### PR TITLE
Nd4jTestSuite unit test errors from missing constructors

### DIFF
--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/rng/distribution/DistributionTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/rng/distribution/DistributionTestsC.java
@@ -3,11 +3,17 @@ package org.nd4j.linalg.api.rng.distribution;
 import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class DistributionTestsC extends BaseNd4jTest {
+
+    public DistributionTestsC(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testBinomial() {
         Nd4j.getDistributions().createBinomial(1,0).sample(new int[]{784,600});

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/learning/UpdaterTest.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/learning/UpdaterTest.java
@@ -23,6 +23,7 @@ import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.rng.distribution.Distribution;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,9 @@ public class UpdaterTest extends BaseNd4jTest {
 
 	private static final Logger log = LoggerFactory.getLogger(UpdaterTest.class);
 
+	public UpdaterTest(String name, Nd4jBackend backend) {
+		super(name, backend);
+	}
 
 	@Test
 	public void testAdaGrad1() {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/shape/NDArrayMathTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/shape/NDArrayMathTests.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.util.NDArrayMath;
 
 
@@ -11,6 +12,11 @@ import org.nd4j.linalg.util.NDArrayMath;
  * @author Adam Gibson
  */
 public class NDArrayMathTests extends BaseNd4jTest {
+
+    public NDArrayMathTests(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testVectorPerSlice() {
         INDArray arr = Nd4j.create(2,2,2,2);

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/shape/ShapeTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/shape/ShapeTests.java
@@ -4,11 +4,17 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class ShapeTests extends BaseNd4jTest {
+
+    public ShapeTests(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testSixteenZeroOne() {
         INDArray baseArr = Nd4j.linspace(1, 16, 16).reshape(2, 2, 2, 2);

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/shape/ShapeTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/shape/ShapeTestsC.java
@@ -4,11 +4,17 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class ShapeTestsC extends BaseNd4jTest {
+
+    public ShapeTestsC(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testSixteenZeroOne() {
         INDArray baseArr = Nd4j.linspace(1,16,16).reshape(2, 2, 2, 2);

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/util/ShapeTest.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/util/ShapeTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 import java.util.Arrays;
 
@@ -13,6 +14,10 @@ import static org.junit.Assert.assertArrayEquals;
  * @author Adam Gibson
  */
 public class ShapeTest extends BaseNd4jTest {
+
+    public ShapeTest(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
 
     @Test
     public void testToOffsetZero() {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/util/ShapeTestC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/util/ShapeTestC.java
@@ -4,11 +4,16 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class ShapeTestC extends BaseNd4jTest {
+
+    public ShapeTestC(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
 
     @Test
     public void testToOffsetZero() {


### PR DESCRIPTION
org.nd4j.linalg.Nd4jTestSuite.suite attempts to find the
constructors of all subclasses of BaseNd4jTest that take
String name and a Nd4jBackend backend parameters. Not all
these classes had constructors that matched this prototype.

The fix is to add constructors that call the superclass.

This fixes issue #248 