### PR TITLE
Device memory gets used first now, pinned memory goes as fallback.

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/test/java/org/nd4j/jita/allocator/impl/AtomicAllocatorTest.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/test/java/org/nd4j/jita/allocator/impl/AtomicAllocatorTest.java
@@ -311,6 +311,9 @@ public class AtomicAllocatorTest {
     @Test
     public void testGpuBlas7() throws Exception {
         INDArray nd = Nd4j.create(2, 2);
+
+        AllocationPoint point = AtomicAllocator.getInstance().getAllocationPoint(nd.data().getTrackingPoint());
+        assertEquals(AllocationStatus.DEVICE, point.getAllocationStatus());
     }
 
     /*


### PR DESCRIPTION
Tested and confimed configurable memory flow.

Within the same allocator it's possible to configure either pinned -> device promotion for certain workloads, or backward way: device for everything and pinned for things that do not fit into device memory.

Later proper configuration builder will be available, to allow flexible configuration for such options.