### PR TITLE
Re-add preload annotations

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -12,7 +12,7 @@ import org.nd4j.linalg.api.buffer.util.LibUtils;
  * op execution on cpu
  * @author Adam Gibson
  */
-@Platform(include="NativeOps.h",link = "nd4j")
+@Platform(include="NativeOps.h",preload = "libnd4j",link = "nd4j")
 public class NativeOps extends Pointer {
     static {
         Loader.load();

--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/Nd4jBlas.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/Nd4jBlas.java
@@ -14,7 +14,7 @@ import org.nd4j.linalg.api.buffer.util.LibUtils;
  *
  *
  */
-@Platform(include="NativeBlas.h",link = "nd4j")
+@Platform(include="NativeBlas.h",preload = "libnd4j",link = "nd4j")
 public class Nd4jBlas extends Pointer {
     static {
         Loader.load();


### PR DESCRIPTION
They are needed for the backend to find its dependencies.