### PR TITLE
Fix IntervalIndex stride, length and next if stride is equal to 2.

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/indexing/IntervalIndex.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/indexing/IntervalIndex.java
@@ -36,7 +36,7 @@ public class IntervalIndex implements INDArrayIndex {
 
     @Override
     public int length() {
-        return (end - begin) / stride;
+        return (end - 1 - begin) / stride + 1;
     }
 
     @Override
@@ -51,7 +51,7 @@ public class IntervalIndex implements INDArrayIndex {
 
     @Override
     public boolean hasNext() {
-        return index < length();
+        return index < end();
     }
 
     @Override
@@ -83,6 +83,7 @@ public class IntervalIndex implements INDArrayIndex {
     @Override
     public void init(INDArray arr, int begin, int dimension) {
         this.begin = begin;
+        this.index = begin;
         this.end = inclusive ? arr.size(dimension) + 1 : arr.size(dimension);
     }
 
@@ -94,6 +95,7 @@ public class IntervalIndex implements INDArrayIndex {
     @Override
     public void init(int begin, int end) {
         this.begin = begin;
+        this.index = begin;
         this.end = inclusive ? end + 1 : end;
 
     }

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingIterationTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingIterationTests.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.*;
 
 
@@ -13,6 +14,10 @@ import static org.junit.Assert.*;
  * @author Adam Gibson
  */
 public class IndexingIterationTests extends BaseNd4jTest {
+    public IndexingIterationTests(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testAll() {
         INDArrayIndex all = NDArrayIndex.all();
@@ -33,6 +38,18 @@ public class IndexingIterationTests extends BaseNd4jTest {
         assertEquals(2, interval.length());
         assertEquals(0, interval.next());
         assertEquals(1,interval.next());
+        assertFalse(interval.hasNext());
+
+    }
+
+    @Test
+    public void testIntervalWithStride() {
+        INDArrayIndex interval = NDArrayIndex.interval(3,2,6);
+        assertTrue(interval.hasNext());
+        assertEquals(2, interval.length());
+        assertEquals(3, interval.next());
+        assertTrue(interval.hasNext());
+        assertEquals(5,interval.next());
         assertFalse(interval.hasNext());
 
     }


### PR DESCRIPTION
This fixes the following indexing bug if stride is 2.

```scala
//This stands for indices list [3,5]
scala> val indices = NDArrayIndex.interval(3,2,6)
indices: org.nd4j.linalg.indexing.INDArrayIndex = org.nd4j.linalg.indexing.IntervalIndex@44bcc47e

//This should return 2.
scala> indices.length
res1: Int = 1

//This should return first index, 3.
scala> indices.next
res2: Int = 0

//This should return second index, 5.
scala> indices.next
res3: Int = 2
```