### PR TITLE
Move momentumAfter back into dl4j

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDelta.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDelta.java
@@ -22,6 +22,8 @@ public class AdaDelta implements Serializable,GradientUpdater {
     private INDArray msg;
     private INDArray msdx;
     private double rho = 0.95;
+    private double learningRate = 0.1;
+    private double momentum = 0.5;
 
     public AdaDelta(double rho) {
         this.rho = rho;

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDelta.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDelta.java
@@ -22,8 +22,8 @@ public class AdaDelta implements Serializable,GradientUpdater {
     private INDArray msg;
     private INDArray msdx;
     private double rho = 0.95;
-    private double learningRate = 0.1;
-    private double momentum = 0.5;
+    private double learningRate = 0.1; //not used
+    private double momentum = 0.5; //not used
 
     public AdaDelta(double rho) {
         this.rho = rho;

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDelta.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDelta.java
@@ -22,11 +22,15 @@ public class AdaDelta implements Serializable,GradientUpdater {
     private INDArray msg;
     private INDArray msdx;
     private double rho = 0.95;
-    private double learningRate = 0.1; //not used
-    private double momentum = 0.5; //not used
+
 
     public AdaDelta(double rho) {
         this.rho = rho;
+    }
+
+    @Override
+    public void update(Object... args) {
+        //no op
     }
 
     /**

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaGrad.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaGrad.java
@@ -48,7 +48,7 @@ public class AdaGrad implements Serializable,GradientUpdater {
     protected double learningRate = 1e-1; // learning rate
     protected int numIterations = 0;
     private double epsilon = 1e-8;
-    private double momentum = 0.5;
+    private double momentum = 0.5; //not used
 
     /**
      *

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaGrad.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaGrad.java
@@ -45,9 +45,10 @@ public class AdaGrad implements Serializable,GradientUpdater {
     //protected double squaredGradientSum = 0;
     public INDArray historicalGradient;
     public int[] shape;
-    protected double masterStepSize = 1e-1; // learning rate
+    protected double learningRate = 1e-1; // learning rate
     protected int numIterations = 0;
     private double epsilon = 1e-8;
+    private double momentum = 0.5;
 
     /**
      *
@@ -57,7 +58,7 @@ public class AdaGrad implements Serializable,GradientUpdater {
      */
     public AdaGrad(int rows, int cols, double learningRate) {
         this.shape = new int[]{rows, cols};
-        this.masterStepSize = learningRate;
+        this.learningRate = learningRate;
     }
 
     public AdaGrad(int rows, int cols){
@@ -66,11 +67,11 @@ public class AdaGrad implements Serializable,GradientUpdater {
 
     public AdaGrad(int[] shape, double learningRate) {
         this.shape = shape;
-        this.masterStepSize = learningRate;
+        this.learningRate = learningRate;
     }
 
     public AdaGrad(double learningRate) {
-        this.masterStepSize = learningRate;
+        this.learningRate = learningRate;
     }
 
     /**
@@ -90,7 +91,7 @@ public class AdaGrad implements Serializable,GradientUpdater {
 
         INDArray sqrtHistory = sqrt(historicalGradient.add(epsilon));
         // lr * gradient / sqrt(sumSquaredGradients + 1e-8)
-        INDArray ret = sqrtHistory.rdivi(masterStepSize).muli(gradient);
+        INDArray ret = sqrtHistory.rdivi(learningRate).muli(gradient);
         numIterations++;
         return ret;
     }
@@ -103,7 +104,7 @@ public class AdaGrad implements Serializable,GradientUpdater {
             }
 
         double sqrtHistory = !historicalInitialized ? Math.sqrt(historicalGradient.getDouble(column)) : historicalGradient.getDouble(column);
-        double learningRates = masterStepSize / (sqrtHistory + epsilon);
+        double learningRates = learningRate / (sqrtHistory + epsilon);
         double adjustedGradient = gradient * (learningRates);
 
         historicalGradient.putScalar(column, historicalGradient.getDouble(column) + gradient * gradient);
@@ -127,7 +128,7 @@ public class AdaGrad implements Serializable,GradientUpdater {
             sqrtHistory = sqrt(historicalGradient);
         else
             sqrtHistory = !historicalInitialized ? sqrt(historicalGradient.slice(slice)) : historicalGradient;
-        INDArray learningRates = sqrtHistory.add(epsilon).rdivi(masterStepSize);
+        INDArray learningRates = sqrtHistory.add(epsilon).rdivi(learningRate);
         gradient.muli(learningRates);
 
         this.historicalGradient.slice(slice).addi(gradient.mul(gradient));
@@ -146,14 +147,14 @@ public class AdaGrad implements Serializable,GradientUpdater {
             //grab only the needed elements
             INDArray slice = historicalGradient.slice(index).dup();
             a.historicalGradient = slice;
-            a.setMasterStepSize(masterStepSize);
+            a.setLearningRate(learningRate);
             return a;
         } else {
             AdaGrad a = new AdaGrad(1, 1);
             //grab only the needed elements
             INDArray slice = Nd4j.scalar(historicalGradient.getDouble(index));
             a.historicalGradient = slice;
-            a.setMasterStepSize(masterStepSize);
+            a.setLearningRate(learningRate);
             return a;
         }
     }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaGrad.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaGrad.java
@@ -48,7 +48,6 @@ public class AdaGrad implements Serializable,GradientUpdater {
     protected double learningRate = 1e-1; // learning rate
     protected int numIterations = 0;
     private double epsilon = 1e-8;
-    private double momentum = 0.5; //not used
 
     /**
      *
@@ -72,6 +71,13 @@ public class AdaGrad implements Serializable,GradientUpdater {
 
     public AdaGrad(double learningRate) {
         this.learningRate = learningRate;
+    }
+
+    @Override
+    public void update(Object... args) {
+        if(args.length > 0) {
+            learningRate = (Double) args[0];
+        }
     }
 
     /**

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/Adam.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/Adam.java
@@ -25,7 +25,7 @@ public class Adam implements Serializable,GradientUpdater {
     private double beta2 = 0.999; // gradient sqrd decay rate
     private double epsilon = 1e-8;
     private INDArray m,v; // moving avg & sqrd gradients
-    private double momentum = 0.5;
+    private double momentum = 0.5; //not used
 
     public Adam(double alpha, double beta1, double beta2, double epsilon) {
         this.learningRate = alpha;

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/Adam.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/Adam.java
@@ -20,27 +20,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Adam implements Serializable,GradientUpdater {
 
-    private double alpha = 1e-3; // learning rate
+    private double learningRate = 1e-3; // learning rate
     private double beta1 = 0.9; // gradient moving avg decay rate
     private double beta2 = 0.999; // gradient sqrd decay rate
     private double epsilon = 1e-8;
     private INDArray m,v; // moving avg & sqrd gradients
+    private double momentum = 0.5;
 
     public Adam(double alpha, double beta1, double beta2, double epsilon) {
-        this.alpha = alpha;
+        this.learningRate = alpha;
         this.beta1 = beta1;
         this.beta2 = beta2;
         this.epsilon = epsilon; // fudge factor to avoid zeros
     }
 
     public Adam(double alpha, double beta1, double beta2) {
-        this.alpha = alpha;
+        this.learningRate = alpha;
         this.beta1 = beta1;
         this.beta2 = beta2;
     }
 
     public Adam(double alpha) {
-        this.alpha = alpha;
+        this.learningRate = alpha;
     }
 
     /**Calculate the update based on the given gradient
@@ -62,7 +63,7 @@ public class Adam implements Serializable,GradientUpdater {
         double beta1t = FastMath.pow(beta1, iteration);
         double beta2t = FastMath.pow(beta2, iteration);
 
-        double alphat = alpha * FastMath.sqrt(1-beta2t)/(1-beta1t);
+        double alphat = learningRate * FastMath.sqrt(1-beta2t)/(1-beta1t);
         if(Double.isNaN(alphat) || alphat==0.0) alphat = Nd4j.EPS_THRESHOLD;
         INDArray sqrtV = Transforms.sqrt(v).addi(epsilon);
         INDArray ret = m.mul(alphat).divi(sqrtV);

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/Adam.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/Adam.java
@@ -44,6 +44,13 @@ public class Adam implements Serializable,GradientUpdater {
         this.learningRate = alpha;
     }
 
+    @Override
+    public void update(Object... args) {
+        if(args.length > 0) {
+           learningRate = (Double) args[0];
+        }
+    }
+
     /**Calculate the update based on the given gradient
      * @param gradient the gradient to get the update for
      * @param iteration
@@ -69,6 +76,7 @@ public class Adam implements Serializable,GradientUpdater {
         INDArray ret = m.mul(alphat).divi(sqrtV);
         return ret;
     }
+
 
 
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/GradientUpdater.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/GradientUpdater.java
@@ -24,4 +24,17 @@ public interface GradientUpdater extends Serializable {
      * @return the modified gradient
      */
     INDArray getGradient(INDArray gradient, int iteration);
+
+    /**
+     * Update learningRate
+     * @param learningRate
+     */
+    void setLearningRate(double learningRate);
+
+    /**
+     * Update momentum
+     * @param momentum
+     */
+    void setMomentum(double momentum);
+
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/GradientUpdater.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/GradientUpdater.java
@@ -17,6 +17,12 @@ public interface GradientUpdater extends Serializable {
 
 
     /**
+     * update(learningRate,momentum)
+     * @param args
+     */
+    void update(Object...args);
+
+    /**
      * Modify the gradient
      * to be an update
      * @param gradient the gradient to modify
@@ -25,16 +31,5 @@ public interface GradientUpdater extends Serializable {
      */
     INDArray getGradient(INDArray gradient, int iteration);
 
-    /**
-     * Update learningRate
-     * @param learningRate
-     */
-    void setLearningRate(double learningRate);
-
-    /**
-     * Update momentum
-     * @param momentum
-     */
-    void setMomentum(double momentum);
 
 }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/Nesterovs.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/Nesterovs.java
@@ -34,6 +34,16 @@ public class Nesterovs implements Serializable,GradientUpdater {
 
     }
 
+    @Override
+    public void update(Object... args) {
+        if(args.length > 0) {
+            learningRate = (Double) args[0];
+            momentum = (Double) args[1];
+        }
+
+    }
+
+
     /**
      * Get the nesterov update
      * @param gradient the gradient to get the update for

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/Nesterovs.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/Nesterovs.java
@@ -22,11 +22,11 @@ import java.util.Map;
 public class Nesterovs implements Serializable,GradientUpdater {
     private double momentum = 0.5;
     private INDArray v;
-    private double lr = 0.1;
-    
-    public Nesterovs(double momentum, double lr) {
+    private double learningRate = 0.1;
+
+    public Nesterovs(double momentum, double learningRate) {
         this.momentum = momentum;
-        this.lr = lr;
+        this.learningRate = learningRate;
     }
 
     public Nesterovs(double momentum) {
@@ -45,7 +45,7 @@ public class Nesterovs implements Serializable,GradientUpdater {
         if(v == null)
             v = Nd4j.zeros(gradient.shape());
         INDArray vPrev = v;
-        v = vPrev.mul(momentum).subi(gradient.mul(lr));
+        v = vPrev.mul(momentum).subi(gradient.mul(learningRate));
         //reference https://cs231n.github.io/neural-networks-3/#sgd 2nd equation
         //DL4J default is negative step function thus we flipped the signs:
         // x += mu * v_prev + (-1 - mu) * v

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/Nesterovs.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/Nesterovs.java
@@ -21,25 +21,12 @@ import java.util.Map;
 @NoArgsConstructor
 public class Nesterovs implements Serializable,GradientUpdater {
     private double momentum = 0.5;
-    protected Map<Integer,Double> momentumAfter = new HashMap<>();
     private INDArray v;
     private double lr = 0.1;
-
-
-    public Nesterovs(double momentum, Map<Integer,Double> momentumAfter, double lr) {
-        this.momentum = momentum;
-        this.momentumAfter = momentumAfter;
-        this.lr = lr;
-    }
-
+    
     public Nesterovs(double momentum, double lr) {
         this.momentum = momentum;
         this.lr = lr;
-    }
-
-    public Nesterovs(double momentum, Map<Integer,Double> momentumAfter) {
-        this.momentum = momentum;
-        this.momentumAfter = momentumAfter;
     }
 
     public Nesterovs(double momentum) {
@@ -57,8 +44,6 @@ public class Nesterovs implements Serializable,GradientUpdater {
     public INDArray getGradient(INDArray gradient, int iteration) {
         if(v == null)
             v = Nd4j.zeros(gradient.shape());
-        if(momentumAfter !=null)
-            momentum = (momentumAfter.containsKey(iteration)) ? momentumAfter.get(iteration) : momentum;
         INDArray vPrev = v;
         v = vPrev.mul(momentum).subi(gradient.mul(lr));
         //reference https://cs231n.github.io/neural-networks-3/#sgd 2nd equation

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/RmsProp.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/RmsProp.java
@@ -18,14 +18,14 @@ import org.nd4j.linalg.ops.transforms.Transforms;
  */
 @Data
 @NoArgsConstructor
-public class RmsPropUpdater implements GradientUpdater {
+public class RmsProp implements GradientUpdater {
     private INDArray lastGradient;
-    private double rmsDecay = 0.5;
+    private double rmsDecay = 0.95;
     private double learningRate = 1e-1;
     private double epsilon = 1e-8;
-    private double momentum = 0.5;
+    private double momentum = 0.5; //not used
 
-    public RmsPropUpdater(double learningRate, double rmsDecay){
+    public RmsProp(double learningRate, double rmsDecay){
     	this.learningRate = learningRate;
     	this.rmsDecay = rmsDecay;
     }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/RmsProp.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/RmsProp.java
@@ -23,11 +23,17 @@ public class RmsProp implements GradientUpdater {
     private double rmsDecay = 0.95;
     private double learningRate = 1e-1;
     private double epsilon = 1e-8;
-    private double momentum = 0.5; //not used
 
     public RmsProp(double learningRate, double rmsDecay){
     	this.learningRate = learningRate;
     	this.rmsDecay = rmsDecay;
+    }
+
+    @Override
+    public void update(Object... args) {
+        if(args.length > 0) {
+            learningRate = (Double) args[0];
+        }
     }
 
     @Override

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/RmsPropUpdater.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/RmsPropUpdater.java
@@ -21,11 +21,12 @@ import org.nd4j.linalg.ops.transforms.Transforms;
 public class RmsPropUpdater implements GradientUpdater {
     private INDArray lastGradient;
     private double rmsDecay = 0.5;
-    private double lr = 1e-1;
+    private double learningRate = 1e-1;
     private double epsilon = 1e-8;
+    private double momentum = 0.5;
 
-    public RmsPropUpdater(double lr, double rmsDecay){
-    	this.lr = lr;
+    public RmsPropUpdater(double learningRate, double rmsDecay){
+    	this.learningRate = learningRate;
     	this.rmsDecay = rmsDecay;
     }
 
@@ -35,7 +36,7 @@ public class RmsPropUpdater implements GradientUpdater {
             lastGradient = Nd4j.zeros(gradient.shape());
         lastGradient.muli(rmsDecay).addi(gradient.mul(gradient).muli(1 - rmsDecay));
         // lr * gradient / sqrt(cache + 1e-8)
-        INDArray ret = gradient.mul(lr).divi(Transforms.sqrt(lastGradient.add(epsilon)));
+        INDArray ret = gradient.mul(learningRate).divi(Transforms.sqrt(lastGradient.add(epsilon)));
         
         return ret;
     }

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/Sgd.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/Sgd.java
@@ -11,10 +11,17 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 @NoArgsConstructor
 public class Sgd implements GradientUpdater {
     private double learningRate = 1e-1;
-    private double momentum = 0.5; //not used
 
     public Sgd(double learningRate) {
         this.learningRate = learningRate;
+    }
+
+    @Override
+    public void update(Object... args) {
+        if(args.length > 0) {
+            learningRate = (Double) args[0];
+        }
+
     }
 
     @Override

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/Sgd.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/Sgd.java
@@ -9,11 +9,11 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  */
 @Data
 @NoArgsConstructor
-public class SgdUpdater implements GradientUpdater {
+public class Sgd implements GradientUpdater {
     private double learningRate = 1e-1;
-    private double momentum = 0.5;
+    private double momentum = 0.5; //not used
 
-    public SgdUpdater(double learningRate) {
+    public Sgd(double learningRate) {
         this.learningRate = learningRate;
     }
 

--- a/nd4j-api/src/main/java/org/nd4j/linalg/learning/SgdUpdater.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/learning/SgdUpdater.java
@@ -10,14 +10,15 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 @Data
 @NoArgsConstructor
 public class SgdUpdater implements GradientUpdater {
-    private double lr = 1e-1;
+    private double learningRate = 1e-1;
+    private double momentum = 0.5;
 
-    public SgdUpdater(double lr) {
-        this.lr = lr;
+    public SgdUpdater(double learningRate) {
+        this.learningRate = learningRate;
     }
 
     @Override
     public INDArray getGradient(INDArray gradient, int iteration) {
-        return gradient.mul(lr);
+        return gradient.mul(learningRate);
     }
 }


### PR DESCRIPTION
- Moved momentumAfter into dl4j to update net config directly
- Setup updater capability to update lr and mu as needed in updaters when schedules are used
- Synced updater class names