### PR TITLE
Removed not necessary code. Fix #563

### DIFF
--- a/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -3518,38 +3518,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
         int[] shape = resolution.getShapes();
 
-        //This means upsampling.
-        if (ArrayUtil.prod(shape) > length()) {
-            INDArray ret = create(shape);
-            INDArrayIndex slices = indexes[0];
-            if(slices.length() == 1) {
-                INDArrayIndex subRange = indexes[0];
-                int count = 0;
-                for(int i = 0; i < slices.length(); i++) {
-                    if(count >= ret.length())
-                        count = 0;
-                    int get = subRange.next();
-                    ret.putScalar(count,getDouble(get));
-                    count++;
-
-                }
-            }
-
-            else {
-                INDArrayIndex[] subRange = Arrays.copyOfRange(indexes, 1, indexes.length);
-                INDArrayIndex[] putRange = NDArrayIndex.rangeOfLength(subRange);
-                for(int i = 0; i < slices.length(); i++) {
-                    INDArray sliceI = ret.slice(i);
-                    INDArray thisSlice = slice(slices.next());
-                    sliceI.put(putRange,thisSlice.get(subRange));
-
-                }
-            }
-
-
-            return ret;
-        }
-
         if(indexes[0] instanceof SpecifiedIndex) {
             INDArray ret = create(shape);
             int count = 0;

--- a/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingTestsC.java
+++ b/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingTestsC.java
@@ -79,10 +79,23 @@ public class IndexingTestsC extends BaseNd4jTest {
 
         INDArray individualElement = twoByTwo.get(NDArrayIndex.interval(1, 2), NDArrayIndex.interval(1, 2));
         assertEquals(Nd4j.create(new float[]{4}), individualElement);
-
-
     }
 
+    @Test
+    public void testGetRow(){
+        Nd4j.getRandom().setSeed(12345);
+        INDArray in = Nd4j.linspace(0,14,15).reshape(3,5);
+        int[] toGet = {0,1};
+        INDArray out = in.getRows(toGet);
+        assertEquals(in.getRow(0),out.getRow(0));
+        assertEquals(in.getRow(1),out.getRow(1));
+
+        int[] toGet2 = {0,1,2,0,1,2};
+        INDArray out2 = in.getRows(toGet2);
+        for( int i=0; i<toGet2.length; i++ ){
+            assertEquals(in.getRow(toGet2[i]),out2.getRow(i));
+        }
+    }
 
     @Test
     public void testConcatColumns() {


### PR DESCRIPTION
Looks like this code is bugged and the one thing it does, it throws exception. Especially 
		
```
            else {		
                INDArrayIndex[] subRange = Arrays.copyOfRange(indexes, 1, indexes.length);		
                INDArrayIndex[] putRange = NDArrayIndex.rangeOfLength(subRange);		
                for(int i = 0; i < slices.length(); i++) {		
                    INDArray sliceI = ret.slice(i);		
                    INDArray thisSlice = slice(slices.next());		
                    sliceI.put(putRange,thisSlice.get(subRange));		
		
                }		
            }
            return ret;
```

this else didn't influence the result and was doing empty operations. 

I have also added @AlexDBlack test. Without this code correctness looks fine. 