### PR TITLE
Add "org.nd4j.nativeblas.pathsfirst" system property

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -21,12 +21,14 @@ import org.slf4j.LoggerFactory;
 public class NativeOps extends Pointer {
     private static Logger log = LoggerFactory.getLogger(NativeOps.class);
     static {
-        // using our custom platform properties from resources, load
-        // in priority libraries found in library path over bundled ones
+        // using our custom platform properties from resources, and on user request,
+        // load in priority libraries found in the library path over bundled ones
         String platform = Loader.getPlatform();
         Properties properties = Loader.loadProperties(platform + "-nd4j", platform);
         properties.remove("platform.preloadpath");
-        Loader.load(NativeOps.class, properties, true);
+        String s = System.getProperty("org.nd4j.nativeblas.pathsfirst", "false").toLowerCase();
+        boolean pathsFirst = s.equals("true") || s.equals("t") || s.equals("");
+        Loader.load(NativeOps.class, properties, pathsFirst);
     }
 
     public NativeOps() {

--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/Nd4jBlas.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/Nd4jBlas.java
@@ -15,12 +15,14 @@ import org.bytedeco.javacpp.annotation.Platform;
 @Platform(include = "NativeBlas.h", compiler = "cpp11", link = "nd4j", library = "jnind4j")
 public class Nd4jBlas extends Pointer {
     static {
-        // using our custom platform properties from resources, load
-        // in priority libraries found in library path over bundled ones
+        // using our custom platform properties from resources, and on user request,
+        // load in priority libraries found in the library path over bundled ones
         String platform = Loader.getPlatform();
         Properties properties = Loader.loadProperties(platform + "-nd4j", platform);
         properties.remove("platform.preloadpath");
-        Loader.load(Nd4jBlas.class, properties, true);
+        String s = System.getProperty("org.nd4j.nativeblas.pathsfirst", "false").toLowerCase();
+        boolean pathsFirst = s.equals("true") || s.equals("t") || s.equals("");
+        Loader.load(Nd4jBlas.class, properties, pathsFirst);
     }
 
     public Nd4jBlas() {


### PR DESCRIPTION
Load BLAS libraries from the system, but only when it is set explicitly by the user, to prevent loading possibly conflicting libraries by default

Would that be satisfactory for now @agibsonccc ?