### PR TITLE
More Nd4jTestSuite unit test errors from missing constructors

### DIFF
--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingTests.java
@@ -5,6 +5,7 @@ import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ndarray.LinearViewNDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 
 /**
@@ -12,7 +13,9 @@ import org.nd4j.linalg.indexing.NDArrayIndex;
  */
 public class IndexingTests extends BaseNd4jTest {
 
-
+    public IndexingTests(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
 
     @Test
     public void testGetScalar() {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingTestsC.java
@@ -4,12 +4,18 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 
 /**
  * @author Adam Gibson
  */
 public class IndexingTestsC extends BaseNd4jTest {
+
+    public IndexingTestsC(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testOffsetsC() {
         INDArray arr = Nd4j.linspace(1,4,4).reshape(2,2);

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/putscalar/PutScalarTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/putscalar/PutScalarTests.java
@@ -1,11 +1,16 @@
 package org.nd4j.linalg.putscalar;
 
 import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class PutScalarTests extends BaseNd4jTest {
+    public PutScalarTests(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Override
     public char ordering() {
         return 'f';

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/putscalar/PutScalarTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/putscalar/PutScalarTestsC.java
@@ -4,11 +4,17 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class PutScalarTestsC extends BaseNd4jTest {
+
+    public PutScalarTestsC(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testRand() {
         INDArray rand = Nd4j.randn(5, 5);


### PR DESCRIPTION
Added constructors to other subclasses of BaseNd4jTest.

See commit c42823378 for details.