### PR TITLE
Fix IComplexNDArray linearView bug

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/LinearViewComplexNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/LinearViewComplexNDArray.java
@@ -64,7 +64,7 @@ public class LinearViewComplexNDArray extends BaseComplexNDArray {
         if(slice.isRowVector()) {
             vectors.add(slice);
         }
-        else if(isMatrix()) {
+        else if(slice.isMatrix()) {
             for(int i = 0; i < slice.rows(); i++)
                 vectors.add(slice.getRow(i));
         }
@@ -136,7 +136,6 @@ public class LinearViewComplexNDArray extends BaseComplexNDArray {
 
 
         int idx =  i - offset;
-
         return currVector.getComplex(idx);
     }
 
@@ -206,7 +205,4 @@ public class LinearViewComplexNDArray extends BaseComplexNDArray {
         sb.append("]");
         return sb.toString();
     }
-
-
-
 }

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/resolve/NDArrayIndexResolveTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/resolve/NDArrayIndexResolveTests.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 
@@ -13,6 +14,10 @@ import static org.junit.Assert.*;
  * @author Adam Gibson
  */
 public class NDArrayIndexResolveTests extends BaseNd4jTest {
+
+    public NDArrayIndexResolveTests(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
 
     @Test
     public void testResolvePoint() {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/shape/IndexShapeTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/shape/IndexShapeTests.java
@@ -2,6 +2,7 @@ package org.nd4j.linalg.api.indexing.shape;
 
 import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 import org.nd4j.linalg.indexing.Indices;
 import org.nd4j.linalg.indexing.NDArrayIndex;
@@ -12,6 +13,10 @@ import static org.junit.Assert.*;
  * @author Adam Gibson
  */
 public class IndexShapeTests extends BaseNd4jTest {
+    public IndexShapeTests(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     private  int[] shape = {1,1,2,1,3,4,5,1};
 
     @Test

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/shape/IndexShapeTests2d.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/shape/IndexShapeTests2d.java
@@ -2,6 +2,7 @@ package org.nd4j.linalg.api.indexing.shape;
 
 import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 import org.nd4j.linalg.indexing.Indices;
 import org.nd4j.linalg.indexing.NDArrayIndex;
@@ -12,6 +13,11 @@ import static org.junit.Assert.assertArrayEquals;
  * @author Adam Gibson
  */
 public class IndexShapeTests2d extends BaseNd4jTest {
+
+    public IndexShapeTests2d(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     private int[] shape = {3,2};
 
 

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ops/broadcast/column/ColumnVectorOps.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ops/broadcast/column/ColumnVectorOps.java
@@ -1,11 +1,15 @@
 package org.nd4j.linalg.ops.broadcast.column;
 
 import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class ColumnVectorOps extends BaseNd4jTest {
+    public ColumnVectorOps(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
 
     @Override
     public char ordering() {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ops/broadcast/column/ColumnVectorOpsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ops/broadcast/column/ColumnVectorOpsC.java
@@ -1,11 +1,16 @@
 package org.nd4j.linalg.ops.broadcast.column;
 
 import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class ColumnVectorOpsC extends BaseNd4jTest {
+    public ColumnVectorOpsC(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Override
     public char ordering() {
         return 'c';

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ops/broadcast/row/RowVectorOpsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ops/broadcast/row/RowVectorOpsC.java
@@ -4,11 +4,16 @@ import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
 
 /**
  * @author Adam Gibson
  */
 public class RowVectorOpsC extends BaseNd4jTest {
+    public RowVectorOpsC(String name, Nd4jBackend backend) {
+        super(name, backend);
+    }
+
     @Test
     public void testAddi() {
         INDArray arr = Nd4j.linspace(1,4,4).reshape(2,2);


### PR DESCRIPTION
This fixed following error due to the bug to check given wrapped NDArray is Matrix or not.

```scala
scala> val complexNDArray =
     |       Array(
     |         Array(1 + i, 1 + i),
     |         Array(1 + 3 * i, 1 + 3 * i)
     |       ).toNDArray
complexNDArray: org.nd4j.linalg.api.complex.IComplexNDArray =
[[1.0 + 1.0i ,1.0 + 1.0i]
[1.0 + 3.0i ,1.0 + 3.0i]
]


scala> complexNDArray.linearView
java.lang.IllegalArgumentException: Index 1 >= 1
  at org.nd4j.linalg.api.complex.BaseComplexNDArray.getComplex(BaseComplexNDArray.java:1445)
  at org.nd4j.linalg.api.complex.LinearViewComplexNDArray.getComplex(LinearViewComplexNDArray.java:140)
  at org.nd4j.linalg.api.complex.LinearViewComplexNDArray.toString(LinearViewComplexNDArray.java:200)
....
```

Simultaneously, this also adds necessarily constructors for TestSuite.