### PR TITLE
fix ComplexNumber calculation issues

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexDouble.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexDouble.java
@@ -173,7 +173,7 @@ public abstract class BaseComplexDouble implements IComplexDouble {
 
     @Override
     public IComplexNumber rsubi(Number a, IComplexNumber result) {
-        return result.set(a.doubleValue() - realComponent().doubleValue(), imaginaryComponent());
+        return result.set(a.doubleValue() - result.realComponent().doubleValue(), imaginaryComponent());
     }
 
     @Override
@@ -193,7 +193,7 @@ public abstract class BaseComplexDouble implements IComplexDouble {
 
     @Override
     public IComplexNumber rdivi(IComplexNumber c, IComplexNumber result) {
-        return result.set(c.realComponent().doubleValue() / realComponent().doubleValue(), c.imaginaryComponent().doubleValue() / imaginaryComponent().doubleValue());
+        return result.set(c.realComponent().doubleValue() / result.realComponent().doubleValue(), c.imaginaryComponent().doubleValue() / result.imaginaryComponent().doubleValue());
     }
 
     @Override
@@ -203,7 +203,8 @@ public abstract class BaseComplexDouble implements IComplexDouble {
 
     @Override
     public IComplexNumber rdivi(Number v, IComplexNumber result) {
-        return result.set(v.doubleValue() / realComponent(), imaginaryComponent());
+        double d = result.realComponent().doubleValue() * result.realComponent().doubleValue() + result.imaginaryComponent().doubleValue() * result.imaginaryComponent().doubleValue();
+        return result.set(v.doubleValue() * result.realComponent().doubleValue() / d, -v.doubleValue() * result.imaginaryComponent().doubleValue() / d);
     }
 
     @Override
@@ -229,13 +230,8 @@ public abstract class BaseComplexDouble implements IComplexDouble {
      */
     @Override
     public IComplexNumber addi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() + c.realComponent().doubleValue(), imaginaryComponent() + c.imaginaryComponent().doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() + c.realComponent().doubleValue(),
+        result.set(result.realComponent().doubleValue() + c.realComponent().doubleValue(),
                     result.imaginaryComponent().doubleValue() + c.imaginaryComponent().doubleValue());
-
-        }
         return this;
     }
 
@@ -267,13 +263,7 @@ public abstract class BaseComplexDouble implements IComplexDouble {
      */
     @Override
     public IComplexNumber addi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() + a.doubleValue(), imaginaryComponent() + a.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() + a.doubleValue(), imaginaryComponent() + a.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() + a.doubleValue(), result.imaginaryComponent().doubleValue());
     }
 
     /**
@@ -304,13 +294,7 @@ public abstract class BaseComplexDouble implements IComplexDouble {
      */
     @Override
     public IComplexNumber subi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() - c.realComponent().doubleValue(), imaginaryComponent() - c.imaginaryComponent().doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() - c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() - c.imaginaryComponent().doubleValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().doubleValue() - c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() - c.imaginaryComponent().doubleValue());
     }
 
     @Override
@@ -330,13 +314,7 @@ public abstract class BaseComplexDouble implements IComplexDouble {
 
     @Override
     public IComplexNumber subi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() - a.doubleValue(), imaginaryComponent() - a.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() - a.doubleValue(), imaginaryComponent() - a.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() - a.doubleValue(), result.imaginaryComponent().doubleValue());
     }
 
     @Override
@@ -385,13 +363,7 @@ public abstract class BaseComplexDouble implements IComplexDouble {
 
     @Override
     public IComplexNumber muli(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() * v.doubleValue(), imaginaryComponent() * v.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() * v.doubleValue(), imaginaryComponent() * v.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() * v.doubleValue(), result.imaginaryComponent().doubleValue() * v.doubleValue());
     }
 
     @Override
@@ -431,13 +403,7 @@ public abstract class BaseComplexDouble implements IComplexDouble {
 
     @Override
     public IComplexNumber divi(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() / v.doubleValue(), imaginaryComponent() / v.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() / v.doubleValue(), result.imaginaryComponent().doubleValue() / v.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() / v.doubleValue(), result.imaginaryComponent().doubleValue() / v.doubleValue());
     }
 
     @Override

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexFloat.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexFloat.java
@@ -165,7 +165,8 @@ public abstract class BaseComplexFloat implements IComplexFloat {
 
     @Override
     public IComplexNumber rdivi(Number v, IComplexNumber result) {
-        return null;
+        float d = result.realComponent().floatValue() * result.realComponent().floatValue() + result.imaginaryComponent().floatValue() * result.imaginaryComponent().floatValue();
+        return result.set(v.floatValue() * result.realComponent().floatValue() / d, -v.floatValue() * result.imaginaryComponent().floatValue() / d);
     }
 
     @Override
@@ -219,7 +220,6 @@ public abstract class BaseComplexFloat implements IComplexFloat {
 
     @Override
     public IComplexNumber copy(IComplexNumber other) {
-
         return Nd4j.createFloat(other.realComponent().floatValue(), other.imaginaryComponent().floatValue());
 
     }
@@ -232,13 +232,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
      */
     @Override
     public IComplexNumber addi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() + c.realComponent().floatValue(), imaginaryComponent() + result.imaginaryComponent().floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() + c.realComponent().floatValue(), result.imaginaryComponent().floatValue() + c.imaginaryComponent().floatValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().floatValue() + c.realComponent().floatValue(), result.imaginaryComponent().floatValue() + c.imaginaryComponent().floatValue());
     }
 
     /**
@@ -269,13 +263,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
      */
     @Override
     public IComplexNumber addi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() + a.floatValue(), imaginaryComponent() + a.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() + a.floatValue(), imaginaryComponent() + a.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() + a.floatValue(), result.imaginaryComponent().floatValue());
     }
 
 
@@ -307,13 +295,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
      */
     @Override
     public IComplexNumber subi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() - c.realComponent().floatValue(), imaginaryComponent() - result.imaginaryComponent().floatValue());
-        } else {
-            return result.set(result.realComponent().floatValue() - c.realComponent().floatValue(), result.imaginaryComponent().floatValue() - c.imaginaryComponent().floatValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().floatValue() - c.realComponent().floatValue(), result.imaginaryComponent().floatValue() - c.imaginaryComponent().floatValue());
     }
 
     @Override
@@ -333,13 +315,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
 
     @Override
     public IComplexNumber subi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() - a.floatValue(), imaginaryComponent() - a.floatValue());
-        } else {
-            return result.set(result.realComponent().floatValue() - a.floatValue(), imaginaryComponent() - a.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() - a.floatValue(), imaginaryComponent());
     }
 
     @Override
@@ -388,13 +364,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
 
     @Override
     public IComplexNumber muli(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() * v.floatValue(), imaginaryComponent() * v.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() * v.floatValue(), result.imaginaryComponent().floatValue() * v.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() * v.floatValue(), result.imaginaryComponent().floatValue() * v.floatValue());
     }
 
     @Override
@@ -434,12 +404,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
 
     @Override
     public IComplexNumber divi(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(realComponent() / v.floatValue(), imaginaryComponent() / v.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() / v.floatValue(), imaginaryComponent() / v.floatValue());
-
-        }
+        result.set(result.realComponent().floatValue() / v.floatValue(), result.imaginaryComponent().floatValue() / v.floatValue());
         return result;
     }
 

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexFloat.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexFloat.java
@@ -338,8 +338,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
     public IComplexNumber muli(IComplexNumber c, IComplexNumber result) {
         float newR = realComponent() * c.realComponent().floatValue() - imaginaryComponent() * c.imaginaryComponent().floatValue();
         float newI = realComponent() * c.imaginaryComponent().floatValue() + imaginaryComponent() * c.realComponent().floatValue();
-        result.set(newR, newI);
-        return result;
+        return result.set(newR, newI);
     }
 
     @Override
@@ -393,8 +392,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
         float d = c.realComponent().floatValue() * c.realComponent().floatValue() + c.imaginaryComponent().floatValue() * c.imaginaryComponent().floatValue();
         float newR = (realComponent() * c.realComponent().floatValue() + imaginaryComponent() * c.imaginaryComponent().floatValue()) / d;
         float newI = (imaginaryComponent() * c.realComponent().floatValue() - realComponent() * c.imaginaryComponent().floatValue()) / d;
-        result.set(newR, newI);
-        return result;
+        return result.set(newR, newI);
     }
 
     @Override
@@ -404,8 +402,7 @@ public abstract class BaseComplexFloat implements IComplexFloat {
 
     @Override
     public IComplexNumber divi(Number v, IComplexNumber result) {
-        result.set(result.realComponent().floatValue() / v.floatValue(), result.imaginaryComponent().floatValue() / v.floatValue());
-        return result;
+        return result.set(result.realComponent().floatValue() / v.floatValue(), result.imaginaryComponent().floatValue() / v.floatValue());
     }
 
     @Override

--- a/nd4j-jblas/src/main/java/org/nd4j/linalg/jblas/complex/ComplexDouble.java
+++ b/nd4j-jblas/src/main/java/org/nd4j/linalg/jblas/complex/ComplexDouble.java
@@ -201,13 +201,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
      */
     @Override
     public IComplexNumber addi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(real() + c.realComponent().doubleValue(), imag() + c.imaginaryComponent().doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() + c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() + c.imaginaryComponent().doubleValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().doubleValue() + c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() + c.imaginaryComponent().doubleValue());
     }
 
     /**
@@ -238,13 +232,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
      */
     @Override
     public IComplexNumber addi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(real() + a.doubleValue(), imag() + a.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() + a.doubleValue(), result.imaginaryComponent().doubleValue() + a.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() + a.doubleValue(), result.imaginaryComponent().doubleValue());
     }
 
     /**
@@ -275,13 +263,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
      */
     @Override
     public IComplexNumber subi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(real() - c.realComponent().doubleValue(), imag() - c.imaginaryComponent().doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() - c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() - c.imaginaryComponent().doubleValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().doubleValue() - c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() - c.imaginaryComponent().doubleValue());
     }
 
     @Override
@@ -301,13 +283,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber subi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(real() - a.doubleValue(), imag() - a.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() - a.doubleValue(), imaginaryComponent().doubleValue() - a.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() - a.doubleValue(), result.imaginaryComponent().doubleValue());
     }
 
     @Override
@@ -327,7 +303,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber rsubi(Number a, IComplexNumber result) {
-        return result.set(a.doubleValue() - realComponent().doubleValue(), imaginaryComponent());
+        return result.set(a.doubleValue() - result.realComponent().doubleValue(), result.imaginaryComponent());
     }
 
     @Override
@@ -376,13 +352,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber muli(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(real() * v.doubleValue(), imag() * v.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() * v.doubleValue(), imaginaryComponent() * v.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() * v.doubleValue(), result.imaginaryComponent().doubleValue() * v.doubleValue());
     }
 
     @Override
@@ -422,13 +392,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber divi(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(real() / v.doubleValue(), imag());
-        } else {
-            result.set(result.realComponent().doubleValue() / v.doubleValue(), imaginaryComponent());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() / v.doubleValue(), result.imaginaryComponent().doubleValue() / v.doubleValue());
     }
 
     @Override
@@ -458,7 +422,8 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber rdivi(Number v, IComplexNumber result) {
-        return result.set(v.doubleValue() / real(), imaginaryComponent());
+        double d = result.realComponent().doubleValue() * result.realComponent().doubleValue() + result.imaginaryComponent().doubleValue() * result.imaginaryComponent().doubleValue();
+        return result.set(v.doubleValue() * result.realComponent().doubleValue() / d, -v.doubleValue() * result.imaginaryComponent().doubleValue() / d);
     }
 
     @Override
@@ -763,8 +728,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
     public boolean equals(Object o) {
         if (!(o instanceof IComplexNumber) || !(o instanceof org.jblas.ComplexFloat) && !(o instanceof org.jblas.ComplexDouble)) {
             return false;
-        }
-        else {
+        } else {
 
             IComplexNumber num = (IComplexNumber) o;
             double thisReal = realComponent().doubleValue();

--- a/nd4j-jblas/src/main/java/org/nd4j/linalg/jblas/complex/ComplexFloat.java
+++ b/nd4j-jblas/src/main/java/org/nd4j/linalg/jblas/complex/ComplexFloat.java
@@ -199,13 +199,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
      */
     @Override
     public IComplexNumber addi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(real() + c.realComponent().floatValue(), imag() + result.imaginaryComponent().floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() + c.realComponent().floatValue(), result.imaginaryComponent().floatValue() + c.imaginaryComponent().floatValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().floatValue() + c.realComponent().floatValue(), result.imaginaryComponent().floatValue() + c.imaginaryComponent().floatValue());
     }
 
     /**
@@ -236,13 +230,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
      */
     @Override
     public IComplexNumber addi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(real() + a.floatValue(), imag() + a.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() + a.floatValue(), imaginaryComponent() + a.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() + a.floatValue(), imaginaryComponent());
     }
 
 
@@ -274,13 +262,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
      */
     @Override
     public IComplexNumber subi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(real() - c.realComponent().floatValue(), imag() - result.imaginaryComponent().floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() - c.realComponent().floatValue(), result.imaginaryComponent().floatValue() - c.imaginaryComponent().floatValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().floatValue() - c.realComponent().floatValue(), result.imaginaryComponent().floatValue() - c.imaginaryComponent().floatValue());
     }
 
     @Override
@@ -300,13 +282,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber subi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(real() - a.floatValue(), imag() - a.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() - a.floatValue(), imaginaryComponent().floatValue() - a.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() - a.floatValue(), result.imaginaryComponent().floatValue() - a.floatValue());
     }
 
     @Override
@@ -375,13 +351,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber muli(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(real() * v.floatValue(), imag() * v.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() * v.floatValue(), imaginaryComponent().floatValue() * v.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() * v.floatValue(), result.imaginaryComponent().floatValue() * v.floatValue());
     }
 
     @Override
@@ -421,13 +391,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber divi(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(real() / v.floatValue(), imag());
-        } else {
-            result.set(result.realComponent().floatValue() / v.floatValue(), imaginaryComponent());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() / v.floatValue(), imaginaryComponent() / v.floatValue());
     }
 
     @Override
@@ -457,7 +421,8 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber rdivi(Number v, IComplexNumber result) {
-        return result.set(v.floatValue() / real(), imag());
+        float d = result.realComponent().floatValue() * result.realComponent().floatValue() + result.imaginaryComponent().floatValue() * result.imaginaryComponent().floatValue();
+        return result.set(v.floatValue() * result.realComponent().floatValue() / d, -v.floatValue() * result.imaginaryComponent().floatValue() / d);
     }
 
     @Override
@@ -762,9 +727,8 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
     public boolean equals(Object o) {
         if (!(o instanceof IComplexNumber) || !(o instanceof org.jblas.ComplexFloat) && !(o instanceof org.jblas.ComplexDouble)) {
             return false;
-        }
-        else {
-            if(o instanceof org.jblas.ComplexFloat)
+        } else {
+            if (o instanceof org.jblas.ComplexFloat)
                 return super.equals(o);
             else {
                 IComplexNumber num = (IComplexNumber) o;

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/complex/ComplexNumberTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/complex/ComplexNumberTests.java
@@ -55,7 +55,7 @@ public  class ComplexNumberTests  extends BaseNd4jTest {
         IComplexDouble test = Nd4j.createDouble(1, 1);
         test.addi(1);
         assertEquals(2, test.realComponent().doubleValue(), 1e-1);
-        assertEquals(2, test.imaginaryComponent(), 1e-1);
+        assertEquals(1, test.imaginaryComponent(), 1e-1);
         test.subi(1);
         assertEquals(1, test.realComponent().doubleValue(), 1e-1);
         assertEquals(1, test.imaginaryComponent(), 1e-1);
@@ -65,8 +65,12 @@ public  class ComplexNumberTests  extends BaseNd4jTest {
         test.divi(2);
         assertEquals(1, test.realComponent().doubleValue(), 1e-1);
         assertEquals(1, test.imaginaryComponent(), 1e-1);
-
-
+        test.addi(Nd4j.createDouble(1, 1));
+        assertEquals(2, test.realComponent().doubleValue(), 1e-1);
+        assertEquals(2, test.imaginaryComponent(), 1e-1);
+        test.rdivi(1);
+        assertEquals(0.25d, test.realComponent().doubleValue(), 1e-1);
+        assertEquals(-0.25d, test.imaginaryComponent(), 1e-1);
     }
 
 
@@ -75,7 +79,7 @@ public  class ComplexNumberTests  extends BaseNd4jTest {
         IComplexFloat test = Nd4j.createFloat(1, 1);
         test.addi(1);
         assertEquals(2, test.realComponent().doubleValue(), 1e-1);
-        assertEquals(2, test.imaginaryComponent(), 1e-1);
+        assertEquals(1, test.imaginaryComponent(), 1e-1);
         test.subi(1);
         assertEquals(1, test.realComponent().doubleValue(), 1e-1);
         assertEquals(1, test.imaginaryComponent(), 1e-1);
@@ -85,8 +89,12 @@ public  class ComplexNumberTests  extends BaseNd4jTest {
         test.divi(2);
         assertEquals(1, test.realComponent().doubleValue(), 1e-1);
         assertEquals(1, test.imaginaryComponent(), 1e-1);
-
-
+        test.addi(Nd4j.createFloat(1, 1));
+        assertEquals(2, test.realComponent().doubleValue(), 1e-1);
+        assertEquals(2, test.imaginaryComponent(), 1e-1);
+        test.rdivi(1);
+        assertEquals(0.25f, test.realComponent().doubleValue(), 1e-1);
+        assertEquals(-0.25f, test.imaginaryComponent(), 1e-1);
     }
 
     @Override

--- a/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/complex/ComplexDouble.java
+++ b/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/complex/ComplexDouble.java
@@ -201,13 +201,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
      */
     @Override
     public IComplexNumber addi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(real() + c.realComponent().doubleValue(), imag() + c.imaginaryComponent().doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() + c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() + c.imaginaryComponent().doubleValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().doubleValue() + c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() + c.imaginaryComponent().doubleValue());
     }
 
     /**
@@ -238,13 +232,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
      */
     @Override
     public IComplexNumber addi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(real() + a.doubleValue(), imag() + a.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() + a.doubleValue(), result.imaginaryComponent().doubleValue() + a.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() + a.doubleValue(), result.imaginaryComponent().doubleValue());
     }
 
     /**
@@ -275,13 +263,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
      */
     @Override
     public IComplexNumber subi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(real() - c.realComponent().doubleValue(), imag() - c.imaginaryComponent().doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() - c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() - c.imaginaryComponent().doubleValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().doubleValue() - c.realComponent().doubleValue(), result.imaginaryComponent().doubleValue() - c.imaginaryComponent().doubleValue());
     }
 
     @Override
@@ -301,13 +283,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber subi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(real() - a.doubleValue(), imag() - a.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() - a.doubleValue(), imaginaryComponent().doubleValue() - a.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() - a.doubleValue(), result.imaginaryComponent().doubleValue() - a.doubleValue());
     }
 
     @Override
@@ -327,7 +303,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber rsubi(Number a, IComplexNumber result) {
-        return result.set(a.doubleValue() - realComponent().doubleValue(), imaginaryComponent());
+        return result.set(a.doubleValue() - result.realComponent().doubleValue(), imaginaryComponent());
     }
 
     @Override
@@ -376,13 +352,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber muli(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(real() * v.doubleValue(), imag() * v.doubleValue());
-        } else {
-            result.set(result.realComponent().doubleValue() * v.doubleValue(), imaginaryComponent() * v.doubleValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() * v.doubleValue(), result.imaginaryComponent().doubleValue() * v.doubleValue());
     }
 
     @Override
@@ -422,13 +392,7 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber divi(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(real() / v.doubleValue(), imag());
-        } else {
-            result.set(result.realComponent().doubleValue() / v.doubleValue(), imaginaryComponent());
-
-        }
-        return result;
+        return result.set(result.realComponent().doubleValue() / v.doubleValue(), result.imaginaryComponent().doubleValue() / v.doubleValue());
     }
 
     @Override
@@ -458,7 +422,8 @@ public class ComplexDouble extends org.jblas.ComplexDouble implements IComplexDo
 
     @Override
     public IComplexNumber rdivi(Number v, IComplexNumber result) {
-        return result.set(v.doubleValue() / real(), imaginaryComponent());
+        double d = result.realComponent().doubleValue() * result.realComponent().doubleValue() + result.imaginaryComponent().doubleValue() * result.imaginaryComponent().doubleValue();
+        return result.set(v.doubleValue() * result.realComponent().doubleValue() / d, -v.doubleValue() * result.imaginaryComponent().doubleValue() / d);
     }
 
     @Override

--- a/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/complex/ComplexFloat.java
+++ b/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/complex/ComplexFloat.java
@@ -199,13 +199,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
      */
     @Override
     public IComplexNumber addi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(real() + c.realComponent().floatValue(), imag() + result.imaginaryComponent().floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() + c.realComponent().floatValue(), result.imaginaryComponent().floatValue() + c.imaginaryComponent().floatValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().floatValue() + c.realComponent().floatValue(), result.imaginaryComponent().floatValue() + c.imaginaryComponent().floatValue());
     }
 
     /**
@@ -236,13 +230,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
      */
     @Override
     public IComplexNumber addi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(real() + a.floatValue(), imag() + a.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() + a.floatValue(), imaginaryComponent() + a.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() + a.floatValue(), result.imaginaryComponent().floatValue());
     }
 
 
@@ -274,13 +262,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
      */
     @Override
     public IComplexNumber subi(IComplexNumber c, IComplexNumber result) {
-        if (this == result) {
-            set(real() - c.realComponent().floatValue(), imag() - result.imaginaryComponent().floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() - c.realComponent().floatValue(), result.imaginaryComponent().floatValue() - c.imaginaryComponent().floatValue());
-
-        }
-        return this;
+        return result.set(result.realComponent().floatValue() - c.realComponent().floatValue(), result.imaginaryComponent().floatValue() - c.imaginaryComponent().floatValue());
     }
 
     @Override
@@ -300,13 +282,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber subi(Number a, IComplexNumber result) {
-        if (this == result) {
-            set(real() - a.floatValue(), imag() - a.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() - a.floatValue(), imaginaryComponent().floatValue() - a.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() - a.floatValue(), result.imaginaryComponent().floatValue());
     }
 
     @Override
@@ -375,13 +351,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber muli(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(real() * v.floatValue(), imag() * v.floatValue());
-        } else {
-            result.set(result.realComponent().floatValue() * v.floatValue(), imaginaryComponent().floatValue() * v.floatValue());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() * v.floatValue(), result.imaginaryComponent().floatValue() * v.floatValue());
     }
 
     @Override
@@ -421,13 +391,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber divi(Number v, IComplexNumber result) {
-        if (this == result) {
-            set(real() / v.floatValue(), imag());
-        } else {
-            result.set(result.realComponent().floatValue() / v.floatValue(), imaginaryComponent());
-
-        }
-        return result;
+        return result.set(result.realComponent().floatValue() / v.floatValue(), imaginaryComponent() / v.floatValue());
     }
 
     @Override
@@ -447,7 +411,7 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber rdivi(IComplexNumber c, IComplexNumber result) {
-        return result.set(c.div(this));
+        return result.set(c.div(result));
     }
 
     @Override
@@ -457,7 +421,8 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
 
     @Override
     public IComplexNumber rdivi(Number v, IComplexNumber result) {
-        return result.set(v.floatValue() / real(), imag());
+        float d = result.realComponent().floatValue() * result.realComponent().floatValue() + result.imaginaryComponent().floatValue() * result.imaginaryComponent().floatValue();
+        return result.set(v.floatValue() * result.realComponent().floatValue() / d, -v.floatValue() * result.imaginaryComponent().floatValue() / d);
     }
 
     @Override
@@ -762,9 +727,8 @@ public class ComplexFloat extends org.jblas.ComplexFloat implements IComplexFloa
     public boolean equals(Object o) {
         if (!(o instanceof IComplexNumber) || !(o instanceof org.jblas.ComplexFloat) && !(o instanceof org.jblas.ComplexDouble)) {
             return false;
-        }
-        else {
-            if(o instanceof org.jblas.ComplexFloat)
+        } else {
+            if (o instanceof org.jblas.ComplexFloat)
                 return super.equals(o);
             else {
                 IComplexNumber num = (IComplexNumber) o;


### PR DESCRIPTION
Fix the following wrong calculations. 

```scala
scala> Nd4j.createComplexNumber(0.0, 0.0).addi(Nd4j.createComplexNumber(1.0, 1.0))
res0: org.nd4j.linalg.api.complex.IComplexNumber = 1.0 + 0.0i //must be 1.0 + 1.0i

scala> Nd4j.createComplexNumber(0.0, 0.0).addi(3)
res1: org.nd4j.linalg.api.complex.IComplexNumber = 3.0 + 3.0i //must be 3.0 + 0.0i

scala> Nd4j.createComplexNumber(2.0, 2.0).div(2)
res2: org.nd4j.linalg.api.complex.IComplexNumber = 1.0 + 2.0i //must be 1.0 + 1.0i

scala> Nd4j.createComplexNumber(2.0, 2.0).rdivi(2) 
res3: org.nd4j.linalg.api.complex.IComplexNumber = 1.0 + 2.0i 
/*
 must be 0.5 - 0.5i, 
 equivalent with Nd4j.createComplexNumber(2.0, 0.0).divi(Nd4j.createComplexNumber(2.0, 2.0)) 
*/
```

Now ND4j returns as follows.

```scala
scala>  Nd4j.createComplexNumber(0.0, 0.0).addi(Nd4j.createComplexNumber(1.0, 1.0))
res0: org.nd4j.linalg.api.complex.IComplexNumber = 1.0 + 1.0i

scala> Nd4j.createComplexNumber(0.0, 0.0).addi(3)
res1: org.nd4j.linalg.api.complex.IComplexNumber = 3.0 + 0.0i

scala>  Nd4j.createComplexNumber(2.0, 2.0).div(2)
res2: org.nd4j.linalg.api.complex.IComplexNumber = 1.0 + 1.0i

scala>  Nd4j.createComplexNumber(2.0, 2.0).rdivi(2)
res3: org.nd4j.linalg.api.complex.IComplexNumber = 0.5 - 0.5i
```