### PR TITLE
Update docs for platform-specific transitive binaries.

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -9,6 +9,58 @@ First, you will need to choose the right dependency for your chips:
 
 ![Alt text](../img/backend_table.png) 
 
+## Platform Specific Binaries
+
+Certain build tools such as [Gradle](http://www.gradle.org) and [SBT](http://www.scala-sbt.org/) cannot resolve transitive dependencies for specific platforms. When using a build tool such as Gradle, you will need to either explicitly state the platform binary you need at runtime or create a command line parameter that will specify your required platform. Creating command line parameters will allow you to switch between multiple platforms, such as testing on OS X and submitting to an Apache Spark cluster using a Linux operating system.
+
+### Explicitly Requiring Binaries (Gradle)
+
+Add the following to your dependencies in `build.gradle`:
+
+```
+dependencies {
+  compile 'org.nd4j:nd4j-native:0.4-rc3.9-SNAPSHOT'
+  compile 'org.nd4j:nd4j-native:0.4-rc3.9-SNAPSHOT:macosx-x86_64'
+}
+```
+
+### Command Line Option (Gradle)
+
+Add the following to your `build.gradle`:
+
+```
+switch(libnd4jOS) {
+  case 'windows':
+    libnd4jOS = 'win-x86_64'
+    break
+  case 'linux':
+    libnd4jOS = 'linux-x86_64'
+    break
+  case 'linux-ppc64':
+    libnd4jOS = 'linux-ppc64'
+    break
+  case 'linux-ppc64le':
+    libnd4jOS = 'linux-ppc64le'
+    break
+  case 'macosx':
+    libnd4jOS = 'macosx-x86_64'
+    break
+  default:
+    throw new Exception('Unknown OS defined for -Plibnd4jOS parameter. ND4J will be unable to find platform-specific binaries and thus unable to run.')
+}
+
+dependencies {
+  compile 'org.nd4j:nd4j-native:0.4-rc3.9-SNAPSHOT'
+  compile 'org.nd4j:nd4j-native:0.4-rc3.9-SNAPSHOT:'+libnd4jOS
+}
+```
+
+Finally, when running a Gradle command, add the parameter via the `-P` flag:
+
+```
+gradle run `-Plibnd4jOS=macosx`
+```
+
 ## Configuring the POM.xml file
 
 Maven can automatically install the required dependencies once we select one of these backends:
@@ -21,10 +73,19 @@ Maven can automatically install the required dependencies once we select one of 
 Go to your root directory -- e.g. nd4j or deeplearning4j -- and inspect the [pom.xml file](https://maven.apache.org/pom.html). You should see one backend defined in the `<dependencies> ... </dependencies>` section. You can switch among:
 
 ### x86
+Before version `4.0-RC3.9` you needed to specify the backend for your device.
 
         <dependency>
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-x86</artifactId>
+            <version>${nd4j.version}</version>
+        </dependency>
+
+After version `4.0-RC3.8` you can now pull include ND4J for all platforms.
+
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-native</artifactId>
             <version>${nd4j.version}</version>
         </dependency>
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -11,6 +11,8 @@ First, you will need to choose the right dependency for your chips:
 
 ## Platform Specific Binaries
 
+Valid for version `0.4-rc3.9` and higher.
+
 Certain build tools such as [Gradle](http://www.gradle.org) and [SBT](http://www.scala-sbt.org/) cannot resolve transitive dependencies for specific platforms. When using a build tool such as Gradle, you will need to either explicitly state the platform binary you need at runtime or create a command line parameter that will specify your required platform. Creating command line parameters will allow you to switch between multiple platforms, such as testing on OS X and submitting to an Apache Spark cluster using a Linux operating system.
 
 ### Explicitly Requiring Binaries (Gradle)
@@ -73,7 +75,7 @@ Maven can automatically install the required dependencies once we select one of 
 Go to your root directory -- e.g. nd4j or deeplearning4j -- and inspect the [pom.xml file](https://maven.apache.org/pom.html). You should see one backend defined in the `<dependencies> ... </dependencies>` section. You can switch among:
 
 ### x86
-Before version `4.0-RC3.9` you needed to specify the backend for your device.
+Before version `4.0-rc3.9` you needed to specify the backend for your device.
 
         <dependency>
             <groupId>org.nd4j</groupId>

--- a/getstarted.md
+++ b/getstarted.md
@@ -87,6 +87,21 @@ ND4J's version is a variable here. It will refer to another line higher in the P
 
 *The dl4j version is also 0.4-rc3.8, and Canova is 0.0.0.13.*
 
+### Platform-specific binaries
+
+Version `0.4-rc3.9` or higher now includes all backends by default. However, if you are using a build tool such as SBT or Gradle, you will need to explicitly pull binaries for the platform you are using. *Especially* if you are building on one platform but deploying to another (OS X vs. Linux). Information on how to do this can be found on the [dependencies](../dependencies.html) page.
+
+For example, a `build.gradle` file will look like this:
+
+```
+dependencies {
+  compile 'org.nd4j:nd4j-native:0.4-rc3.9-SNAPSHOT'
+  compile 'org.nd4j:nd4j-native:0.4-rc3.9-SNAPSHOT:macosx-x86_64'
+}
+```
+
+### Staying Up-to-date
+
 The number of the version will vary as we progress with new releases. Make sure you check [the latest version available on Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cnd4j). If you paste in the right dependency and nd4j version, Maven will automatically install the required libraries and you should be able to run ND4J. 
 
 The backend does not have to be x86; it can be switched to Jcublas for GPUs. That's explained on our [dependencies](../dependencies.html) page, alongside more advanced configuration changes. The same page also explains how to check on the [latest version](http://search.maven.org/#search%7Cga%7C1%7Cnd4j) of the libraries.

--- a/getstarted.md
+++ b/getstarted.md
@@ -91,7 +91,7 @@ ND4J's version is a variable here. It will refer to another line higher in the P
 
 Version `0.4-rc3.9` or higher now includes all backends by default. However, if you are using a build tool such as SBT or Gradle, you will need to explicitly pull binaries for the platform you are using. *Especially* if you are building on one platform but deploying to another (OS X vs. Linux). Information on how to do this can be found on the [dependencies](../dependencies.html) page.
 
-For example, a `build.gradle` file will look like this:
+For example, a `build.gradle` file will include an extra definition for the targeted platform:
 
 ```
 dependencies {
@@ -100,11 +100,15 @@ dependencies {
 }
 ```
 
-### Staying Up-to-date
+### Stay Up-to-date
 
 The number of the version will vary as we progress with new releases. Make sure you check [the latest version available on Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cnd4j). If you paste in the right dependency and nd4j version, Maven will automatically install the required libraries and you should be able to run ND4J. 
 
+### Switching Backends
+
 The backend does not have to be x86; it can be switched to Jcublas for GPUs. That's explained on our [dependencies](../dependencies.html) page, alongside more advanced configuration changes. The same page also explains how to check on the [latest version](http://search.maven.org/#search%7Cga%7C1%7Cnd4j) of the libraries.
+
+### Your Main Class
 
 You can now create a new Java file within IntelliJ, and start using ND4J's API for distributed linear algebra. 
 


### PR DESCRIPTION
Current documentation does not explain to the user how to pull transitive binaries when using a build tool such as Gradle or SBT. This PR addresses that and provides an example of how to specify the targeted build system. It also updates some info for `4.0-rc3.9` regarding the `nd4j-native` group change.