### PR TITLE
fix NDArray offset with float 2d values

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -577,14 +577,13 @@ public abstract class BaseNDArray implements INDArray {
      * @param ordering
      */
     public BaseNDArray(float[][] data,char ordering) {
-        this(Nd4j.createBuffer(ArrayUtil.flatten(data)), new int[]{data.length, data[0].length},ordering);
+        this(Nd4j.createBuffer(ArrayUtil.flatten(data)), new int[]{data.length, data[0].length},Nd4j.getStrides(new int[]{data.length, data[0].length},ordering),0,ordering);
 
         for (int r = 0; r < rows; r++) {
             assert (data[r].length == columns);
         }
 
         this.data = Nd4j.createBuffer(length);
-
 
         for (int r = 0; r < rows; r++) {
             for (int c = 0; c < columns; c++) {

--- a/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2151,8 +2151,8 @@ public class Nd4j {
      * @param doubles
      * @return
      */
-    public static INDArray create(float[][] doubles) {
-        return INSTANCE.create(doubles);
+    public static INDArray create(float[][] data) {
+        return INSTANCE.create(data);
     }
 
     public static INDArray create(float[][] data, char ordering) {


### PR DESCRIPTION
Fix offset bug in creating NDArray from float 2d array.

```scala
scala> Nd4j.create(Array(Array(1f,2f),Array(3f,4f)))
res0: org.nd4j.linalg.api.ndarray.INDArray =
[[1.00,2.00]
 [2.00,3.00]]

scala> res0.offset
res1: Int = 99
```