### PR TITLE
Validate INDArrayIndex if it is out of range index in its dimension.

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -1752,8 +1752,8 @@ public abstract class BaseNDArray implements INDArray {
             return create(Nd4j.createBuffer(shape));
         if (offsets.length != n)
             throw new IllegalArgumentException("Invalid offset " + Arrays.toString(offsets));
-        if (shape.length != n)
-            throw new IllegalArgumentException("Invalid shape " + Arrays.toString(shape));
+        if (stride.length != n)
+            throw new IllegalArgumentException("Invalid stride " + Arrays.toString(stride));
 
         if (Arrays.equals(shape, this.shape)) {
             if (ArrayUtil.isZero(offsets)) {
@@ -1763,19 +1763,15 @@ public abstract class BaseNDArray implements INDArray {
             }
         }
 
-        //handle strides/offsets < rank
-        if(offsets.length != stride.length)
-            throw new IllegalStateException("Offsets and stride must be same length");
-        if(offset >= data().length())
+        if (offset >= data().length())
             offset = ArrayUtil.sum(offsets);
 
         return create(
                 data
                 , Arrays.copyOf(shape, shape.length)
-                ,stride
+                , stride
                 , offset, ordering
         );
-
     }
 
     @Override
@@ -1786,8 +1782,8 @@ public abstract class BaseNDArray implements INDArray {
             return create(Nd4j.createBuffer(shape));
         if (offsets.length != n)
             throw new IllegalArgumentException("Invalid offset " + Arrays.toString(offsets));
-        if (shape.length != n)
-            throw new IllegalArgumentException("Invalid shape " + Arrays.toString(shape));
+        if (stride.length != n)
+            throw new IllegalArgumentException("Invalid stride " + Arrays.toString(stride));
 
         if (Arrays.equals(shape, this.shape)) {
             if (ArrayUtil.isZero(offsets)) {
@@ -1797,35 +1793,19 @@ public abstract class BaseNDArray implements INDArray {
             }
         }
 
-        //handle strides/offsets < rank
-        if(offsets.length != stride.length)
-            throw new IllegalStateException("Offsets and stride must be same length");
         int[] dotProductOffsets = offsets;
         int[] dotProductStride = stride;
 
-        int offset = this.offset + NDArrayIndex.offset(dotProductStride,dotProductOffsets);
-        if(offset >= data().length())
+        int offset = this.offset + NDArrayIndex.offset(dotProductStride, dotProductOffsets);
+        if (offset >= data().length())
             offset = ArrayUtil.sum(offsets);
 
-
-        if(ordering() == NDArrayFactory.C ) {
-            return create(
-                    data
-                    , Arrays.copyOf(shape, shape.length)
-                    ,stride
-                    , offset, ordering
-            );
-        }
-        else if(ordering() == NDArrayFactory.FORTRAN) {
-            return create(
-                    data
-                    , Arrays.copyOf(shape, shape.length)
-                    , stride
-                    , offset, ordering
-            );
-        }
-        throw new IllegalStateException("Illegal ordering");
-
+        return create(
+                data
+                , Arrays.copyOf(shape, shape.length)
+                , stride
+                , offset, ordering
+        );
     }
 
     protected INDArray create(DataBuffer buffer) {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
@@ -131,9 +131,9 @@ public class ShapeResolutionTestsC extends BaseNd4jTest {
         ShapeOffsetResolution resolution = new ShapeOffsetResolution(arr);
         try {
             resolution.exec(NDArrayIndex.interval(0, 2), NDArrayIndex.interval(2, 4));
-            assertTrue("Out of range index should throw an IllegalArgumentException",false);
+            fail("Out of range index should throw an IllegalArgumentException");
         }catch (IllegalArgumentException e){
-            assertTrue(true);
+            //do nothing
         }
     }
 

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
@@ -12,7 +12,7 @@ import org.nd4j.linalg.util.ArrayUtil;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -34,6 +34,7 @@ public class ShapeResolutionTestsC extends BaseNd4jTest {
     public ShapeResolutionTestsC(String name) {
         super(name);
     }
+
 
     @Test
     public void testRowVectorShapeOneZeroOffset() {
@@ -115,6 +116,26 @@ public class ShapeResolutionTestsC extends BaseNd4jTest {
         assertArrayEquals(new int[]{2,1},strides);
     }
 
+
+    @Test
+    public void testPartiallyOutOfRangeIndices() {
+        INDArray arr = Nd4j.linspace(1,4, 4).reshape(2,2);
+        ShapeOffsetResolution resolution = new ShapeOffsetResolution(arr);
+        resolution.exec(NDArrayIndex.interval(0,2),  NDArrayIndex.interval(1,4));
+        assertArrayEquals(new int[]{2,1},resolution.getShapes());
+    }
+
+    @Test
+    public void testOutOfRangeIndices() {
+        INDArray arr = Nd4j.linspace(1,4, 4).reshape(2,2);
+        ShapeOffsetResolution resolution = new ShapeOffsetResolution(arr);
+        try {
+            resolution.exec(NDArrayIndex.interval(0, 2), NDArrayIndex.interval(2, 4));
+            assertTrue("Out of range index should throw an IllegalArgumentException",false);
+        }catch (IllegalArgumentException e){
+            assertTrue(true);
+        }
+    }
 
 
     @Override

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/resolve/NDArrayIndexResolveTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/resolve/NDArrayIndexResolveTests.java
@@ -7,8 +7,10 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 import org.nd4j.linalg.indexing.NDArrayIndex;
+import org.nd4j.linalg.indexing.PointIndex;
 
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Adam Gibson
@@ -38,7 +40,17 @@ public class NDArrayIndexResolveTests extends BaseNd4jTest {
     public void testResolvePointVector() {
         INDArray arr = Nd4j.linspace(1,4,4);
         INDArrayIndex[] getPoint  = {NDArrayIndex.point(1)};
-        assertArrayEquals(getPoint,NDArrayIndex.resolve(arr.shape(),getPoint));
+        INDArrayIndex[] resolved = NDArrayIndex.resolve(arr.shape(), getPoint);
+        if(getPoint.length == resolved.length)
+            assertArrayEquals(getPoint,resolved);
+        else{
+            assertEquals(2,resolved.length);
+            assertTrue(resolved[0] instanceof PointIndex);
+            assertEquals(0,resolved[0].current());
+            assertTrue(resolved[1] instanceof PointIndex);
+            assertEquals(1,resolved[1].current());
+        }
+
     }
 
     @Override

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/ops/OpExecutionerTests.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/ops/OpExecutionerTests.java
@@ -221,7 +221,7 @@ public  class OpExecutionerTests extends BaseNd4jTest {
         INDArray bias = Nd4j.linspace(1,4,4);
         Bias biaOp = new Bias(bias);
         Nd4j.getExecutioner().exec(biaOp);
-        assertEquals(0.0,biaOp.currentResult().doubleValue());
+        assertEquals(0.0,biaOp.currentResult().doubleValue(),1e-1);
     }
 
     @Test


### PR DESCRIPTION
This fixes slicing bug if NDArrayIndex is out of range in its dimension.

```java
INDArray nd = Nd4j.create(new double[]{0d,1d,2d,3d,4d,5d,6d,7d), new int[]{4, 2});
System.out.println(nd);
/*
[[0.00,1.00]
[2.00,3.00]
[4.00,5.00]
[6.00,7.00]]
*/

INDArray sliced = nd.get(NDArrayIndex.interval(0,2),NDArrayIndex.interval(2,4));
System.out.println(sliced);
/*
Returns following wrong INDArray.
[[2.00,3.00]
[4.00,5.00]]
*/
```

With this PR, `NDArrayIndex.resolve` throws an IllegalArgumentException if its NDArrayIndex is totally out of range, or modify NDArrayIndex if it is partially out of range, as shown below.

```scala
scala> Nd4j.create((0d until 8d by 1d).toArray,Array(4,2))
res0: org.nd4j.linalg.api.ndarray.INDArray =
[[0.00,1.00]
 [2.00,3.00]
 [4.00,5.00]
 [6.00,7.00]]

scala> import org.nd4j.linalg.indexing._
import org.nd4j.linalg.indexing._

//This returns slicing with (NDArrayIndex.interval(0,2),NDArrayIndex.interval(1,2)) instead.
scala> res0.get(NDArrayIndex.interval(0,2),NDArrayIndex.interval(1,3))
res1: org.nd4j.linalg.api.ndarray.INDArray = [ 1.00, 3.00]

scala> res1.shape
res2: Array[Int] = Array(2, 1)

//This throws exception since the column index has to be less than 2.
scala> res0.get(NDArrayIndex.interval(0,2),NDArrayIndex.interval(3,4))
java.lang.IllegalArgumentException: NDArrayIndex is out of range. Beginning index:3 must be less than its size:2
  at org.nd4j.linalg.indexing.NDArrayIndex.validate(NDArrayIndex.java:322)
  at org.nd4j.linalg.indexing.NDArrayIndex.resolve(NDArrayIndex.java:290)
  at org.nd4j.linalg.indexing.ShapeOffsetResolution.exec(ShapeOffsetResolution.java:46)
  at org.nd4j.linalg.api.ndarray.BaseNDArray.get(BaseNDArray.java:3621)
  ... 43 elided
```

Ref: https://github.com/deeplearning4j/nd4s/issues/52