### PR TITLE
Fix behavior on DataSet.*batchBy* to function as specified in the doc…

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -439,8 +439,12 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      * @return the partitioned datasets
      */
     @Override
-    public List<List<DataSet>> batchBy(int num) {
-        return Lists.partition(asList(), num);
+    public List<DataSet> batchBy(int num) {
+        List<DataSet> batched = Lists.newArrayList();
+        for(List<DataSet> splitBatch : Lists.partition(asList(), num)) {
+            batched.add(DataSet.merge(splitBatch));
+        }
+        return batched;
     }
 
     /**
@@ -539,14 +543,14 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      * @return a list of data sets partitioned by outcomes
      */
     @Override
-    public List<List<DataSet>> sortAndBatchByNumLabels() {
+    public List<DataSet> sortAndBatchByNumLabels() {
         sortByLabel();
-        return Lists.partition(asList(), numOutcomes());
+        return batchByNumLabels();
     }
 
     @Override
-    public List<List<DataSet>> batchByNumLabels() {
-        return Lists.partition(asList(), numOutcomes());
+    public List<DataSet> batchByNumLabels() {
+        return batchBy(numOutcomes());
     }
 
     @Override

--- a/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
@@ -99,17 +99,21 @@ public interface DataSet extends Iterable<org.nd4j.linalg.dataset.DataSet>, Seri
 
     org.nd4j.linalg.dataset.DataSet get(int[] i);
 
-    List<List<org.nd4j.linalg.dataset.DataSet>> batchBy(int num);
+    List<org.nd4j.linalg.dataset.DataSet> batchBy(int num);
 
     org.nd4j.linalg.dataset.DataSet filterBy(int[] labels);
 
     void filterAndStrip(int[] labels);
 
+    /**
+     * @deprecated prefer {@link #batchBy(int)}
+     */
+    @Deprecated
     List<org.nd4j.linalg.dataset.DataSet> dataSetBatches(int num);
 
-    List<List<org.nd4j.linalg.dataset.DataSet>> sortAndBatchByNumLabels();
+    List<org.nd4j.linalg.dataset.DataSet> sortAndBatchByNumLabels();
 
-    List<List<org.nd4j.linalg.dataset.DataSet>> batchByNumLabels();
+    List<org.nd4j.linalg.dataset.DataSet> batchByNumLabels();
 
     List<org.nd4j.linalg.dataset.DataSet> asList();
 


### PR DESCRIPTION
…s. Deprecated redundant method on DataSet.

From [Gitter](https://gitter.im/deeplearning4j/deeplearning4j?at=5649ee048b242470793e154c)