### PR TITLE
Use Nd4j.createUninitialized when possible

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -60,6 +60,8 @@ import java.nio.IntBuffer;
 import java.util.*;
 import java.util.Set;
 
+import static org.nd4j.linalg.factory.Nd4j.createUninitialized;
+
 
 /**
  * NDArray: (think numpy)
@@ -2436,7 +2438,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Override
     public INDArray mmul(INDArray other) {
         int[] shape = {rows(), other.columns()};
-        INDArray result = create(shape,'f');
+        INDArray result = createUninitialized(shape,'f');
         if(result.isScalar())
             return Nd4j.scalar(Nd4j.getBlasWrapper().dot(this,other));
         return mmuli(other, result);
@@ -3338,7 +3340,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         }
 
 
-        INDArray ret = Nd4j.create(shape,order);
+        INDArray ret = Nd4j.createUninitialized(shape,order);
         if(order != ordering()) {
             ret.setData(dup(order).data());
         }
@@ -4547,7 +4549,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     protected void read(ObjectInputStream s) {
         shapeInformation = Nd4j.createBuffer(new int[Shape.shapeInfoLength(rank)],0);
         shapeInformation.read(s);
-        data = Nd4j.createBuffer(length);
+        data = Nd4j.createBuffer(length,false);
         data().read(s);
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/convolution/Im2col.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/convolution/Im2col.java
@@ -69,7 +69,7 @@ public class Im2col extends BaseTransformOp {
         int outHeight = Convolution.outSize(h, kernelHeight, strideY, padHeight, coverAll);
         int outWidth = Convolution.outSize(w, kernelWidth, strideX, padWidth, coverAll);
 
-        return Nd4j.create(n, c, kernelHeight, kernelWidth, outHeight, outWidth);
+        return Nd4j.createUninitialized(new int[]{n, c, kernelHeight, kernelWidth, outHeight, outWidth},'c');
     }
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
@@ -146,9 +146,7 @@ public class Shape {
             char outOrder = (anyOrder ? arr.ordering() : order);
             if(outOrder == 'a')
                 outOrder = Nd4j.order();
-//            System.out.println("ShapeInfo on original: " + arr.shapeInfoDataBuffer() + " isView: " + arr.isView());
-            INDArray z = Nd4j.create(arr.shape(),outOrder);
-//            System.out.println("ShapeInfo on dup(): " + z.shapeInfoDataBuffer());
+            INDArray z = Nd4j.createUninitialized(arr.shape(),outOrder);
             z.assign(arr);
             return z;
         }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/checkutil/CheckUtil.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/checkutil/CheckUtil.java
@@ -191,6 +191,12 @@ public class CheckUtil {
 			for( int j = 0; j < outShape[1]; j++) {
 				double expOut = rmResult.getEntry(i, j);
 				double actOut = result.getDouble(i,j);
+
+                if(Double.isNaN(actOut)){
+                    System.out.println("NaN failure on value: (" +i+","+j+" exp="+expOut + ", act="+actOut);
+                    return false;
+                }
+
 				if(expOut==0.0 && actOut==0.0)
                     continue;
 				double absError = Math.abs(expOut - actOut);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
@@ -911,21 +911,9 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray valueArrayOf(int[] shape, double value) {
-        INDArray create = null;
-        if(Nd4j.dataType() == DataBuffer.Type.DOUBLE) {
-            double[] vals = new double[ArrayUtil.prod(shape)];
-            if(value != 0.0)
-                Arrays.fill(vals,value);
-            create = Nd4j.create(vals,shape);
-        }
-        else if(Nd4j.dataType() == DataBuffer.Type.FLOAT) {
-            float[] vals = new float[ArrayUtil.prod(shape)];
-            if(value != 0.0)
-                Arrays.fill(vals,(float) value);
-            create = Nd4j.create(vals,shape);
-        }
-
-        return create;
+        INDArray ret = Nd4j.createUninitialized(shape, Nd4j.order());
+        ret.assign(value);
+        return ret;
     }
 
     @Override
@@ -947,7 +935,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray valueArrayOf(int rows, int columns, double value) {
-        INDArray create = create(rows, columns);
+        INDArray create = createUninitialized(new int[]{rows, columns},Nd4j.order());
         create.assign(value);
         return create;
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -4237,7 +4237,7 @@ public class Nd4j {
     }
 
     /**
-     * Creates an ndarray with the specified value
+     * Creates a row vector ndarray with the specified value
      * as the  only value in the ndarray
      *
      * @param num   number of columns

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -701,7 +701,7 @@ public class Nd4j {
     public static INDArray gemm(INDArray a, INDArray b, boolean transposeA, boolean transposeB){
         int cRows = (transposeA ? a.columns() : a.rows() );
         int cCols = (transposeB ? b.rows() : b.columns() );
-        INDArray c = Nd4j.create(new int[]{cRows, cCols}, 'f');
+        INDArray c = Nd4j.createUninitialized(new int[]{cRows, cCols}, 'f');
         return gemm(a, b, c, transposeA, transposeB, 1.0, 0.0);
     }
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -545,9 +545,8 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
         int[] outputShape = ArrayUtil.copy(toConcat[0].shape());
 
         outputShape[dimension] = sumAlongDim;
-        int[] sortedStrides = Nd4j.getStrides(outputShape);
 
-        INDArray ret = Nd4j.create(outputShape,sortedStrides);
+        INDArray ret = Nd4j.createUninitialized(outputShape,Nd4j.order());
 
         AtomicAllocator allocator = AtomicAllocator.getInstance();
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
@@ -584,11 +584,9 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
 
         outputShape[dimension] = sumAlongDim;
 
-        int[] sortedStrides = Nd4j.getStrides(outputShape);
-
         long dummy[] = new long[1];
 
-        INDArray ret = Nd4j.create(outputShape,sortedStrides);
+        INDArray ret = Nd4j.createUninitialized(outputShape,Nd4j.order());
         if(ret.data().dataType() == DataBuffer.Type.DOUBLE) {
             nativeOps.concatDouble(
                     dummy,

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsComparisonC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsComparisonC.java
@@ -119,6 +119,24 @@ public  class Nd4jTestsComparisonC extends BaseNd4jTest {
                                 true, false, a, b, 1e-4, 1e-6));
                         assertTrue(errorMsgtt, CheckUtil.checkGemm(p1T.getFirst(), p2T.getFirst(), ctt,
                                 true, true, a, b, 1e-4, 1e-6));
+
+                        //Also: Confirm that if the C array is uninitialized and beta is 0.0, we don't have issues like 0*NaN = NaN
+                        if(b == 0.0){
+                            cff.assign(Double.NaN);
+                            cft.assign(Double.NaN);
+                            ctf.assign(Double.NaN);
+                            ctt.assign(Double.NaN);
+
+                            assertTrue(errorMsgff, CheckUtil.checkGemm(p1.getFirst(), p2.getFirst(), cff,
+                                    false, false, a, b, 1e-4, 1e-6));
+                            assertTrue(errorMsgft, CheckUtil.checkGemm(p1.getFirst(), p2T.getFirst(), cft,
+                                    false, true, a, b, 1e-4, 1e-6));
+                            assertTrue(errorMsgtf, CheckUtil.checkGemm(p1T.getFirst(), p2.getFirst(), ctf,
+                                    true, false, a, b, 1e-4, 1e-6));
+                            assertTrue(errorMsgtt, CheckUtil.checkGemm(p1T.getFirst(), p2T.getFirst(), ctt,
+                                    true, true, a, b, 1e-4, 1e-6));
+                        }
+
                     }
                 }
             }


### PR DESCRIPTION

Used in the following situations:
- Nd4j.valueArrayOf
- dup()
- im2col
- concat
- mmul/gemm (for results array)
- Uninitialized buffer for deserialization
