### PR TITLE
fixes the bug that some tests don't run due to test filename setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,9 @@
                     <environmentVariables>
                         <LD_LIBRARY_PATH>${env.LD_LIBRARY_PATH}:${user.dir}</LD_LIBRARY_PATH>
                     </environmentVariables>
+                    <includes>
+                        <include>**/*Test*.java</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This fixes the bug that many test files such as `org.nd4j.linalg.Nd4jTestsC.java` don't run by `mvn test` command ,since these files don't satisfy maven test file naming default requirements as follows.

> By default, the Surefire Plugin will automatically include all test classes with the following wildcard patterns:
> "\*\*/Test\*.java" - includes all of its subdirectories and all Java filenames that start with "Test".
> "\*\*/\*Test.java" - includes all of its subdirectories and all Java filenames that end with "Test".
> "\*\*/\*TestCase.java" - includes all of its subdirectories and all Java filenames that end with "TestCase".
> If the test classes do not follow any of these naming conventions, then configure Surefire Plugin and specify the tests you want to include.

http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html