### PR TITLE
Fix initializationError in running TestSuite

### DIFF
--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTests.java
@@ -1,11 +1,17 @@
 package org.nd4j.linalg.api.indexing;
 
 import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class ShapeResolutionTests extends BaseNd4jTest {
+
+    public ShapeResolutionTests(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Override
     public char ordering() {
         return 'f';

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 import org.nd4j.linalg.indexing.ShapeOffsetResolution;
 import org.nd4j.linalg.util.ArrayUtil;
@@ -16,6 +17,11 @@ import static org.junit.Assume.*;
  * @author Adam Gibson
  */
 public class ShapeResolutionTestsC extends BaseNd4jTest {
+
+    public ShapeResolutionTestsC(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testRowVectorShapeOneZeroOffset() {
         INDArray arr = Nd4j.create(2, 2);

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/iterator/NDIndexIteratorTest.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/iterator/NDIndexIteratorTest.java
@@ -3,6 +3,7 @@ package org.nd4j.linalg.api.iterator;
 import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.iter.NdIndexIterator;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 import java.util.Iterator;
 
@@ -12,6 +13,10 @@ import static org.junit.Assert.*;
  * @author Adam Gibson
  */
 public class NDIndexIteratorTest extends BaseNd4jTest {
+
+    public NDIndexIteratorTest(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
 
     @Test
     public void testIterate() {


### PR DESCRIPTION
This fixes test build errors in running TestSuite via specified backend such as:

```
mvn test -pl nd4j-jblas
```

Though TestSuite requires a constructor with arguments `(java.lang.String, org.nd4j.linalg.factory.Nd4jBackend)`, some test don't have one and shows following initializationError.

> initializationError(org.nd4j.linalg.Nd4jTestSuite)  Time elapsed: 0.015 sec  <<< ERROR!
> java.lang.NoSuchMethodException: org.nd4j.linalg.api.iterator.NDIndexIteratorTest.<init>(java.lang.String, org.nd4j.linalg.factory.Nd4jBackend)