### PR TITLE
Fix concat issue with vector and matrix

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
@@ -975,7 +975,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
         if(ret.isVector()) {
             int offset = 0;
             for(INDArray arr : toConcat) {
-                for(int i = 0; i < arr.length(); i++) {
+                for(int i = 0; i < arr.size(dimension); i++) {
                     ret.putScalar(offset++,arr.getDouble(i));
                 }
             }

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/shape/concat/ConcatTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/shape/concat/ConcatTests.java
@@ -93,6 +93,31 @@ public class ConcatTests extends BaseNd4jTest {
     }
 
 
+    @Test
+    public void testConcatColVectorAndMatrix() {
+      
+        INDArray colVector = Nd4j.create(new double[]{1, 2, 3, 1, 2, 3}, new int[]{6, 1});
+        INDArray matrix = Nd4j.create(new double[]{4, 5, 6, 4, 5, 6}, new int[]{2, 3});
+
+        INDArray assertion = Nd4j.create(new double[]{1, 2, 3, 1, 2, 3, 4, 5}, new int[]{8, 1});
+
+        INDArray concat = Nd4j.vstack(colVector, matrix);
+        assertEquals(assertion,concat);
+        
+    }
+
+    @Test
+    public void testConcatRowVectorAndMatrix() {
+
+        INDArray rowVector = Nd4j.create(new double[]{1, 2, 3, 1, 2, 3}, new int[]{1, 6});
+        INDArray matrix = Nd4j.create(new double[]{4, 5, 6, 4, 5, 6}, new int[]{3, 2});
+
+        INDArray assertion = Nd4j.create(new double[]{1, 2, 3, 1, 2, 3, 4, 5}, new int[]{1, 8});
+
+        INDArray concat = Nd4j.hstack(rowVector, matrix);
+        assertEquals(assertion, concat);
+      
+    }
 
 
     @Override

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/shape/concat/ConcatTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/shape/concat/ConcatTestsC.java
@@ -96,6 +96,33 @@ public class ConcatTestsC extends BaseNd4jTest {
         ones.assign(tensor);
         assertEquals(tensor,ones);
     }
+    
+    @Test
+    public void testConcatColVectorAndMatrix() {
+      
+        INDArray colVector = Nd4j.create(new double[]{1, 2, 3, 1, 2, 3}, new int[]{6, 1});
+        INDArray matrix = Nd4j.create(new double[]{4, 5, 6, 4, 5, 6}, new int[]{2, 3});
+
+        INDArray assertion = Nd4j.create(new double[]{1, 2, 3, 1, 2, 3, 4, 5}, new int[]{8, 1});
+
+        INDArray concat = Nd4j.vstack(colVector, matrix);
+        assertEquals(assertion,concat);
+        
+    }
+
+    @Test
+    public void testConcatRowVectorAndMatrix() {
+
+        INDArray rowVector = Nd4j.create(new double[]{1, 2, 3, 1, 2, 3}, new int[]{1, 6});
+        INDArray matrix = Nd4j.create(new double[]{4, 5, 6, 4, 5, 6}, new int[]{3, 2});
+
+        INDArray assertion = Nd4j.create(new double[]{1, 2, 3, 1, 2, 3, 4, 5}, new int[]{1, 8});
+
+        INDArray concat = Nd4j.hstack(rowVector, matrix);
+        assertEquals(assertion, concat);
+      
+    }
+
 
     @Override
     public char ordering() {


### PR DESCRIPTION
Performing vstack on a column vector and a matrix with more columns than rows results in an IllegalIndexException at concat method. The same results from a hstack with a row vector and a matrix with more rows than columns.

This PR solves the issue and adds four tests to avoid regressions.