### PR TITLE
Dataset preprocessor warnings and tests

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/StandardScaler.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/StandardScaler.java
@@ -11,12 +11,16 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Standard scaler calculates a moving column wise
  * variance and mean
  * http://www.johndcook.com/blog/standard_deviation/
  */
 public class StandardScaler {
+    private static Logger logger = LoggerFactory.getLogger(StandardScaler.class);
     private INDArray mean,std;
     private int runningTotal = 0;
 
@@ -24,6 +28,9 @@ public class StandardScaler {
     public void fit(DataSet dataSet) {
         mean = dataSet.getFeatureMatrix().mean(0);
         std = dataSet.getFeatureMatrix().std(0);
+        std.addi(Nd4j.scalar(Nd4j.EPS_THRESHOLD));
+        if (std.min(1) == Nd4j.scalar(Nd4j.EPS_THRESHOLD)) 
+            logger.info("API_INFO: Std deviation found to be zero. Transform will round upto epsilon to avoid nans.");
     }
 
     /**
@@ -65,6 +72,9 @@ public class StandardScaler {
         }
         std.divi(runningTotal);
         std = Transforms.sqrt(std);
+        std.addi(Nd4j.scalar(Nd4j.EPS_THRESHOLD));
+        if (std.min(1) == Nd4j.scalar(Nd4j.EPS_THRESHOLD)) 
+            logger.info("API_INFO: Std deviation found to be zero. Transform will round upto epsilon to avoid nans.");
         iterator.reset();
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/NormalizerStandardize.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/NormalizerStandardize.java
@@ -8,12 +8,16 @@ import org.nd4j.linalg.factory.Nd4j;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Standard scaler calculates a moving column wise
  * variance and mean
  * http://www.johndcook.com/blog/standard_deviation/
  */
 public class NormalizerStandardize implements org.nd4j.linalg.dataset.api.DataSetPreProcessor {
+    private static Logger logger = LoggerFactory.getLogger(NormalizerStandardize.class);
     private INDArray mean,std;
     private int runningTotal = 0;
 
@@ -26,6 +30,8 @@ public class NormalizerStandardize implements org.nd4j.linalg.dataset.api.DataSe
         mean = dataSet.getFeatureMatrix().mean(0);
         std = dataSet.getFeatureMatrix().std(0);
         std.addi(Nd4j.scalar(Nd4j.EPS_THRESHOLD));
+        if (std.min(1) == Nd4j.scalar(Nd4j.EPS_THRESHOLD)) 
+            logger.info("API_INFO: Std deviation found to be zero. Transform will round upto epsilon to avoid nans.");
     }
 
     /**
@@ -68,6 +74,8 @@ public class NormalizerStandardize implements org.nd4j.linalg.dataset.api.DataSe
         std.divi(runningTotal);
         std = Transforms.sqrt(std);
         std.addi(Nd4j.scalar(Nd4j.EPS_THRESHOLD));
+        if (std.min(1) == Nd4j.scalar(Nd4j.EPS_THRESHOLD)) 
+            logger.info("API_INFO: Std deviation found to be zero. Transform will round upto epsilon to avoid nans.");
         iterator.reset();
     }
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/NormalizerMinMaxScalerTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/NormalizerMinMaxScalerTest.java
@@ -152,6 +152,26 @@ public class NormalizerMinMaxScalerTest  extends BaseNd4jTest {
         assertTrue(maxdeltaPerc < tolerancePerc);
     }
 
+    @Test
+    public void testConstant() {
+        double tolerancePerc = 0.01; // 0.01% of correct value
+        int nSamples = 500;
+        int nFeatures = 3;
+
+        INDArray featureSet = Nd4j.zeros(nSamples,nFeatures).add(100);
+        INDArray labelSet = Nd4j.zeros(nSamples, 1);
+        DataSet sampleDataSet = new DataSet(featureSet, labelSet);
+
+        NormalizerMinMaxScaler myNormalizer = new NormalizerMinMaxScaler();
+        myNormalizer.fit(sampleDataSet);
+        myNormalizer.transform(sampleDataSet);
+        assertFalse (Double.isNaN(sampleDataSet.getFeatures().min(0,1).getDouble(0)));
+        assertEquals(sampleDataSet.getFeatures().sumNumber().doubleValue(),0,0.00001);
+        myNormalizer.revert(sampleDataSet);
+        assertFalse (Double.isNaN(sampleDataSet.getFeatures().min(0,1).getDouble(0)));
+        assertEquals(sampleDataSet.getFeatures().sumNumber().doubleValue(),100*nFeatures*nSamples,0.00001);
+    }
+
     @Override
     public char ordering() {
         return 'c';

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/NormalizerStandardizeTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/NormalizerStandardizeTest.java
@@ -196,6 +196,27 @@ public class NormalizerStandardizeTest extends BaseNd4jTest {
 
     }
 
+    @Test
+    public void testConstant() {
+        double tolerancePerc = 0.01; // 0.01% of correct value
+        int nSamples = 500;
+        int nFeatures = 3;
+
+        INDArray featureSet = Nd4j.zeros(nSamples,nFeatures).add(100);
+        INDArray labelSet = Nd4j.zeros(nSamples, 1);
+        DataSet sampleDataSet = new DataSet(featureSet, labelSet);
+
+        NormalizerStandardize myNormalizer = new NormalizerStandardize();
+        myNormalizer.fit(sampleDataSet);
+        assertFalse (Double.isNaN(myNormalizer.getStd().getDouble(0)));
+        myNormalizer.transform(sampleDataSet);
+        assertFalse (Double.isNaN(sampleDataSet.getFeatures().min(0,1).getDouble(0)));
+        assertEquals(sampleDataSet.getFeatures().sumNumber().doubleValue(),0,0.00001);
+        myNormalizer.revert(sampleDataSet);
+        assertFalse (Double.isNaN(sampleDataSet.getFeatures().min(0,1).getDouble(0)));
+        assertEquals(sampleDataSet.getFeatures().sumNumber().doubleValue(),100*nFeatures*nSamples,0.00001);
+    }
+
     public class genRandomDataSet {
         /* generate random dataset from normally distributed mean 0, std 1
         based on given seed and scaling constants


### PR DESCRIPTION
Variance of a constant array was returning nans.
https://github.com/deeplearning4j/libnd4j/pull/233

Dataset preprocessors now has warnings if a roundup is done to avoid div by zero.
More tests for preprocessors.