### PR TITLE
#376 - Loss calculation robustness for z=0

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/LossCalculation.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/LossCalculation.java
@@ -3,7 +3,6 @@ package org.nd4j.linalg.lossfunctions;
 import lombok.Builder;
 import lombok.Data;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.BooleanIndexing;
 import org.nd4j.linalg.indexing.conditions.Conditions;
 import org.nd4j.linalg.indexing.functions.Value;
@@ -81,7 +80,7 @@ class LossCalculation {
     }
 
 
-    public static INDArray logZ(INDArray z) {
+    private static INDArray logZ(INDArray z) {
         INDArray log = log(z, true);
 
         // log approaches -Infinity as z approaches zero.  Replace -Infinity with the least possible value.


### PR DESCRIPTION
When z is zero, log(z) is -Infinity.  This produces an overall score of
NaN.   For loss calculation, better to use the smallest possible value for log(z) when z=0.

Ran a few tests in dl4j, could not find a problem.   I would have preferred to run more tests before merging.

Closes #376.
