### PR TITLE
eps bug with number argument

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -1201,7 +1201,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public INDArray epsi(Number other) {
-        return Nd4j.getExecutioner().execAndReturn(new Eps(this));
+        INDArray otherArr = this.mul(0).add(other);
+        return dup().eps(otherArr);
     }
 
     /**

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/ops/OpExecutionerTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/ops/OpExecutionerTestsC.java
@@ -648,6 +648,17 @@ public  class OpExecutionerTestsC extends BaseNd4jTest {
         assertEquals(exp,var,1e-7f);
     }
 
+    @Test
+    public void testEpsOps() {
+        INDArray ones = Nd4j.ones(6);
+        double tiny = 1.000000000000000000000000000001;
+        assertTrue(ones.eps(tiny).sumNumber().doubleValue() == 6);
+        INDArray consec = Nd4j.linspace(1,6,6);
+        assertTrue(consec.eps(5).sumNumber().doubleValue() == 1);
+        assertTrue(consec.sub(1).eps(5).sumNumber().doubleValue() == 1);
+        assertTrue(consec.sub(1).eps(5).getDouble(0,5) == 1);
+    }
+
     @Override
     public char ordering() {
         return 'c';


### PR DESCRIPTION
Issue: https://github.com/deeplearning4j/nd4j/issues/1007
If eps is used with a single number as an argument instead of an array it gets incorrectly routed - as in no longer as a pairwise transform and ending up with the op number of the non-pair transform. aka the sigmoid.
Also added test.