### PR TITLE
Catch out of range PointIndexes

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/ShapeOffsetResolution.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/ShapeOffsetResolution.java
@@ -184,11 +184,20 @@ public class ShapeOffsetResolution implements Serializable {
      *
      */
     public void exec(INDArrayIndex... indexes) {
+        int[] shape = arr.shape();
+
+        // Check that given point indexes are not out of bounds
+        for (int i = 0; i < indexes.length; i++) {
+            INDArrayIndex idx = indexes[i];
+            if(idx instanceof PointIndex && idx.current() >= shape[i]){
+                throw new IllegalArgumentException("INDArrayIndex["+i+"] is out of bounds (value: "+idx.current()+")");
+            }
+        }
+
         indexes = NDArrayIndex.resolve(arr.shapeInfo(),indexes);
         if(tryShortCircuit(indexes)) {
             return;
         }
-        int[] shape = arr.shape();
 
 
         int numIntervals = 0;

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
@@ -14,7 +14,6 @@ import org.nd4j.linalg.util.ArrayUtil;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -124,6 +123,18 @@ public class ShapeResolutionTestsC extends BaseNd4jTest {
         ShapeOffsetResolution resolution = new ShapeOffsetResolution(arr);
         try {
             resolution.exec(NDArrayIndex.interval(0, 2), NDArrayIndex.interval(2, 4));
+            fail("Out of range index should throw an IllegalArgumentException");
+        }catch (IllegalArgumentException e){
+            //do nothing
+        }
+    }
+
+    @Test
+    public void testOutOfRangeIndices2() {
+        INDArray arr = Nd4j.create(1,4, 4);
+        ShapeOffsetResolution resolution = new ShapeOffsetResolution(arr);
+        try {
+            resolution.exec(NDArrayIndex.point(1), NDArrayIndex.point(0), NDArrayIndex.point(0));
             fail("Out of range index should throw an IllegalArgumentException");
         }catch (IllegalArgumentException e){
             //do nothing


### PR DESCRIPTION
If this is not caught, it allows wrong indexes to go to libnd4j, which depending on the size of the array it works on, can result in anything from silent memory corruption, to a JVM crash.