### PR TITLE
Copy and rename MKL libraries to automate loading process

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-ppc64-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-ppc64-nd4j.properties
@@ -21,4 +21,4 @@ platform.framework=
 platform.library.prefix=lib
 platform.library.suffix=.so
 platform.preloadpath=/usr/lib64/:/usr/lib/
-platform.preload=gomp@.1:quadmath@.0:gfortran@.3:openblas@.0:blas@.3
+platform.preload=gomp@.1:quadmath@.0:gfortran@.3:openblas@.0:blas@.3#openblas@.0

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-ppc64le-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-ppc64le-nd4j.properties
@@ -21,4 +21,4 @@ platform.framework=
 platform.library.prefix=lib
 platform.library.suffix=.so
 platform.preloadpath=/usr/lib64/:/usr/lib/
-platform.preload=gomp@.1:quadmath@.0:gfortran@.3:openblas@.0:blas@.3
+platform.preload=gomp@.1:quadmath@.0:gfortran@.3:openblas@.0:blas@.3#openblas@.0

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-x86_64-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/linux-x86_64-nd4j.properties
@@ -21,4 +21,4 @@ platform.framework=
 platform.library.prefix=lib
 platform.library.suffix=.so
 platform.preloadpath=/usr/lib64/:/usr/lib/
-platform.preload=gomp@.1:quadmath@.0:gfortran@.3:openblas@.0:blas@.3
+platform.preload=mkl_rt#openblas@.0:gomp@.1:quadmath@.0:gfortran@.3:openblas@.0:blas@.3#openblas@.0

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/windows-x86_64-nd4j.properties
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/resources/org/bytedeco/javacpp/properties/windows-x86_64-nd4j.properties
@@ -20,4 +20,4 @@ platform.framework=
 platform.library.prefix=
 platform.library.suffix=.dll
 platform.preloadpath=C:/msys64/mingw64/bin/
-platform.preload=libwinpthread-1;libgcc_s_seh-1;libgomp-1;libstdc++-6;libquadmath-0;libgfortran-3;libopenblas;libblas3;libnd4j
+platform.preload=mkl_rt#libopenblas;libwinpthread-1;libgcc_s_seh-1;libgomp-1;libstdc++-6;libquadmath-0;libgfortran-3;libopenblas;libblas3#libopenblas;libnd4j

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <netty.version>4.0.28.Final</netty.version>
         <slf4j.version>1.7.10</slf4j.version>
         <logback.version>1.1.2</logback.version>
-        <javacpp.version>1.2</javacpp.version>
+        <javacpp.version>1.2.1-SNAPSHOT</javacpp.version>
         <process-classes.skip> false</process-classes.skip>  <!-- To skip native compilation phase: -Dprocess-classes.skip=true    -->
         <javacpp.platform>${os.name}-${os.arch}</javacpp.platform> <!-- For Android: -Dplatform=android-arm                                        -->
         <javacpp.platform.root />            <!--              -Dplatform.root=/path/to/android-ndk/                         -->


### PR DESCRIPTION
Relies on changes in https://github.com/bytedeco/javacpp/commit/91762facdb75e7087a8ca65282f5452098e3ed07 and https://github.com/deeplearning4j/libnd4j/pull/199

With these changes, even though there is no need to set the system property (#957) to get MKL loaded from the system, nothing else gets loaded from the system for OpenBLAS by default.