### PR TITLE
Fixes the bug that some of ComplexNDArray calculations doesn't reflect Imaginary Component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Or, run the following command to execute TestSuite with only specified backend e
 - nd4j-netlib-blas
 - nd4j-x86
 
+Or, run the following command to execute only specified tests in TestSuite with only specified backend.
+
+     mvn test -pl nd4j-XXX -Dorg.nd4j.linalg.tests.classestorun=org.nd4j.linalg.YYY -Dorg.nd4j.linalg.tests.methods=ZZZ
+
 ---
 ## Contribute
 

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexNDArray.java
@@ -1329,7 +1329,43 @@ public abstract class BaseComplexNDArray extends BaseNDArray implements IComplex
      */
     @Override
     public IComplexNDArray putSlice(int slice, IComplexNDArray put) {
-        return (IComplexNDArray) super.putSlice(slice,put);
+        ensureNotCleanedUp();
+        if (isScalar()) {
+            assert put.isScalar() : "Invalid dimension. Can only insert a scalar in to another scalar";
+            put(0, put.getScalar(0));
+            return this;
+        } else if (isVector()) {
+            assert put.isScalar() || put.isVector() &&
+                    put.length() == length() : "Invalid dimension on insertion. Can only insert scalars input vectors";
+            if (put.isScalar())
+                putScalar(slice, put.getComplex(0));
+            else
+                for (int i = 0; i < length(); i++)
+                    putScalar(i, put.getComplex(i));
+
+            return this;
+        }
+
+        assertSlice(put, slice);
+
+        IComplexNDArray view = slice(slice);
+
+        if (put.length() == 1)
+            putScalar(slice, put.getComplex(0));
+        else if (put.isVector())
+            for (int i = 0; i < put.length(); i++)
+                view.putScalar(i, put.getComplex(i));
+        else {
+
+            assert Shape.shapeEquals(view.shape(),put.shape());
+            IComplexNDArray linear = (IComplexNDArray)view.linearView();
+            IComplexNDArray putLinearView = put.linearView();
+            for(int i = 0; i < linear.length(); i++) {
+                linear.putScalar(i,putLinearView.getComplex(i));
+            }
+        }
+
+        return this;
     }
 
 

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexNDArray.java
@@ -2892,7 +2892,7 @@ public abstract class BaseComplexNDArray extends BaseNDArray implements IComplex
 
     @Override
     public IComplexNDArray add(IComplexNumber n) {
-        return addi(n, this);
+        return dup().addi(n);
     }
 
     @Override

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ComplexNDArrayTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ComplexNDArrayTestsC.java
@@ -744,6 +744,31 @@ public  class ComplexNDArrayTestsC extends BaseComplexNDArrayTests  {
         assertEquals(6, sum, 1e-1);
     }
 
+    @Test
+    public void testComplexCalculation() {
+        IComplexNDArray arr = Nd4j.createComplex(
+                new IComplexNumber[][]{{Nd4j.createComplexNumber(1, 1), Nd4j.createComplexNumber(2, 1)},
+                {Nd4j.createComplexNumber(3, 2), Nd4j.createComplexNumber(4, 2)}});
+
+        IComplexNumber scalar =  arr.sumComplex();
+        double sum = scalar.realComponent().doubleValue();
+        assertEquals(10, sum, 1e-1);
+
+        double sumImag = scalar.imaginaryComponent().doubleValue();
+        assertEquals(6, sumImag, 1e-1);
+
+        IComplexNDArray res = arr.add(Nd4j.createComplexNumber(1, 1));
+        scalar = res.sumComplex();
+        sum = scalar.realComponent().doubleValue();
+        assertEquals(14, sum, 1e-1);
+        sumImag = scalar.imaginaryComponent().doubleValue();
+        assertEquals(10, sumImag, 1e-1);
+
+        //original array should keep as it is
+        sum = arr.sumComplex().realComponent().doubleValue();
+        assertEquals(10, sum, 1e-1);
+    }
+
 
     @Test
     public void testElementWiseOps() {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ComplexNDArrayTestsFortran.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ComplexNDArrayTestsFortran.java
@@ -528,6 +528,31 @@ public  class ComplexNDArrayTestsFortran extends BaseComplexNDArrayTests  {
         assertEquals(6, sum, 1e-1);
     }
 
+    @Test
+    public void testComplexCalculation() {
+        IComplexNDArray arr = Nd4j.createComplex(
+                new IComplexNumber[][]{{Nd4j.createComplexNumber(1, 1), Nd4j.createComplexNumber(2, 1)},
+                        {Nd4j.createComplexNumber(3, 2), Nd4j.createComplexNumber(4, 2)}});
+
+        IComplexNumber scalar =  arr.sumComplex();
+        double sum = scalar.realComponent().doubleValue();
+        assertEquals(10, sum, 1e-1);
+
+        double sumImag = scalar.imaginaryComponent().doubleValue();
+        assertEquals(6, sumImag, 1e-1);
+
+        IComplexNDArray res = arr.add(Nd4j.createComplexNumber(1, 1));
+        scalar = res.sumComplex();
+        sum = scalar.realComponent().doubleValue();
+        assertEquals(14, sum, 1e-1);
+        sumImag = scalar.imaginaryComponent().doubleValue();
+        assertEquals(10, sumImag, 1e-1);
+
+        //original array should keep as it is
+        sum = arr.sumComplex().realComponent().doubleValue();
+        assertEquals(10, sum, 1e-1);
+    }
+
 
     @Test
     public void testElementWiseOps() {


### PR DESCRIPTION
This fixes ComplexNDArray calculation bug, which doesn't reflect Imaginary Component.

```scala
scala> val complexNDArray =
     |       Array(
     |         Array(1 + i, 1 + i),
     |         Array(1 + 3 * i, 1 + 3 * i)
     |       ).toNDArray
complexNDArray: org.nd4j.linalg.api.complex.IComplexNDArray =
[[1.0 + 1.0i ,1.0 + 1.0i]
[1.0 + 3.0i ,1.0 + 3.0i]
]

scala> complexNDArray add 2
res0: org.nd4j.api.NDArrayEvidence.complexNDArrayEvidence.NDArray =
[[3.0 + 0.0i ,3.0 + 0.0i]
[3.0 + 0.0i ,3.0 + 0.0i]
]
```