### PR TITLE
memset-less memory initialization

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/Allocator.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/Allocator.java
@@ -113,7 +113,7 @@ public interface Allocator {
      *
      * @param requiredMemory
      */
-    AllocationPoint allocateMemory(DataBuffer buffer,AllocationShape requiredMemory);
+    AllocationPoint allocateMemory(DataBuffer buffer,AllocationShape requiredMemory, boolean initialize);
 
     /**
      * This method allocates required chunk of memory in specific location
@@ -123,7 +123,7 @@ public interface Allocator {
      * @param requiredMemory
      * @param location
      */
-    AllocationPoint allocateMemory(DataBuffer buffer,AllocationShape requiredMemory, AllocationStatus location);
+    AllocationPoint allocateMemory(DataBuffer buffer,AllocationShape requiredMemory, AllocationStatus location, boolean initialize);
 
 
     void memcpyBlocking(DataBuffer dstBuffer, Pointer srcPointer, long length, long dstOffset);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
@@ -322,16 +322,12 @@ public class AtomicAllocator implements Allocator {
      * @param requiredMemory
      */
     @Override
-    public AllocationPoint allocateMemory(DataBuffer buffer,AllocationShape requiredMemory) {
+    public AllocationPoint allocateMemory(DataBuffer buffer,AllocationShape requiredMemory, boolean initialize) {
         // by default we allocate on initial location
         AllocationPoint point = null;
 
         // TODO: size limitation should be rised in final release to something more sensible
-//        if (buffer instanceof CudaIntDataBuffer || AllocationUtils.getRequiredMemory(requiredMemory) / requiredMemory.getLength() <= 2) {
-//            point = allocateMemory(buffer, requiredMemory, AllocationStatus.HOST);
-//        } else {
-            point = allocateMemory(buffer, requiredMemory, memoryHandler.getInitialLocation());
-//        }
+        point = allocateMemory(buffer, requiredMemory, memoryHandler.getInitialLocation(), initialize);
 
         return point;
     }
@@ -345,7 +341,7 @@ public class AtomicAllocator implements Allocator {
      * @param location
      */
     @Override
-    public AllocationPoint allocateMemory(DataBuffer buffer,AllocationShape requiredMemory, AllocationStatus location) {
+    public AllocationPoint allocateMemory(DataBuffer buffer,AllocationShape requiredMemory, AllocationStatus location, boolean initialize) {
         AllocationPoint point = new AllocationPoint();
 
         // we use these longs as tracking codes for memory tracking
@@ -368,7 +364,7 @@ public class AtomicAllocator implements Allocator {
 
 
         // we stay naive on PointersPair, we just don't know on this level, which pointers are set. MemoryHandler will be used for that
-        PointersPair pair = memoryHandler.alloc(location, point, requiredMemory);
+        PointersPair pair = memoryHandler.alloc(location, point, requiredMemory, initialize);
         point.setPointers(pair);
 
         allocationsMap.put(allocId, point);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/MemoryHandler.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/MemoryHandler.java
@@ -55,7 +55,7 @@ public interface MemoryHandler {
      * @param targetMode valid arguments are DEVICE, ZERO
      * @return
      */
-    PointersPair alloc(AllocationStatus targetMode, AllocationPoint point, AllocationShape shape);
+    PointersPair alloc(AllocationStatus targetMode, AllocationPoint point, AllocationShape shape, boolean initialize);
 
     /**
      * This method checks if specified device has free memory

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/handler/impl/CudaZeroHandler.java
@@ -188,7 +188,7 @@ public class CudaZeroHandler implements MemoryHandler {
      * @return
      */
     @Override
-    public PointersPair alloc(AllocationStatus targetMode, AllocationPoint point, AllocationShape shape) {
+    public PointersPair alloc(AllocationStatus targetMode, AllocationPoint point, AllocationShape shape, boolean initialize) {
 
         long reqMemory = AllocationUtils.getRequiredMemory(shape);
         CudaContext context = getCudaContext();
@@ -216,15 +216,11 @@ public class CudaZeroHandler implements MemoryHandler {
                 PointersPair pair = provider.malloc(shape, point, targetMode);
 
 
-                //JCuda.cudaMemsetAsync(new Pointer(pair.getHostPointer().address()), 0, reqMemory, context.getOldStream());
-                //JCuda.cudaStreamSynchronize(context.getOldStream());
-             //   if (point.isConstant()) {
+                if (initialize) {
                     org.bytedeco.javacpp.Pointer.memset(pair.getHostPointer(), 0, reqMemory);
                     point.tickHostWrite();
-            //    } else {
-            //        JCuda.cudaMemsetAsync(new Pointer(pair.getHostPointer().address()), 0, reqMemory, context.getOldStream());
-                    //point.tickHostWrite();
-         //       }
+                }
+
 
                 pickupHostAllocation(point);
 
@@ -238,7 +234,7 @@ public class CudaZeroHandler implements MemoryHandler {
 
                 // if the initial memory location is device, there's a chance we don't have zero memory allocated
                 if (point.getPointers() == null || point.getPointers().getHostPointer() == null) {
-                    tmpPair = alloc(AllocationStatus.HOST, point, point.getShape());
+                    tmpPair = alloc(AllocationStatus.HOST, point, point.getShape(), initialize);
 
                     returnPair.setDevicePointer(tmpPair.getHostPointer());
                     returnPair.setHostPointer(tmpPair.getHostPointer());
@@ -806,7 +802,7 @@ public class CudaZeroHandler implements MemoryHandler {
 
             point.setDeviceId(getDeviceId());
 
-            PointersPair newPointers = alloc(AllocationStatus.DEVICE, point, shape);
+            PointersPair newPointers = alloc(AllocationStatus.DEVICE, point, shape, false);
 
             if (newPointers != null && newPointers.getDevicePointer() != null) {
                 //relocate(AllocationStatus.HOST, AllocationStatus.DEVICE, point, shape);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaDirectProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/jita/memory/impl/CudaDirectProvider.java
@@ -45,10 +45,6 @@ public class CudaDirectProvider implements MemoryProvider {
                 Pointer devicePointer = new Pointer();
                 long reqMem = AllocationUtils.getRequiredMemory(shape);
 
-
-           //     log.info("Allocating {} bytes on [HOST]", reqMem);
-
-
                 // FIXME: this is WRONG, and directly leads to memleak
                 if (reqMem < 1)
                     reqMem = 1;
@@ -58,12 +54,7 @@ public class CudaDirectProvider implements MemoryProvider {
                     throw new RuntimeException("Can't allocate [HOST] memory: " + reqMem);
 
                 Pointer hostPointer = new CudaPointer(pointer);
-/*
-                JCuda.cudaHostGetDevicePointer(
-                        devicePointer,
-                        hostPointer,
-                        0);
-*/
+
                 PointersPair devicePointerInfo = new PointersPair();
                 devicePointerInfo.setDevicePointer(new CudaPointer(hostPointer, reqMem));
                 devicePointerInfo.setHostPointer(new CudaPointer(hostPointer, reqMem));
@@ -76,24 +67,12 @@ public class CudaDirectProvider implements MemoryProvider {
             case DEVICE: {
                 // cudaMalloc call
 
-
-
                 long reqMem = AllocationUtils.getRequiredMemory(shape);
 
-  //              log.info("Allocating {} bytes on [DEVICE]", reqMem);
 
                 // FIXME: this is WRONG, and directly leads to memleak
                 if (reqMem < 1)
                     reqMem = 1;
-/*
-                if (reqMem == 65536 || reqMem == 1048576 || reqMem == 262144)
-                    emergencyCounter.incrementAndGet();
-
-                if (emergencyCounter.get() > 2000)
-                    throw new RuntimeException("PEW");
-*/
-                // FIXME: it would be nice to get rid of typecasting here
-
 
                 long pointer = nativeOps.mallocDevice(reqMem, 0, 0);
                 if (pointer == 0)

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -560,6 +560,14 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
             dataPointers[i] = AtomicAllocator.getInstance().getPointer(toConcat[i], context).address();
             hostShapeInfoPointers[i] = AtomicAllocator.getInstance().getHostPointer(toConcat[i].shapeInfoDataBuffer()).address();
 
+            sumAlongDim += toConcat[i].size(dimension);
+            for(int j = 0; j < toConcat[i].rank(); j++)
+                if(j != dimension) {
+                    if(toConcat[i].size(j) != outputShape[j]) {
+                        throw new IllegalArgumentException("Illegal concatneation at array " + i + " and shape element "  + j);
+                    }
+                }
+
             Pair<DataBuffer, DataBuffer> tadBuffers = tadManager.getTADOnlyShapeInfo(toConcat[i], new int[]{dimension});
 
             long devTadShapeInfo = AtomicAllocator.getInstance().getPointer(tadBuffers.getFirst(), context).address();
@@ -569,6 +577,7 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
 
             tadPointers[i] = devTadShapeInfo;
             offsetsPointers[i] = devTadOffsets;
+
         }
 
         //System.out.println("shapePointers: " + Arrays.toString(shapeInfoPointers));

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -129,30 +129,16 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
     }
 
 
-
-    /**
-     * Base constructor. It's used within all constructors internally
-     *
-     * @param length      the length of the buffer
-     * @param elementSize the size of each element
-     */
-    public BaseCudaDataBuffer(long length, int elementSize) {
+    public BaseCudaDataBuffer(long length, int elementSize, boolean initialize) {
         this.allocationMode = AllocationMode.JAVACPP;
 
-        this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize));
+        this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize), initialize);
         this.length = length;
         //allocationPoint.attachBuffer(this);
         this.elementSize = elementSize;
         this.trackingPoint = allocationPoint.getObjectId();
         this.offset = 0;
         this.originalOffset = 0;
-
-
-//        log.info("ElementSize: " + this.elementSize);
-//        log.info("Host pointer: " + allocationPoint.getPointers().getHostPointer().address());
-//        log.info("Device pointer: " + allocationPoint.getPointers().getDevicePointer().address());
-
-//        log.info("Creating fresh buffer: length: ["+length+"], elementSize: ["+ elementSize+"]");
 
         if (dataType() == Type.DOUBLE) {
             this.pointer = new CudaPointer(allocationPoint.getPointers().getHostPointer(), length,0).asDoublePointer();
@@ -170,11 +156,16 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         if (this.wrappedBuffer == null) {
             throw new IllegalStateException("WrappedBuffer is NULL");
         }
+    }
 
-        // TODO: probably this one could be reconsidered
-//        Long tmpPoint = AtomicAllocator.getInstance().pickupSpan(allocationPoint);
-
-//        log.info("BCDB wrappedBuffer params: " + wrappedBuffer.capacity() + " position: ["+ wrappedBuffer+"]");
+    /**
+     * Base constructor. It's used within all constructors internally
+     *
+     * @param length      the length of the buffer
+     * @param elementSize the size of each element
+     */
+    public BaseCudaDataBuffer(long length, int elementSize) {
+        this(length, elementSize, true);
     }
 
     public BaseCudaDataBuffer(long length, int elementSize, long offset) {
@@ -221,19 +212,19 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
 
     public BaseCudaDataBuffer(float[] data) {
         //super(data);
-        this(data.length, Nd4j.dataType() == Type.DOUBLE ? 8 : 4);
+        this(data.length, Nd4j.dataType() == Type.DOUBLE ? 8 : 4, false);
         set(data, data.length, 0, 0);
     }
 
     public BaseCudaDataBuffer(int[] data) {
         //super(data);
-        this(data.length, Nd4j.dataType() == Type.DOUBLE ? 8 : 4);
+        this(data.length, Nd4j.dataType() == Type.DOUBLE ? 8 : 4, false);
         set(data, data.length, 0, 0);
     }
 
     public BaseCudaDataBuffer(double[] data) {
        // super(data);
-        this(data.length, Nd4j.dataType() == Type.DOUBLE ? 8 : 4);
+        this(data.length, Nd4j.dataType() == Type.DOUBLE ? 8 : 4, false);
         set(data, data.length, 0, 0);
     }
 
@@ -660,7 +651,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
     //        log.info("Restoring buffer ["+t+"] of length ["+ length+"]");
             if(t == Type.DOUBLE) {
                 this.elementSize = 8;
-                this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize));
+                this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize), false);
                 //allocationPoint.attachBuffer(this);
                 this.trackingPoint = allocationPoint.getObjectId();
 
@@ -676,7 +667,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
 
             } else if(t == Type.FLOAT) {
                 this.elementSize = 4;
-                this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize));
+                this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize), false);
                 //allocationPoint.attachBuffer(this);
                 this.trackingPoint = allocationPoint.getObjectId();
 
@@ -692,7 +683,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
 
             } else if(t == Type.INT) {
                 this.elementSize = 4;
-                this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize));
+                this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize), false);
                 this.trackingPoint = allocationPoint.getObjectId();
 
                 this.pointer = new CudaPointer(allocationPoint.getPointers().getHostPointer(), length).asIntPointer();

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/buffer/CudaDoubleDataBuffer.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/buffer/CudaDoubleDataBuffer.java
@@ -235,7 +235,7 @@ public class CudaDoubleDataBuffer extends BaseCudaDataBuffer {
         //wrappedBuffer = ByteBuffer.allocateDirect(length() * getElementSize());
         //wrappedBuffer.order(ByteOrder.nativeOrder());
 
-        this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize));
+        this.allocationPoint = AtomicAllocator.getInstance().allocateMemory(this, new AllocationShape(length, elementSize), false);
         this.trackingPoint = allocationPoint.getObjectId();
         this.wrappedBuffer = allocationPoint.getPointers().getHostPointer().asByteBuffer();
         this.wrappedBuffer.order(ByteOrder.nativeOrder());


### PR DESCRIPTION
added option to create DataBuffers without call to memset.

default behavior still forces memset, but for DataBuffer creation out of java arrays it's forced to false, since anyway memory will be overwritten by subsequent memcpy