### PR TITLE
Runtime Casting Errors with Complex NDArrays

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -595,10 +595,6 @@ public abstract class BaseNDArray implements INDArray {
         return create(data, new int[]{length, 1}, offset());
     }
 
-    protected INDArray create(DataBuffer data,int[] shape,int offset) {
-        return Nd4j.create(data, shape, offset);
-    }
-
     protected void ensureNotCleanedUp() {
         if(cleanedUp)
             throw new IllegalStateException("Invalid operation: already collected");
@@ -627,11 +623,11 @@ public abstract class BaseNDArray implements INDArray {
         if(isVector() || isScalar() || length() == 1)
             linearView = this;
         else if(ordering() == NDArrayFactory.C) {
-            linearView = Nd4j.create(data(),new int[]{1,length()},ArrayUtil.of(stride(-2),stride(-1)),offset);
+            linearView = create(data(), new int[]{1, length()}, ArrayUtil.of(stride(-2), stride(-1)), offset);
             linearView.setWrapAround(true);
         }
         else {
-            // linearView = Nd4j.create(data(),new int[]{1,length()},ArrayUtil.of(stride(-2),stride(-1)),offset);
+            // linearView = create(data(),new int[]{1,length()},ArrayUtil.of(stride(-2),stride(-1)),offset);
             // linearView.setWrapAround(true);
             linearView = new LinearViewNDArray(this);
 
@@ -795,7 +791,7 @@ public abstract class BaseNDArray implements INDArray {
         INDArray ret =  tensorAlongDimension(index, dimension);
         //column vector
         if(dimension == 0) {
-            return Nd4j.create(ret.data(),ArrayUtil.reverseCopy(ret.shape()),ret.stride(),ret.offset());
+            return create(ret.data(),ArrayUtil.reverseCopy(ret.shape()),ret.stride(),ret.offset());
         }
 
         return ret;
@@ -1645,19 +1641,52 @@ public abstract class BaseNDArray implements INDArray {
     }
 
     protected INDArray create(DataBuffer data, int[] newShape, int[] newStrides, int offset, char ordering) {
-        return Nd4j.create(data, newShape, newStrides, offset, ordering);
+        if (this instanceof IComplexNDArray)
+            return Nd4j.createComplex(data, newShape, newStrides, offset, ordering);
+        else
+            return Nd4j.create(data, newShape, newStrides, offset, ordering);
     }
 
     protected INDArray create(DataBuffer data, int[] newShape, int[] newStrides, int offset) {
-        return Nd4j.create(data, newShape, newStrides, offset);
+        if (this instanceof IComplexNDArray)
+            return Nd4j.createComplex(data, newShape, newStrides, offset);
+        else
+            return Nd4j.create(data, newShape, newStrides, offset);
+    }
+
+    protected INDArray create(DataBuffer data, int[] shape, int offset) {
+        if (this instanceof IComplexNDArray)
+            return Nd4j.createComplex(data, shape, offset);
+        else
+            return Nd4j.create(data, shape, offset);
+    }
+
+    protected INDArray create(int[] shape, char ordering) {
+        if (this instanceof IComplexNDArray)
+            return Nd4j.createComplex(shape, ordering);
+        else
+            return Nd4j.create(shape, ordering);
     }
 
     protected INDArray create(int[] shape) {
-        return Nd4j.create(shape, getStrides(shape, ordering), 0);
+        if (this instanceof IComplexNDArray)
+            return Nd4j.createComplex(shape, getStrides(shape, ordering), 0);
+        else
+            return Nd4j.create(shape, getStrides(shape, ordering), 0);
     }
 
-    protected INDArray create(int[] shape,int[] strides,int offset) {
-        return Nd4j.create(shape, strides, offset);
+    protected INDArray create(int[] shape, int[] strides, int offset) {
+        if (this instanceof IComplexNDArray)
+            return Nd4j.createComplex(shape, strides, offset);
+        else
+            return Nd4j.create(shape, strides, offset);
+    }
+
+    protected INDArray create(DataBuffer data, int[] shape, int[] strides) {
+        if (this instanceof IComplexNDArray)
+            return Nd4j.createComplex(data, shape, strides, offset(), ordering());
+        else
+            return Nd4j.create(data,shape,strides,offset(),ordering());
     }
 
     protected int[] getStrides(int[] shape,char ordering) {
@@ -2579,10 +2608,6 @@ public abstract class BaseNDArray implements INDArray {
         return mmuli(other, result);
     }
 
-    protected INDArray create(int[] shape, char ordering) {
-        return Nd4j.create(shape, ordering);
-    }
-
     /**
      * Perform an copy matrix multiplication
      *
@@ -2794,7 +2819,10 @@ public abstract class BaseNDArray implements INDArray {
     }
 
     private INDArray create(int[] shape, int[] stride) {
-        return Nd4j.create(shape, stride);
+        if (this instanceof IComplexNDArray)
+            return Nd4j.createComplex(shape, stride);
+        else
+            return Nd4j.create(shape, stride);
     }
 
     /**
@@ -3130,7 +3158,7 @@ public abstract class BaseNDArray implements INDArray {
 
 
     protected INDArray createScalarForIndex(int i,boolean applyOffset) {
-        return Nd4j.create(data(), new int[]{1, 1}, new int[]{1, 1}, applyOffset ? offset + i : i);
+        return create(data(), new int[]{1, 1}, new int[]{1, 1}, applyOffset ? offset + i : i);
     }
 
     protected INDArray createScalar(double d) {
@@ -3344,7 +3372,7 @@ public abstract class BaseNDArray implements INDArray {
             if(isRowVector()) {
                 if(shape.length == 1) {
                     int[] shape2 = Ints.concat(new int[]{1},new int[]{ArrayUtil.prod(Ints.concat(shape,shape()))});
-                    INDArray ret = Nd4j.create(shape2);
+                    INDArray ret = create(shape2);
                     int curr = 0;
                     for(int i = 0; i < ret.length(); i++) {
                         ret.putScalar(i,getDouble(curr));
@@ -3358,7 +3386,7 @@ public abstract class BaseNDArray implements INDArray {
 
                 }
                 else {
-                    INDArray ret = Nd4j.create(shape);
+                    INDArray ret = create(shape);
                     int curr = 0;
                     for(int i = 0; i < ret.length(); i++) {
                         ret.putScalar(i,getDouble(curr));
@@ -3372,7 +3400,7 @@ public abstract class BaseNDArray implements INDArray {
                 }
             }
             else {
-                INDArray ret = Nd4j.create(shape);
+                INDArray ret = create(shape);
                 int curr = 0;
                 for(int i = 0; i < ret.length(); i++) {
                     ret.putScalar(i,getDouble(curr));
@@ -3589,10 +3617,6 @@ public abstract class BaseNDArray implements INDArray {
         return arr;
 
 
-    }
-
-    protected INDArray create(DataBuffer data, int[] shape, int[] strides) {
-        return Nd4j.create(data,shape,strides,offset(),ordering());
     }
 
     @Override
@@ -3983,7 +4007,7 @@ public abstract class BaseNDArray implements INDArray {
                 if(indexes.length == 1) {
                     int offset = NDArrayIndex.offset(this,indexes[0]);
                     int length = indexes[0].length();
-                    return Nd4j.create(data,new int[]{1,length},stride(),offset);
+                    return create(data, new int[]{1, length}, stride(), offset);
                 }
                 //use the column index only
                 else {
@@ -3991,7 +4015,7 @@ public abstract class BaseNDArray implements INDArray {
                         throw new IllegalArgumentException("Illegal index specified on first input. Must be zero for a row vector");
                     int offset = NDArrayIndex.offset(this,indexes[1]);
                     int length = indexes[1].length();
-                    return Nd4j.create(data,new int[]{1,length},stride(),offset);
+                    return create(data, new int[]{1, length}, stride(), offset);
 
                 }
             }
@@ -4000,7 +4024,7 @@ public abstract class BaseNDArray implements INDArray {
                 if(indexes.length == 1) {
                     int offset = NDArrayIndex.offset(this,indexes[0]);
                     int length =  indexes[0].length();
-                    return Nd4j.create(data,new int[]{length,1},stride(),offset);
+                    return create(data, new int[]{length, 1}, stride(), offset);
 
                 }
                 //use the row index only
@@ -4010,7 +4034,7 @@ public abstract class BaseNDArray implements INDArray {
 
                     int offset = NDArrayIndex.offset(this,indexes[0]);
                     int length = indexes[0].length();
-                    return Nd4j.create(data,new int[]{length,1},stride(),offset);
+                    return create(data, new int[]{length, 1}, stride(), offset);
                 }
             }
         }
@@ -4162,7 +4186,7 @@ public abstract class BaseNDArray implements INDArray {
         // (for example when asking for a row/column, this will account for the
         // original offset) while still accounting for the truncated shape
         if(offsetAugment > 0)
-            ret = Nd4j.create(ret.data(),ret.shape(),ret.stride(),ret.offset() + offsetAugment);
+            ret = create(ret.data(), ret.shape(), ret.stride(), ret.offset() + offsetAugment);
         return ret;
     }
 


### PR DESCRIPTION
A number of unit tests fail with runtime casting errors between complex and real-valued NDArrays.

The problem is that BaseNDArray sometimes calls Nd4j.create directly. This returns a real-valued NDArray. When derived classes are complex-valued, this leads to a runtime error.

The fix is to put all calls to Nd4j.create inside create wrappers and call either Nd4j.create or Nd4j.createComplex as appropriate.

This fixes issue #251 

Once I have fixed all the unit test constructors, I can run a total of 2,056 unit tests in nd4j-tests. Without
this fix 376 fail. With this fix 288 fail.