### PR TITLE
Add support for mask arrays (DataSet and score calculation)

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -51,6 +51,8 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
     private List<String> labelNames = new ArrayList<>();
     private INDArray features, labels;
     private String id = UUID.randomUUID().toString();
+    private INDArray featuresMask;
+    private INDArray labelsMask;
 
     public DataSet() {
         this(Nd4j.zeros(new int[]{1,1}), Nd4j.zeros(new int[]{1,1}));
@@ -882,6 +884,31 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
     @Override
     public Iterator<DataSet> iterator() {
         return asList().iterator();
+    }
+
+    @Override
+    public INDArray getFeaturesMaskArray() {
+        return featuresMask;
+    }
+
+    @Override
+    public void setFeaturesMaskArray(INDArray featuresMask) {
+        this.featuresMask = featuresMask;
+    }
+
+    @Override
+    public INDArray getLabelsMaskArray() {
+        return labelsMask;
+    }
+
+    @Override
+    public void setLabelsMaskArray(INDArray labelsMask) {
+        this.labelsMask = labelsMask;
+    }
+
+    @Override
+    public boolean hasMaskArrays() {
+        return labelsMask != null || featuresMask != null;
     }
 
     @Override

--- a/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -32,6 +32,7 @@ import org.nd4j.linalg.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.*;
 import java.util.*;
 
@@ -69,10 +70,23 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      *               has a value of 1 in the desired column with the label)
      */
     public DataSet(INDArray first, INDArray second) {
-        if (first.size(0) != second.size(0))
-            throw new IllegalStateException("Invalid data transform; first and second do not have equal rows. First was " + first.size(0) + " second was " + second.size(0));
-        this.features = first;
-        this.labels = second;
+        this(first,second,null,null);
+    }
+
+    /**Create a dataset with the specified input INDArray and labels (output) INDArray, plus (optionally) mask arrays
+     * for the features and labels
+     * @param features Features (input)
+     * @param labels Labels (output)
+     * @param featuresMask Mask array for features, may be null
+     * @param labelsMask Mask array for labels, may be null
+     */
+    public DataSet(INDArray features, INDArray labels, INDArray featuresMask, INDArray labelsMask) {
+        if (features.size(0) != labels.size(0))
+            throw new IllegalStateException("Invalid data transform; features and labels do not have equal rows. First was " + features.size(0) + " labels was " + labels.size(0));
+        this.features = features;
+        this.labels = labels;
+        this.featuresMask = featuresMask;
+        this.labelsMask = labelsMask;
     }
 
     /**

--- a/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
@@ -164,4 +164,24 @@ public interface DataSet extends Iterable<org.nd4j.linalg.dataset.DataSet>, Seri
 
     @Override
     Iterator<org.nd4j.linalg.dataset.DataSet> iterator();
+
+    /** Input mask array: a mask array for input, where each value is in {0,1} in order to specify whether an input is
+     *  actually present or not. Typically used for situations such as RNNs with variable length inputs
+      * @return Input mask array
+     */
+    INDArray getFeaturesMaskArray();
+
+    void setFeaturesMaskArray(INDArray inputMask);
+
+    /** Labels (output) mask array: a mask array for input, where each value is in {0,1} in order to specify whether an
+     * output is actually present or not. Typically used for situations such as RNNs with variable length inputs or many-
+     * to-one situations.
+     * @return Labels (output) mask array
+     */
+    INDArray getLabelsMaskArray();
+
+    void setLabelsMaskArray(INDArray labelsMask);
+
+    /** Whether the labels or input (features) mask arrays are present for this DataSet */
+    boolean hasMaskArrays();
 }


### PR DESCRIPTION
DataSet now has fields for mask arrays (used in variable-length time series in same mini-batch stuff, one-to-many and many-to-one RNN applications, etc)

Score calculation also utilizes mask array if present.