### PR TITLE
R119 memory management

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/Allocator.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/Allocator.java
@@ -129,6 +129,8 @@ public interface Allocator {
 
     void memcpySpecial(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset);
 
+    void memcpyDevice(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset);
+
     void memcpy(DataBuffer dstBuffer, DataBuffer srcBuffer);
 
     void tickHostWrite(DataBuffer buffer);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
@@ -555,12 +555,13 @@ public class AtomicAllocator implements Allocator {
 
     private class UnifiedGarbageCollectorThread extends Thread implements Runnable {
         private final ReferenceQueue<BaseDataBuffer> queue;
-
+        private int threadId;
 
         public UnifiedGarbageCollectorThread(Integer threadId, @NonNull ReferenceQueue<BaseDataBuffer> queue) {
             this.queue = queue;
             this.setDaemon(true);
             this.setName("UniGC thread " + threadId);
+            this.threadId = threadId;
         }
 
         @Override
@@ -581,7 +582,9 @@ public class AtomicAllocator implements Allocator {
 
                 } else {
                     try {
-                        Thread.sleep(50);
+                        if (threadId == 0)
+                            System.gc();
+                        Thread.sleep(500);
                     } catch (Exception e) {
 
                     }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
@@ -582,8 +582,8 @@ public class AtomicAllocator implements Allocator {
 
                 } else {
                     try {
-                        if (threadId == 0)
-                            System.gc();
+                        //if (threadId == 0)
+                         //   System.gc();
                         Thread.sleep(500);
                     } catch (Exception e) {
 
@@ -762,6 +762,11 @@ public class AtomicAllocator implements Allocator {
     @Override
     public void memcpySpecial(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset) {
         this.memoryHandler.memcpySpecial(dstBuffer, srcPointer, length, dstOffset);
+    }
+
+    @Override
+    public void memcpyDevice(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset) {
+        this.memoryHandler.memcpyDevice(dstBuffer, srcPointer, length, dstOffset);
     }
 
     /**

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
@@ -582,9 +582,10 @@ public class AtomicAllocator implements Allocator {
 
                 } else {
                     try {
-                        //if (threadId == 0)
-                         //   System.gc();
-                        Thread.sleep(500);
+                        if (threadId == 0) {
+                            System.gc();
+                            Thread.sleep(2000);
+                        } else Thread.sleep(500);
                     } catch (Exception e) {
 
                     }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/conf/Configuration.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/conf/Configuration.java
@@ -52,13 +52,13 @@ public class Configuration implements Serializable {
     /**
      * Maximum allocated per-device memory, in bytes
      */
-    private long maximumDeviceAllocation = 1 * 1024 * 1024 * 1024L;
+    private long maximumDeviceAllocation = 3 * 1024 * 1024 * 1024L;
 
 
     /**
      * Maximum allocatable zero-copy/pinned/pageable memory
      */
-    private long maximumZeroAllocation = Runtime.getRuntime().maxMemory();
+    private long maximumZeroAllocation = Runtime.getRuntime().maxMemory() + (500 * 1024 * 1024L);
 
     /**
      * True if allowed, false if relocation required

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/MemoryHandler.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/MemoryHandler.java
@@ -139,6 +139,8 @@ public interface MemoryHandler {
 
     void memcpySpecial(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset);
 
+    void memcpyDevice(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset);
+
     /**
      * Synchronous version of memcpy
      *

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
@@ -518,6 +518,18 @@ public class CudaZeroHandler implements MemoryHandler {
 //
     }
 
+    @Override
+    public void memcpyDevice(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset) {
+        CudaContext context = getCudaContext();
+        AllocationPoint point = ((BaseCudaDataBuffer) dstBuffer).getAllocationPoint();
+
+        Pointer dP = new CudaPointer((point.getPointers().getDevicePointer().address()) + dstOffset);
+
+        nativeOps.memcpyAsync(dP.address(), srcPointer.address(), length, CudaConstants.cudaMemcpyDeviceToDevice, context.getOldStream().address());
+
+        point.tickDeviceWrite();
+    }
+
     /**
      * Special memcpy version, addressing shapeInfoDataBuffer copies
      *

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
@@ -248,7 +248,7 @@ public class CudaZeroHandler implements MemoryHandler {
                     }
                 } else {
                     log.info("Skipping allocation A on [DEVICE] [{}]", deviceId);
-                    log.info("ReqMem: [{}], current state: [{}], maxTotalAllocation: [{}] ", reqMemory, deviceMemoryTracker.getAllocatedSize(deviceId), configuration.getMaximumDeviceAllocation());
+               //     log.info("ReqMem: [{}], current state: [{}], maxTotalAllocation: [{}] ", reqMemory, deviceMemoryTracker.getAllocatedSize(deviceId), configuration.getMaximumDeviceAllocation());
 //                    throw new RuntimeException("PEW");
                 }
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
@@ -22,6 +22,7 @@ import org.nd4j.jita.conf.Configuration;
 import org.nd4j.jita.memory.impl.CudaCachingZeroProvider;
 import org.nd4j.jita.memory.MemoryProvider;
 import org.nd4j.jita.handler.MemoryHandler;
+import org.nd4j.jita.memory.impl.CudaFullCachingProvider;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
@@ -74,7 +75,7 @@ public class CudaZeroHandler implements MemoryHandler {
 
     private final AtomicBoolean wasInitialised = new AtomicBoolean(false);
 
-    private final MemoryProvider provider = new CudaCachingZeroProvider();
+    private final MemoryProvider provider = new CudaFullCachingProvider();
 
     private final FlowController flowController = new AsynchronousFlowController();
 
@@ -504,7 +505,7 @@ public class CudaZeroHandler implements MemoryHandler {
                     context.getOldStream()
             );*/
             if (nativeOps.memcpyAsync(rDP.address(), dP.address(), length, CudaConstants.cudaMemcpyHostToDevice, context.getOldStream().address()) == 0)
-                throw new IllegalStateException("MemcpyAsync failed");
+                throw new IllegalStateException("MemcpyAsync failed: [" + dP.address() + "] -> [" + rDP.address() + "]");
 
             //context.syncOldStream();
         }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
@@ -225,7 +225,7 @@ public class CudaZeroHandler implements MemoryHandler {
 
                             point.setAllocationStatus(AllocationStatus.DEVICE);
 
-                            nativeOps.memsetAsync(pair.getDevicePointer().address(), 0, reqMemory, 0, context.getOldStream().address());
+                            //nativeOps.memsetAsync(pair.getDevicePointer().address(), 0, reqMemory, 0, context.getOldStream().address());
                             //JCuda.cudaStreamSynchronize(context.getOldStream());
 
 
@@ -234,8 +234,8 @@ public class CudaZeroHandler implements MemoryHandler {
                             zeroAllocations.get(point.getBucketId()).remove(point.getObjectId());
                             deviceMemoryTracker.addToAllocation(Thread.currentThread().getId(), deviceId, reqMemory);
 
-                            point.tickDeviceWrite();
-                            point.tickHostRead();
+                          //  point.tickDeviceWrite();
+                            point.tickHostWrite();
                         } else {
                             log.info("Skipping allocation C on [DEVICE]");
                             // if device memory allocation failed (aka returned NULL), keep using host memory instead

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
@@ -460,7 +460,7 @@ public class CudaZeroHandler implements MemoryHandler {
 
             point.tickHostRead();
         } else {
-
+          //  log.info("Memcpy async: {} bytes ", length);
             /*
             JCuda.cudaMemcpyAsync(
                     dP,
@@ -520,6 +520,7 @@ public class CudaZeroHandler implements MemoryHandler {
 
     @Override
     public void memcpyDevice(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset) {
+      //  log.info("Memcpy device: {} bytes ", length);
         CudaContext context = getCudaContext();
         AllocationPoint point = ((BaseCudaDataBuffer) dstBuffer).getAllocationPoint();
 
@@ -542,7 +543,7 @@ public class CudaZeroHandler implements MemoryHandler {
      */
     @Override
     public void memcpySpecial(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset) {
-        //log.info("memcpySpecial called");
+     //   log.info("Memcpy special: {} bytes ", length);
         CudaContext context = getCudaContext();
         AllocationPoint point = ((BaseCudaDataBuffer) dstBuffer).getAllocationPoint();
 
@@ -615,6 +616,7 @@ public class CudaZeroHandler implements MemoryHandler {
     @Override
     public void memcpy(DataBuffer dstBuffer, DataBuffer srcBuffer) {
         //log.info("Buffer MemCpy called");
+        log.info("Memcpy buffer: {} bytes ", dstBuffer.length() * dstBuffer.getElementSize());
         CudaContext context = getCudaContext();
         AllocationPoint dstPoint = ((BaseCudaDataBuffer) dstBuffer).getAllocationPoint();
         AllocationPoint srcPoint = ((BaseCudaDataBuffer) srcBuffer).getAllocationPoint();

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaCachingZeroProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaCachingZeroProvider.java
@@ -163,11 +163,11 @@ public class CudaCachingZeroProvider extends CudaDirectProvider implements Memor
                 // total memory allocated within this bucket
                 long cacheDepth = cacheEntries * reqMemory;
 
-            //    if (cacheDepth < MAX_CACHED_MEMORY / cacheHeight) {
+                if (cacheDepth < MAX_CACHED_MEMORY / cacheHeight) {
                     cache.put(new CudaPointer(point.getHostPointer().address()));
-            //    } else {
-            //        super.free(point);
-          //      }
+                } else {
+                    super.free(point);
+                }
             }
         }
     }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaCachingZeroProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaCachingZeroProvider.java
@@ -42,7 +42,7 @@ public class CudaCachingZeroProvider extends CudaDirectProvider implements Memor
     protected final Semaphore singleLock = new Semaphore(1);
 
     // we don't cache allocations greater then this value
-    protected final long MAX_SINGLE_ALLOCATION = 1000000;
+    protected final long MAX_SINGLE_ALLOCATION = 32000000;
 
     // maximum cached size of memory
     protected final long MAX_CACHED_MEMORY;

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaCachingZeroProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaCachingZeroProvider.java
@@ -31,12 +31,18 @@ public class CudaCachingZeroProvider extends CudaDirectProvider implements Memor
 
     protected volatile ConcurrentHashMap<AllocationShape, CacheHolder> zeroCache = new ConcurrentHashMap<>();
 
-    protected final AtomicLong cacheHit = new AtomicLong(0);
-    protected final AtomicLong cacheMiss = new AtomicLong(0);
+    protected final AtomicLong cacheZeroHit = new AtomicLong(0);
+    protected final AtomicLong cacheZeroMiss = new AtomicLong(0);
+
+    protected final AtomicLong cacheDeviceHit = new AtomicLong(0);
+    protected final AtomicLong cacheDeviceMiss = new AtomicLong(0);
+
+
 
     private final AtomicLong allocRequests = new AtomicLong(0);
 
-    private final AtomicLong zeroCachedAmount = new AtomicLong(0);
+    protected final AtomicLong zeroCachedAmount = new AtomicLong(0);
+    protected final AtomicLong deviceCachedAmount = new AtomicLong(0);
 
 
     protected final Semaphore singleLock = new Semaphore(1);
@@ -80,7 +86,7 @@ public class CudaCachingZeroProvider extends CudaDirectProvider implements Memor
             if (cache != null ) {
                 Pointer pointer = cache.poll();
                 if (pointer != null) {
-                    cacheHit.incrementAndGet();
+                    cacheZeroHit.incrementAndGet();
 
                     // since this memory chunk is going to be used now, remove it's amount from
                     zeroCachedAmount.addAndGet(-1 * reqMemory);
@@ -93,14 +99,14 @@ public class CudaCachingZeroProvider extends CudaDirectProvider implements Memor
                     return pair;
                 }
             }
-            cacheMiss.incrementAndGet();
+            cacheZeroMiss.incrementAndGet();
 
             if (zeroCachedAmount.get() < MAX_CACHED_MEMORY / 10) {
                 CachePreallocator preallocator = new CachePreallocator(shape, location, PREALLOCATION_LIMIT);
                 preallocator.start();
             }
 
-            cacheMiss.incrementAndGet();
+            cacheZeroMiss.incrementAndGet();
             return super.malloc(shape, point, location);
         }
 
@@ -114,7 +120,7 @@ public class CudaCachingZeroProvider extends CudaDirectProvider implements Memor
             try {
                 singleLock.acquire();
                 if (!zeroCache.containsKey(shape)) {
-                    zeroCache.put(shape, new CacheHolder(shape));
+                    zeroCache.put(shape, new CacheHolder(shape, zeroCachedAmount));
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -172,27 +178,35 @@ public class CudaCachingZeroProvider extends CudaDirectProvider implements Memor
         }
     }
 
-    private float getCacheHitRatio() {
-        long totalHits = cacheHit.get() + cacheMiss.get();
-        float cacheRatio = cacheHit.get() * 100 / (float) totalHits;
+    private float getZeroCacheHitRatio() {
+        long totalHits = cacheZeroHit.get() + cacheZeroMiss.get();
+        float cacheRatio = cacheZeroHit.get() * 100 / (float) totalHits;
+        return cacheRatio;
+    }
+
+    private float getDeviceCacheHitRatio() {
+        long totalHits = cacheDeviceHit.get() + cacheDeviceMiss.get();
+        float cacheRatio = cacheDeviceHit.get() * 100 / (float) totalHits;
         return cacheRatio;
     }
 
     public void printCacheStats() {
-        float cacheRatio = getCacheHitRatio();
-
-        log.debug("Cached amount: " + zeroCachedAmount.get());
+        log.debug("Cached host amount: " + zeroCachedAmount.get());
+        log.debug("Cached device amount: " + deviceCachedAmount.get());
         log.debug("Total shapes in cache: " + zeroCache.size());
-        log.debug("Current hit ratio: " + cacheRatio);
+        log.debug("Current host hit ratio: " + getZeroCacheHitRatio());
+        log.debug("Current device hit ratio: " + getDeviceCacheHitRatio());
     }
 
     protected class CacheHolder {
         private Queue<Pointer> queue = new ConcurrentLinkedQueue<>();
         private AtomicInteger counter = new AtomicInteger(0);
         private long reqMem = 0;
+        private final AtomicLong allocCounter;
 
-        public CacheHolder(AllocationShape shape) {
+        public CacheHolder(AllocationShape shape, AtomicLong counter) {
             this.reqMem = AllocationUtils.getRequiredMemory(shape);
+            this.allocCounter = counter;
         }
 
         public int size() {
@@ -208,7 +222,7 @@ public class CudaCachingZeroProvider extends CudaDirectProvider implements Memor
         }
 
         public void put(Pointer pointer) {
-            zeroCachedAmount.addAndGet(reqMem);
+            allocCounter.addAndGet(reqMem);
             counter.incrementAndGet();
             queue.add(pointer);
         }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaFullCachingProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaFullCachingProvider.java
@@ -7,6 +7,8 @@ import org.nd4j.jita.allocator.impl.AllocationShape;
 import org.nd4j.jita.allocator.pointers.CudaPointer;
 import org.nd4j.jita.allocator.pointers.PointersPair;
 import org.nd4j.jita.allocator.utils.AllocationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -18,14 +20,18 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class CudaFullCachingProvider extends CudaCachingZeroProvider {
 
+    protected final long MAX_GPU_ALLOCATION = 10000000;
+
     protected final AtomicLong deviceCachedAmount = new AtomicLong(0);
 
     protected volatile ConcurrentHashMap<Integer, ConcurrentHashMap<AllocationShape, CacheHolder>> deviceCache = new ConcurrentHashMap<>();
 
+    private static Logger log = LoggerFactory.getLogger(CudaFullCachingProvider.class);
+
     @Override
     public PointersPair malloc(AllocationShape shape, AllocationPoint point, AllocationStatus location) {
         long reqMemory = AllocationUtils.getRequiredMemory(shape);
-        if (location == AllocationStatus.DEVICE && reqMemory < MAX_SINGLE_ALLOCATION) {
+        if (location == AllocationStatus.DEVICE && reqMemory < MAX_GPU_ALLOCATION) {
             ensureDeviceCacheHolder(point.getDeviceId(), shape);
 
             CacheHolder cache = deviceCache.get(point.getDeviceId()).get(shape);
@@ -37,8 +43,7 @@ public class CudaFullCachingProvider extends CudaCachingZeroProvider {
                     deviceCachedAmount.addAndGet(-1 * reqMemory);
 
                     PointersPair pair = new PointersPair();
-                    pair.setDevicePointer(new CudaPointer(pointer.address()));
-                    pair.setHostPointer(new CudaPointer(pointer.address()));
+                    pair.setDevicePointer(pointer);
 
                     point.setAllocationStatus(AllocationStatus.DEVICE);
                     return pair;
@@ -57,7 +62,7 @@ public class CudaFullCachingProvider extends CudaCachingZeroProvider {
             long reqMemory = AllocationUtils.getRequiredMemory(shape);
             // we don't cache too big objects
 
-            if (reqMemory > MAX_SINGLE_ALLOCATION || deviceCachedAmount.get() >= MAX_CACHED_MEMORY) {
+            if (reqMemory > MAX_GPU_ALLOCATION || deviceCachedAmount.get() >= MAX_CACHED_MEMORY) {
                 super.free(point);
                 return;
             }
@@ -70,6 +75,7 @@ public class CudaFullCachingProvider extends CudaCachingZeroProvider {
             // memory chunks < threshold will be cached no matter what
             if (reqMemory <= FORCED_CACHE_THRESHOLD) {
                 cache.put(new CudaPointer(point.getDevicePointer().address()));
+                return;
             } else {
                 long cacheEntries = cache.size();
                 long cacheHeight = deviceCache.get(point.getDeviceId()).size();
@@ -79,6 +85,7 @@ public class CudaFullCachingProvider extends CudaCachingZeroProvider {
 
                 if (cacheDepth < MAX_CACHED_MEMORY / cacheHeight) {
                     cache.put(new CudaPointer(point.getDevicePointer().address()));
+                    return;
                 } else {
                     super.free(point);
                 }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
@@ -26,6 +26,7 @@ import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.FloatBuffer;
 import org.nd4j.linalg.api.ndarray.BaseNDArray;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 
 import java.util.List;
@@ -338,6 +339,30 @@ public class JCublasNDArray extends BaseNDArray {
 
     public JCublasNDArray(double[] data, int[] shape, int[] stride, int offset, char ordering) {
         super(data, shape, stride, offset, ordering);
+    }
+
+    @Override
+    public INDArray dup() {
+        /*
+            Special case for cuda: if we have not a view, and shapes do match - we
+        */
+        if (!isView() && ordering() == Nd4j.order()) {
+            AtomicAllocator allocator = AtomicAllocator.getInstance();
+            INDArray array = Nd4j.create(shape(), ordering());
+            allocator.memcpyAsync(array.data(), allocator.getHostPointer(this.data), this.data.length() * this.data().getElementSize(), 0);
+            return array;
+        } else return super.dup();
+    }
+
+    @Override
+    public INDArray dup(char order) {
+
+        if (!isView() && ordering() == order) {
+            AtomicAllocator allocator = AtomicAllocator.getInstance();
+            INDArray array = Nd4j.create(shape(), order);
+            allocator.memcpyAsync(array.data(), allocator.getHostPointer(this.data), this.data.length() * this.data().getElementSize(), 0);
+            return array;
+        } else return super.dup(order);
     }
 
     @Override

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
@@ -349,7 +349,7 @@ public class JCublasNDArray extends BaseNDArray {
         if (!isView() && ordering() == Nd4j.order()) {
             AtomicAllocator allocator = AtomicAllocator.getInstance();
             INDArray array = Nd4j.create(shape(), ordering());
-            allocator.memcpyAsync(array.data(), allocator.getHostPointer(this.data), this.data.length() * this.data().getElementSize(), 0);
+            allocator.memcpyDevice(array.data(), allocator.getPointer(this.data), this.data.length() * this.data().getElementSize(), 0);
             return array;
         } else return super.dup();
     }
@@ -360,7 +360,7 @@ public class JCublasNDArray extends BaseNDArray {
         if (!isView() && ordering() == order) {
             AtomicAllocator allocator = AtomicAllocator.getInstance();
             INDArray array = Nd4j.create(shape(), order);
-            allocator.memcpyAsync(array.data(), allocator.getHostPointer(this.data), this.data.length() * this.data().getElementSize(), 0);
+            allocator.memcpyDevice(array.data(), allocator.getPointer(this.data), this.data.length() * this.data().getElementSize(), 0);
             return array;
         } else return super.dup(order);
     }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/JCudaExecutioner.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/JCudaExecutioner.java
@@ -161,7 +161,7 @@ public class JCudaExecutioner extends DefaultOpExecutioner {
         long x = AtomicAllocator.getInstance().getPointer(op.x()).address();
         long xShapeInfo = AddressRetriever.retrieveDeviceAddress(op.x().shapeInfoDataBuffer());
         long[] xShapeInfoHostPointer = new long[]{ AddressRetriever.retrieveHostAddress(op.x().shapeInfoDataBuffer()), context.getOldStream().getNativePointer(), allocator.getDeviceId(), context.getBufferAllocation(), context.getBufferReduction(), context.getBufferScalar()};
-        long extraArgs = op.extraArgs() != null && !(op instanceof Variance) ? AddressRetriever.retrieveDeviceAddress(op.extraArgsDataBuff()) : 0;
+        long extraArgs = op.extraArgs() != null && op instanceof Variance ? AddressRetriever.retrieveDeviceAddress(op.extraArgsDataBuff()) : 0;
         long dimensionPointer = AddressRetriever.retrieveDeviceAddress(Nd4j.createBuffer(dimension));
 
         /*

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/JCudaExecutioner.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/JCudaExecutioner.java
@@ -161,7 +161,7 @@ public class JCudaExecutioner extends DefaultOpExecutioner {
         long x = AtomicAllocator.getInstance().getPointer(op.x()).address();
         long xShapeInfo = AddressRetriever.retrieveDeviceAddress(op.x().shapeInfoDataBuffer());
         long[] xShapeInfoHostPointer = new long[]{ AddressRetriever.retrieveHostAddress(op.x().shapeInfoDataBuffer()), context.getOldStream().getNativePointer(), allocator.getDeviceId(), context.getBufferAllocation(), context.getBufferReduction(), context.getBufferScalar()};
-        long extraArgs = 0; //op.extraArgs() != null ? AddressRetriever.retrieveDeviceAddress(op.extraArgsDataBuff()) : 0;
+        long extraArgs = op.extraArgs() != null && !(op instanceof Variance) ? AddressRetriever.retrieveDeviceAddress(op.extraArgsDataBuff()) : 0;
         long dimensionPointer = AddressRetriever.retrieveDeviceAddress(Nd4j.createBuffer(dimension));
 
         /*

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/JCudaExecutioner.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/JCudaExecutioner.java
@@ -161,7 +161,7 @@ public class JCudaExecutioner extends DefaultOpExecutioner {
         long x = AtomicAllocator.getInstance().getPointer(op.x()).address();
         long xShapeInfo = AddressRetriever.retrieveDeviceAddress(op.x().shapeInfoDataBuffer());
         long[] xShapeInfoHostPointer = new long[]{ AddressRetriever.retrieveHostAddress(op.x().shapeInfoDataBuffer()), context.getOldStream().getNativePointer(), allocator.getDeviceId(), context.getBufferAllocation(), context.getBufferReduction(), context.getBufferScalar()};
-        long extraArgs = op.extraArgs() != null ? AddressRetriever.retrieveDeviceAddress(op.extraArgsDataBuff()) : 0;
+        long extraArgs = 0; //op.extraArgs() != null ? AddressRetriever.retrieveDeviceAddress(op.extraArgsDataBuff()) : 0;
         long dimensionPointer = AddressRetriever.retrieveDeviceAddress(Nd4j.createBuffer(dimension));
 
         /*

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/test/java/org/nd4j/jita/allocator/impl/AtomicAllocatorTest.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/test/java/org/nd4j/jita/allocator/impl/AtomicAllocatorTest.java
@@ -254,12 +254,12 @@ public class AtomicAllocatorTest {
         System.out.println("Array1 length: " + array1.length());
         BlasWrapper blasWrapper = Nd4j.getBlasWrapper();
         // Warmup
-        for (int i = 0; i < 50000; i++) {
+        for (int i = 0; i < 500; i++) {
             blasWrapper.axpy(new Float(0.75f), array1, array2);
         }
 
         long time1 = System.nanoTime();
-        int count = 5000000;
+        int count = 50000;
         for (int i = 0; i < count; i++) {
             blasWrapper.axpy(new Float(0.75f), array1, array2);
         }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/test/java/org/nd4j/linalg/jcublas/buffer/CudaFloatDataBufferTest.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/test/java/org/nd4j/linalg/jcublas/buffer/CudaFloatDataBufferTest.java
@@ -667,4 +667,9 @@ public class CudaFloatDataBufferTest {
         assertEquals(true, pointMain.isActualOnDeviceSide());
         assertEquals(true, pointMain.isActualOnHostSide());
     }
+
+    @Test
+    public void testDup4() throws Exception {
+
+    }
 }


### PR DESCRIPTION
Minor improvements:

- no more extraArgsDataBuffers for reduce ops

- memcpy for INDArray.dup() where possible instead of assign op.

- device memory cache

- D2D copies go first.