### PR TITLE
Enforce correct setup of environment variables on build

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/pom.xml
@@ -88,6 +88,37 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>libnd4j-checks</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireProperty>
+                                    <property>env.LIBND4J_HOME</property>
+                                    <message>You must set the LIBND4J_HOME environment variable!</message>
+                                    <regex>.*/.*</regex>
+                                    <regexMessage>!!! LIBND4J_HOME must be a valid unix path!</regexMessage>
+                                </requireProperty>
+                                <requireFilesExist>
+                                    <files>
+                                        <file>${env.LIBND4J_HOME}/blas/NativeBlas.h</file>
+                                        <file>${env.LIBND4J_HOME}/blasbuild/cuda/blas</file>
+                                    </files>
+                                    <message>!!! You have to compile libnd4j with cuda support first!</message>
+                                </requireFilesExist>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -112,6 +112,37 @@
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>libnd4j-checks</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireProperty>
+                                    <property>env.LIBND4J_HOME</property>
+                                    <message>You must set the LIBND4J_HOME environment variable!</message>
+                                    <regex>.*/.*</regex>
+                                    <regexMessage>!!! LIBND4J_HOME must be a valid unix path!</regexMessage>
+                                </requireProperty>
+                                <requireFilesExist>
+                                    <files>
+                                        <file>${env.LIBND4J_HOME}/blas/NativeBlas.h</file>
+                                        <file>${env.LIBND4J_HOME}/blasbuild/cpu/blas</file>
+                                    </files>
+                                    <message>!!! You have to compile libnd4j with cpu support first!</message>
+                                </requireFilesExist>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Both the -native and the -cuda-7.5 backends need libnd4j to have been built prior to them. They also require that LIBND4J_HOME is set.

This checks that these requirements are met, and prints an a bit more helpful message about what the problem is.