### PR TITLE
fix non double BaseDataBuffer's NPE

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -562,7 +562,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
                 throw new IllegalStateException("Index out of bounds " + i);
             return (float) doubleData[i];
         } else if(floatData != null) {
-            if(i >= doubleData.length)
+            if(i >= floatData.length)
                 throw new IllegalStateException("Index out of bounds " + i);
             return floatData[i];
         }


### PR DESCRIPTION
This fixed following NPE due to typo.
```scala
scala> List(1 + i).toNDArray
res0: org.nd4j.linalg.api.complex.IComplexNDArray = 1.0 + 1.0i

scala> res0.getComplex(0)
java.lang.NullPointerException
  at org.nd4j.linalg.api.buffer.BaseDataBuffer.getFloat(BaseDataBuffer.java:565)
  at org.nd4j.linalg.api.buffer.BaseDataBuffer.getComplexFloat(BaseDataBuffer.java:409)
  at org.nd4j.linalg.api.buffer.BaseDataBuffer.getComplex(BaseDataBuffer.java:419)
  at org.nd4j.linalg.api.complex.BaseComplexNDArray.getComplex(BaseComplexNDArray.java:1462)
  at org.nd4j.linalg.api.complex.BaseComplexNDArray.getComplex(BaseComplexNDArray.java:1447)
  ... 43 elided
```