### PR TITLE
fixes #369 / fix wrong delegation of NDArrayFactory#create with mixing char and int

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -382,7 +382,17 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      * @param offset
      */
     public BaseNDArray(DataBuffer buffer, int[] shape, int offset) {
-        this(buffer, shape, Nd4j.getStrides(shape), offset);
+        this(buffer, shape, Nd4j.getStrides(shape), offset, Nd4j.order());
+    }
+
+    /**
+     *
+     * @param buffer
+     * @param shape
+     * @param ordering
+     */
+    public BaseNDArray(DataBuffer buffer, int[] shape, char ordering) {
+        this(buffer, shape, Nd4j.getStrides(shape,ordering), 0, ordering);
     }
 
     /**

--- a/nd4j-jblas/src/main/java/org/nd4j/linalg/jblas/NDArray.java
+++ b/nd4j-jblas/src/main/java/org/nd4j/linalg/jblas/NDArray.java
@@ -305,6 +305,10 @@ public class NDArray extends BaseNDArray {
         super(data, shape);
     }
 
+    public NDArray(DataBuffer buffer, int[] shape, char ordering) {
+        super(buffer, shape, ordering);
+    }
+
     public NDArray(DataBuffer buffer, int[] shape, int offset) {
         super(buffer, shape, offset);
     }

--- a/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
+++ b/nd4j-jcublas-parent/nd4j-jcublas-common/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
@@ -334,7 +334,7 @@ public class JCublasNDArray extends BaseNDArray {
     }
 
     public JCublasNDArray(double[] data, int[] shape, char ordering) {
-        this(Nd4j.createBuffer(data), shape, 0,ordering);
+        super(data, shape ,ordering);
     }
 
     public JCublasNDArray(double[] data, int[] shape, int[] stride, int offset, char ordering) {

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
@@ -1822,7 +1822,7 @@ public  class Nd4jTestsC extends BaseNd4jTest {
    @Test
    public void testNdArrayCreation(){
        double delta = 1e-1;
-       INDArray n1 = Nd4j.create(new double[]{0d,1d,2d,3d},new int[]{2,2},0,'c');
+       INDArray n1 = Nd4j.create(new double[]{0d,1d,2d,3d},new int[]{2,2},'c');
        INDArray lv = n1.linearView();
        assertEquals(0d,lv.getDouble(0),delta);
        assertEquals(1d,lv.getDouble(1),delta);

--- a/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/NDArray.java
+++ b/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/NDArray.java
@@ -309,6 +309,10 @@ public class NDArray extends BaseNDArray {
         super(buffer, shape, offset);
     }
 
+    public NDArray(DataBuffer buffer, int[] shape, char ordering) {
+        super(buffer, shape, ordering);
+    }
+
     public NDArray(double[] data, int[] shape, char ordering) {
         super(data, shape, ordering);
     }


### PR DESCRIPTION
This fixes the bug which mixed up char and int.
`XXXNDArrayFactory#create(double[], int[], char)` was wrongly delegated to `new NDArray(double[] or DataBuffer, int[], int)` in several backends.