### PR TITLE
Fix indexing edgecase

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/ShapeOffsetResolution.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/ShapeOffsetResolution.java
@@ -447,7 +447,7 @@ public class ShapeOffsetResolution implements Serializable {
                 pointOffsets.add(0);
             }
             //special case where offsets aren't caught
-            if(arr.isRowVector() && !intervalStrides.isEmpty() && pointOffsets.get(0) == 0)
+            if(arr.isRowVector() && !intervalStrides.isEmpty() && pointOffsets.get(0) == 0 && !(indexes[1] instanceof IntervalIndex))
                 this.offset = indexes[1].offset();
             else
                 this.offset = ArrayUtil.dotProduct(pointOffsets, pointStrides);
@@ -463,6 +463,7 @@ public class ShapeOffsetResolution implements Serializable {
         }
         else
             this.offset += ArrayUtil.calcOffset(accumShape, accumOffsets, accumStrides);
+
     }
 
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/ShapeResolutionTestsC.java
@@ -174,6 +174,30 @@ public class ShapeResolutionTestsC extends BaseNd4jTest {
     }
 
     @Test
+    public void testFlatIndexPointInterval(){
+        INDArray zeros = Nd4j.zeros(1, 4);
+        INDArrayIndex x = NDArrayIndex.point(0);
+        INDArrayIndex y = NDArrayIndex.interval(1,2, true);
+        INDArray value = Nd4j.ones(1, 2);
+        zeros.put(new INDArrayIndex[]{x, y}, value);
+        assertEquals(
+                "[ 0,00, 1,00, 1,00, 0,00]",
+                zeros.toString());
+    }
+
+    @Test
+    public void testFlatIndexPointPoint(){
+        INDArray zeros = Nd4j.zeros(1, 4);
+        INDArrayIndex x = NDArrayIndex.point(0);
+        INDArrayIndex y = NDArrayIndex.point(2);
+        INDArray value = Nd4j.ones(1, 1);
+        zeros.put(new INDArrayIndex[]{x, y}, value);
+        assertEquals(
+                "[ 0,00, 0,00, 1,00, 0,00]",
+                zeros.toString());
+    }
+
+    @Test
     public void testIndexPointAll(){
         INDArray zeros = Nd4j.zeros(3, 3, 3);
         INDArrayIndex x = NDArrayIndex.point(1);
@@ -235,6 +259,8 @@ public class ShapeResolutionTestsC extends BaseNd4jTest {
                  " [0,00,0,00,0,00]]]",
                 zeros.toString());
     }
+
+
 
     @Override
     public char ordering() {


### PR DESCRIPTION
When the given array is a vector, the first point index provides no offset
and the second index is an interval index, then the offset was added
twice. This should fix the problem.