### PR TITLE
Enhance support for the native components

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeLapack.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeLapack.java
@@ -1,18 +1,22 @@
 package org.nd4j.nativeblas;
 
 
+import org.bytedeco.javacpp.Loader;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.Platform;
 
 /**
  * Created by agibsonccc on 2/20/16.
- *
- * the preload="libnd4j" is there because MinGW puts a "lib" in front of the filename for the DLL, but at load time,
- * we are using the default Windows platform naming scheme, which doesn't put "lib" in front, so that's a bit of a hack,
- * but easier than forcing MinGW into not renaming the library name -- @saudet on 3/21/16
  */
-@Platform(include="NativeLapack.h",preload = "libnd4j", link = "nd4j")
+@Platform(include = "NativeLapack.h", compiler = "cpp11", link = "nd4j", library = "jnind4j")
 public class NativeLapack extends Pointer {
+    static {
+        // using our custom platform properties from resources, load
+        // in priority libraries found in library path over bundled ones
+        String platform = Loader.getPlatform();
+        Loader.load(NativeLapack.class, Loader.loadProperties(platform + "-nd4j", platform), true);
+    }
+
     public NativeLapack() {
     }
 // LU decomoposition of a general matrix

--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -15,16 +15,15 @@ import org.slf4j.LoggerFactory;
  * Native interface for
  * op execution on cpu
  * @author Adam Gibson
- *
- * the preload="libnd4j" is there because MinGW puts a "lib" in front of the filename for the DLL, but at load time,
- * we are using the default Windows platform naming scheme, which doesn't put "lib" in front, so that's a bit of a hack,
- * but easier than forcing MinGW into not renaming the library name -- @saudet on 3/21/16
  */
-@Platform(include={"NativeOps.h"}, preload="libnd4j", link = "nd4j")
+@Platform(include = "NativeOps.h", compiler = "cpp11", link = "nd4j", library = "jnind4j")
 public class NativeOps extends Pointer {
     private static Logger log = LoggerFactory.getLogger(NativeOps.class);
     static {
-        Loader.load();
+        // using our custom platform properties from resources, load
+        // in priority libraries found in library path over bundled ones
+        String platform = Loader.getPlatform();
+        Loader.load(NativeOps.class, Loader.loadProperties(platform + "-nd4j", platform), true);
     }
 
     public NativeOps() {

--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/Nd4jBlas.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/Nd4jBlas.java
@@ -10,15 +10,14 @@ import org.bytedeco.javacpp.annotation.Platform;
  *
  * Original credit:
  * https://github.com/uncomplicate/neanderthal-atlas
- *
- * the preload="libnd4j" is there because MinGW puts a "lib" in front of the filename for the DLL, but at load time,
- * we are using the default Windows platform naming scheme, which doesn't put "lib" in front, so that's a bit of a hack,
- * but easier than forcing MinGW into not renaming the library name -- @saudet on 3/21/16
  */
-@Platform(include="NativeBlas.h",preload = "libnd4j", link = "nd4j")
+@Platform(include = "NativeBlas.h", compiler = "cpp11", link = "nd4j", library = "jnind4j")
 public class Nd4jBlas extends Pointer {
     static {
-        Loader.load();
+        // using our custom platform properties from resources, load
+        // in priority libraries found in library path over bundled ones
+        String platform = Loader.getPlatform();
+        Loader.load(Nd4jBlas.class, Loader.loadProperties(platform + "-nd4j", platform), true);
     }
 
     public Nd4jBlas() {

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -99,6 +99,7 @@
                             <goal>build</goal>
                         </goals>
                         <configuration>
+                            <propertyFile>${project.basedir}/src/main/resources/org/bytedeco/javacpp/properties/${javacpp.platform}-nd4j.properties</propertyFile>
                             <outputDirectory>${project.build.outputDirectory}/org/nd4j/nativeblas/${javacpp.platform}</outputDirectory>
                             <skip>${process-classes.skip}</skip>
                             <classOrPackageNames>
@@ -146,17 +147,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>mingw</id>
-            <activation><os><family>windows</family></os></activation>
-            <build><plugins><plugin>
-                <groupId>org.bytedeco</groupId>
-                <artifactId>javacpp</artifactId>
-                <configuration><properties>${javacpp.platform}-mingw</properties></configuration>
-            </plugin></plugins></build>
-        </profile>
-    </profiles>
 
 </project>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-ppc64-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-ppc64-nd4j.properties
@@ -1,0 +1,24 @@
+platform=linux-ppc64
+platform.path.separator=:
+platform.source.suffix=.cpp
+platform.includepath.prefix=-I
+platform.includepath=
+platform.compiler=g++
+platform.compiler.cpp11=-std=c++11
+platform.compiler.default=
+platform.compiler.fastfpu=-ffast-math
+platform.compiler.nodeprecated=-Wno-deprecated-declarations
+platform.compiler.output=-Wl,-rpath,$ORIGIN/ -Wl,-z,noexecstack -Wl,-Bsymbolic -mcpu=powerpc64 -m64 -Wall -O3 -fPIC -shared -s -o\u0020
+platform.linkpath.prefix=-L
+platform.linkpath.prefix2=-Wl,-rpath,
+platform.linkpath=
+platform.link.prefix=-l
+platform.link.suffix=
+platform.link=
+platform.framework.prefix=-F
+platform.framework.suffix=
+platform.framework=
+platform.library.prefix=lib
+platform.library.suffix=.so
+platform.preloadpath=/usr/lib64/:/usr/lib/
+platform.preload=quadmath@.0:gfortran@.3:openblas@.0:blas@.3

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-ppc64le-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-ppc64le-nd4j.properties
@@ -1,0 +1,24 @@
+platform=linux-ppc64le
+platform.path.separator=:
+platform.source.suffix=.cpp
+platform.includepath.prefix=-I
+platform.includepath=
+platform.compiler=g++
+platform.compiler.cpp11=-std=c++11
+platform.compiler.default=
+platform.compiler.fastfpu=-ffast-math
+platform.compiler.nodeprecated=-Wno-deprecated-declarations
+platform.compiler.output=-Wl,-rpath,$ORIGIN/ -Wl,-z,noexecstack -Wl,-Bsymbolic -mcpu=powerpc64le -m64 -Wall -O3 -fPIC -shared -s -o\u0020
+platform.linkpath.prefix=-L
+platform.linkpath.prefix2=-Wl,-rpath,
+platform.linkpath=
+platform.link.prefix=-l
+platform.link.suffix=
+platform.link=
+platform.framework.prefix=-F
+platform.framework.suffix=
+platform.framework=
+platform.library.prefix=lib
+platform.library.suffix=.so
+platform.preloadpath=/usr/lib64/:/usr/lib/
+platform.preload=quadmath@.0:gfortran@.3:openblas@.0:blas@.3

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-x86_64-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-x86_64-nd4j.properties
@@ -1,0 +1,24 @@
+platform=linux-x86_64
+platform.path.separator=:
+platform.source.suffix=.cpp
+platform.includepath.prefix=-I
+platform.includepath=
+platform.compiler=g++
+platform.compiler.cpp11=-std=c++11
+platform.compiler.default=
+platform.compiler.fastfpu=-msse3 -ffast-math
+platform.compiler.nodeprecated=-Wno-deprecated-declarations
+platform.compiler.output=-Wl,-rpath,$ORIGIN/ -Wl,-z,noexecstack -Wl,-Bsymbolic -march=x86-64 -m64 -Wall -O3 -fPIC -shared -s -o\u0020
+platform.linkpath.prefix=-L
+platform.linkpath.prefix2=-Wl,-rpath,
+platform.linkpath=
+platform.link.prefix=-l
+platform.link.suffix=
+platform.link=
+platform.framework.prefix=-F
+platform.framework.suffix=
+platform.framework=
+platform.library.prefix=lib
+platform.library.suffix=.so
+platform.preloadpath=/usr/lib64/:/usr/lib/
+platform.preload=quadmath@.0:gfortran@.3:openblas@.0:blas@.3

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/macosx-x86_64-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/macosx-x86_64-nd4j.properties
@@ -1,0 +1,23 @@
+platform=macosx-x86_64
+platform.path.separator=:
+platform.source.suffix=.cpp
+platform.includepath.prefix=-I
+platform.includepath=
+platform.compiler=clang++
+platform.compiler.cpp11=-std=c++11
+platform.compiler.default=
+platform.compiler.fastfpu=-msse3 -ffast-math
+platform.compiler.nodeprecated=-Wno-deprecated-declarations
+platform.compiler.output=-Wl,-rpath,@loader_path/. -march=x86-64 -m64 -Wall -O3 -fPIC -dynamiclib -undefined dynamic_lookup -o\u0020
+platform.linkpath.prefix=-L
+platform.linkpath.prefix2=-Wl,-rpath,
+platform.linkpath=
+platform.link.prefix=-l
+platform.link.suffix=
+platform.link=
+platform.frameworkpath.prefix=-F
+platform.framework.prefix=-framework\u0020
+platform.framework.suffix=
+platform.framework=
+platform.library.prefix=lib
+platform.library.suffix=.dylib:.so

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/windows-x86_64-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/windows-x86_64-nd4j.properties
@@ -1,0 +1,23 @@
+platform=windows-x86_64
+platform.path.separator=;
+platform.source.suffix=.cpp
+platform.includepath.prefix=-I
+platform.includepath=
+platform.compiler=g++
+platform.compiler.cpp11=-std=c++11
+platform.compiler.default=
+platform.compiler.fastfpu=-msse3 -ffast-math
+platform.compiler.nodeprecated=-Wno-deprecated-declarations
+platform.compiler.output=-D_JNI_IMPLEMENTATION_ -Wl,--kill-at -march=x86-64 -m64 -Wall -O3 -fPIC -shared -s -o\u0020
+platform.linkpath.prefix=-L
+platform.linkpath=
+platform.link.prefix=-l
+platform.link.suffix=
+platform.link=
+platform.framework.prefix=-F
+platform.framework.suffix=
+platform.framework=
+platform.library.prefix=
+platform.library.suffix=.dll
+platform.preloadpath=C:/msys64/mingw64/bin/
+platform.preload=libwinpthread-1;libgcc_s_seh-1;libgomp-1;libstdc++-6;libquadmath-0;libgfortran-3;libopenblas;libblas3;libnd4j

--- a/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -16,6 +16,21 @@
         <module>nd4j-native</module>
         <module>nd4j-cuda-7.5</module>
     </modules>
+
+    <properties>
+        <javacpp.platform.dependency>${javacpp.platform}</javacpp.platform.dependency>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${project.artifactId}</artifactId>
+            <version>${project.version}</version>
+            <type>${project.packaging}</type>
+            <classifier>${javacpp.platform.dependency}</classifier>
+        </dependency>
+    </dependencies>
+
     <build>
         <testSourceDirectory>../nd4j-tests/src/test/java</testSourceDirectory>
         <pluginManagement>
@@ -46,9 +61,56 @@
                         <createChecksum>true</createChecksum>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>default-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                          <excludes>
+                            <exclude>org/nd4j/nativeblas/${javacpp.platform}/*</exclude>
+                          </excludes>
+                        </configuration>
+                      </execution>
+                      <execution>
+                        <id>${javacpp.platform}</id>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                          <classifier>${javacpp.platform}</classifier>
+                          <skipIfEmpty>true</skipIfEmpty>
+                          <includes>
+                            <include>org/nd4j/nativeblas/${javacpp.platform}/*</include>
+                          </includes>
+                        </configuration>
+                      </execution>
+                    </executions>
+                </plugin>
             </plugins>
 
 
         </pluginManagement>
     </build>
+
+    <!-- Disable platform dependency when building the artifact for the dependency itself -->
+    <profiles>
+        <profile>
+            <id>platform-dependency</id>
+            <activation>
+                <file>
+                    <exists>${basedir}</exists>
+                </file>
+            </activation>
+            <properties>
+                <javacpp.platform.dependency></javacpp.platform.dependency>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/nd4j-jdbc/nd4j-jdbc-mysql/pom.xml
+++ b/nd4j-jdbc/nd4j-jdbc-mysql/pom.xml
@@ -32,12 +32,6 @@
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-x86</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>5.1.27</version>

--- a/nd4j-perf/pom.xml
+++ b/nd4j-perf/pom.xml
@@ -38,11 +38,5 @@
             <artifactId>nd4j-api</artifactId>
             <version>${version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-x86</artifactId>
-            <version>${version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/nd4j-serde/nd4j-jackson/pom.xml
+++ b/nd4j-serde/nd4j-jackson/pom.xml
@@ -19,12 +19,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-x86</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,7 @@
                 <configuration>
                     <includes>
                         <include>**/*.so</include>
+                        <include>**/*.so.*</include>
                         <include>META-INF/*</include>
                         <include>META-INF/services/**</include>
                         <include>org.*</include>


### PR DESCRIPTION
- At build time, automatically place compiled binaries in a separate JAR file using a classifier named after the detected or provided platform (linux-x86_64, etc)
- At load time, have that JAR file automatically added as a Maven dependency, without having the user
 do anything special
- Also bundle necessary files for OpenBLAS to obtain easily a self-contained application, while still
 prioritizing libraries found in the paths
- Remove obsolete dependencies on nd4j-x86 preventing the build from succeeding with the new features

FYI, having separate artifacts containing the native libraries makes it possible to deploy from Maven as usual, just from multiple machines for the different platforms. This is because this way the content of the main artifact is the same regardless of the build platform, so we can freely have it redeployed multiple times without consequence.

I've tested on Linux and Windows, and the bundled libraries seem to work fine without having to install additional packages for Linux or MSYS2. But this doesn't cover everything that we need. libnd4j links with `libopenblas.so.0`, but we would probably want to coerce it into linking with `libblas.so.3` to get the same behavior as netlib-java.

On OS X, we can reasonably assume that Accelerate is installed, but we are relying on `clang-omp` installed from Homebrew, so I think we need to figure out a way to bundle the required library `libiomp5.dylib` as well. The concept of "rpath" on OS X isn't as flexible as it is on Linux, so even just bundling that file from Homebrew could be problematic, but not impossible. Or we could link with a static version of the library, but they don't seem to provide one for some reason. To get one, we could rebuild `clang-omp` from scratch, not impossible either, but...