### PR TITLE
Should not allow out of index

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/indexing/NDArrayIndex.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/indexing/NDArrayIndex.java
@@ -274,14 +274,14 @@ public class NDArrayIndex implements INDArrayIndex {
         Arrays.fill(all,NDArrayIndex.all());
         for(int i = 0; i < allIndex.length; i++) {
             //collapse single length indexes in to point indexes
-            if(intendedIndexes[i] instanceof NDArrayIndex) {
-                NDArrayIndex idx = (NDArrayIndex) intendedIndexes[i];
-                if(idx.indices.length == 1)
-                    intendedIndexes[i] = new PointIndex(idx.indices[0]);
-            }
-            if(i < intendedIndexes.length)
-                all[i] =  intendedIndexes[i];
+            if (i >= intendedIndexes.length) break;
 
+            if (intendedIndexes[i] instanceof NDArrayIndex) {
+                NDArrayIndex idx = (NDArrayIndex) intendedIndexes[i];
+                if (idx.indices.length == 1)
+                    intendedIndexes[i] = new PointIndex(idx.indices[0]);
+          }
+          all[i] = intendedIndexes[i];
         }
 
         return all;


### PR DESCRIPTION
Problem: This issue was raised while trying to execute the DBNIrisExample in current state of [DL4J examples](https://github.com/deeplearning4j/dl4j-0.0.3.3-examples).

Implemented solution: Moved if condition up in order to guard the intendedIndexes array so that it does not go out of its boundary. 

Note: I'm not really sure if this is even the correct solution. I'm having a hard time understanding what is actually supposed to happen in the method but it seems that there's a smell in the actual implementation since a new "all" array is created to include the allIndexes + new ones in intendedIndexes and then the iteration only happens for the allIndexes. The new ones will never be inserted at the end of the "all" list.