### PR TITLE
Avoid Native BLAS class reference outside of if-statement

### DIFF
--- a/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/BlasWrapper.java
+++ b/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/BlasWrapper.java
@@ -42,11 +42,13 @@ public class BlasWrapper extends BaseBlasWrapper {
     public final static String FORCE_NATIVE = "org.nd4j.linalg.cpu.force_native";
     static {
         String forceNative = System.getProperty(FORCE_NATIVE,"false");
+        boolean hasSetNative = false;
         if(Boolean.parseBoolean(forceNative)) {
             try {
                 Field blasInstance = BLAS.class.getDeclaredField("INSTANCE");
                 BLAS newInstance = (BLAS) Class.forName("com.github.fommil.netlib.NativeSystemBLAS").newInstance();
                 setFinalStatic(blasInstance, newInstance);
+                hasSetNative = true;
             } catch(ClassNotFoundException e) {
                 log.warn("Native BLAS not available on classpath");
             } catch (Exception e) {
@@ -55,7 +57,7 @@ public class BlasWrapper extends BaseBlasWrapper {
         }
 
         //Check that native system blas is used:
-        if(!(BLAS.getInstance() instanceof com.github.fommil.netlib.NativeSystemBLAS)){
+        if(!hasSetNative){
             System.out.println("****************************************************************");
             System.out.println("WARNING: COULD NOT LOAD NATIVE SYSTEM BLAS");
             System.out.println("ND4J performance WILL be reduced");


### PR DESCRIPTION
This fixes the following DL4J issue, NoClassDefFoundError.
https://github.com/deeplearning4j/deeplearning4j/issues/1012

The problem was:
Even if native lib is not loaded (this means no native lib classes in its classpath), if-statement refers to native lib classes so it always throw NoClassDefFoundError.