### PR TITLE
Fix CNN error Index [0] must not be >= shape[d] under BaseNDArray broadcast

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -3900,7 +3900,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 INDArray thisTensor = slice(i);
                 INDArray retTensor = ret.slice(i);
                 int retIdx = 0;
-                for(int k = 0; k < thisTensor.length(); k++) {
+                int tensorLen = thisTensor.length() -1;
+                for(int k = 0; k < tensorLen; k++) {
                     for(int j = 0; j < repeatDelta; j++) {
                         retTensor.putScalar(retIdx++,thisTensor.getDouble(k));
                     }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -3900,7 +3900,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 INDArray thisTensor = slice(i);
                 INDArray retTensor = ret.slice(i);
                 int retIdx = 0;
-                int tensorLen = thisTensor.length() -1;
+                int tensorLen = thisTensor.shape().length;
                 for(int k = 0; k < tensorLen; k++) {
                     for(int j = 0; j < repeatDelta; j++) {
                         retTensor.putScalar(retIdx++,thisTensor.getDouble(k));


### PR DESCRIPTION
Fix the following error for CNN examples taking place in preOutput when broadcasting bias:

java.lang.IllegalArgumentException: Index [0] must not be >= shape[d].
	at org.nd4j.linalg.api.shape.Shape.getOffset(Shape.java:496)
	at org.nd4j.linalg.api.ndarray.BaseNDArray.putScalar(BaseNDArray.java:1121)
	at org.nd4j.linalg.api.ndarray.BaseNDArray.putScalar(BaseNDArray.java:1104)
	at org.nd4j.linalg.api.ndarray.BaseNDArray.broadcast(BaseNDArray.java:3905)
	at org.deeplearning4j.nn.layers.convolution.ConvolutionLayer.preOutput(ConvolutionLayer.java:123)
	at org.deeplearning4j.nn.layers.convolution.ConvolutionLayer.activate(ConvolutionLayer.java:135)
	at org.deeplearning4j.nn.layers.BaseLayer.activate(BaseLayer.java:341)
	at org.deeplearning4j.nn.layers.convolution.ConvolutionLayerTest.testCNNInputSetupMNIST(ConvolutionLayerTest.java:115)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:78)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:212)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:140)
