### PR TITLE
Fix x86 blas warning (warning previously always displayed, unless blas is forced)

### DIFF
--- a/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/BlasWrapper.java
+++ b/nd4j-x86/src/main/java/org/nd4j/linalg/cpu/BlasWrapper.java
@@ -42,13 +42,11 @@ public class BlasWrapper extends BaseBlasWrapper {
     public final static String FORCE_NATIVE = "org.nd4j.linalg.cpu.force_native";
     static {
         String forceNative = System.getProperty(FORCE_NATIVE,"false");
-        boolean hasSetNative = false;
         if(Boolean.parseBoolean(forceNative)) {
             try {
                 Field blasInstance = BLAS.class.getDeclaredField("INSTANCE");
                 BLAS newInstance = (BLAS) Class.forName("com.github.fommil.netlib.NativeSystemBLAS").newInstance();
                 setFinalStatic(blasInstance, newInstance);
-                hasSetNative = true;
             } catch(ClassNotFoundException e) {
                 log.warn("Native BLAS not available on classpath");
             } catch (Exception e) {
@@ -56,12 +54,19 @@ public class BlasWrapper extends BaseBlasWrapper {
             }
         }
 
+        boolean usingNative = false;
+        try{
+            usingNative = BLAS.getInstance() instanceof com.github.fommil.netlib.NativeSystemBLAS;
+        }catch(Throwable t){
+            //May throw a NoClassDefFoundError
+        }
+
         //Check that native system blas is used:
-        if(!hasSetNative){
+        if(!usingNative){
             System.out.println("****************************************************************");
             System.out.println("WARNING: COULD NOT LOAD NATIVE SYSTEM BLAS");
-            System.out.println("ND4J performance WILL be reduced");
-            System.out.println("Please install native BLAS library such as OpenBLAS or IntelMKL");
+            System.out.println("ND4J computational performance WILL be reduced");
+            System.out.println("Please install native BLAS library such as OpenBLAS or Intel MKL");
             System.out.println("See http://nd4j.org/getstarted.html#open for further details");
             System.out.println("****************************************************************");
         }


### PR DESCRIPTION
Fixes BLAS warning; previously blas warning would always display (even if native was being used), unless force native was set to true.

This was changed here:
https://github.com/deeplearning4j/nd4j/pull/551

@taisukeoe tagging you here re: this change, just FYI. Should still fix the no class def error mentioned in your PR, but displays the warning message only when required.