### PR TITLE
Make Device GC Threads daemnoic

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
@@ -1187,6 +1187,7 @@ public class AtomicAllocator implements Allocator {
             this.terminate = terminate;
 
             this.setName("zero gc thread " + threadId);
+            this.setDaemon(true);
         }
 
         @Override
@@ -1241,6 +1242,7 @@ public class AtomicAllocator implements Allocator {
             this.deviceId = deviceId;
             this.terminate = terminate;
             this.setName("device gc thread " + threadId + "/" + deviceId);
+            this.setDaemon(true);
         }
 
         @Override


### PR DESCRIPTION
This makes the device gc threads daemonic, so they will die when the JVM exists.

As far as I can tell the gc threads don't need any clean up, to making daemon threads should not be a problem. If there is any clean up to be performed, they may not be daemonic, as the JVM just terminates them on exit, with no stack unwinding and **no code in finally running**.