### PR TITLE
Introduce artifacts that pull backend binaries for all platforms

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5-platform/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5-platform/pom.xml
@@ -1,0 +1,86 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>nd4j-backend-impls</artifactId>
+        <groupId>org.nd4j</groupId>
+        <version>0.4-rc3.11-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>nd4j-cuda-7.5-platform</artifactId>
+    <packaging>jar</packaging>
+
+    <name>nd4j-cuda-7.5-platform</name>
+
+    <properties>
+        <nd4j.backend>nd4j-cuda-7.5</nd4j.backend>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform0}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform1}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform2}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform3}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform4}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform5}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform6}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform7}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform8}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform9}</classifier>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native-platform/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native-platform/pom.xml
@@ -1,0 +1,86 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>nd4j-backend-impls</artifactId>
+        <groupId>org.nd4j</groupId>
+        <version>0.4-rc3.11-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>nd4j-native-platform</artifactId>
+    <packaging>jar</packaging>
+
+    <name>nd4j-native-platform</name>
+
+    <properties>
+        <nd4j.backend>nd4j-native</nd4j.backend>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform0}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform1}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform2}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform3}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform4}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform5}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform6}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform7}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform8}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${javacpp.platform9}</classifier>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -13,7 +13,9 @@
 
     <modules>
         <module>nd4j-native</module>
+        <module>nd4j-native-platform</module>
         <module>nd4j-cuda-7.5</module>
+        <module>nd4j-cuda-7.5-platform</module>
     </modules>
     <dependencies>
         <dependency>
@@ -29,6 +31,16 @@
         <dependency.version>${project.version}</dependency.version>
         <dependency.packaging>${project.packaging}</dependency.packaging>
         <dependency.classifier>${javacpp.platform}</dependency.classifier>
+        <javacpp.platform0></javacpp.platform0>
+        <javacpp.platform1>linux-x86_64</javacpp.platform1>
+        <javacpp.platform2>macosx-x86_64</javacpp.platform2>
+        <javacpp.platform3>windows-x86_64</javacpp.platform3>
+        <javacpp.platform4>linux-ppc64le</javacpp.platform4>
+        <javacpp.platform5></javacpp.platform5>
+        <javacpp.platform6></javacpp.platform6>
+        <javacpp.platform7></javacpp.platform7>
+        <javacpp.platform8></javacpp.platform8>
+        <javacpp.platform9></javacpp.platform9>
     </properties>
 
 
@@ -116,5 +128,82 @@
                 <dependency.classifier />
             </properties>
         </profile>
+
+        <profile>
+            <id>javacpp-platform-zero</id>
+            <activation>
+                <file>
+                    <exists>${user.dir}</exists>
+                </file>
+            </activation>
+            <properties>
+                <javacpp.platform0>${javacpp.platform}</javacpp.platform0>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp-platform-one</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform0>${javacpp.platform}</javacpp.platform0>
+                <javacpp.platform1>${javacpp.platform}</javacpp.platform1>
+                <javacpp.platform2>${javacpp.platform}</javacpp.platform2>
+                <javacpp.platform3>${javacpp.platform}</javacpp.platform3>
+                <javacpp.platform4>${javacpp.platform}</javacpp.platform4>
+                <javacpp.platform5>${javacpp.platform}</javacpp.platform5>
+                <javacpp.platform6>${javacpp.platform}</javacpp.platform6>
+                <javacpp.platform7>${javacpp.platform}</javacpp.platform7>
+                <javacpp.platform8>${javacpp.platform}</javacpp.platform8>
+                <javacpp.platform9>${javacpp.platform}</javacpp.platform9>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp-platform-none</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform</name>
+                    <value>none</value>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform0></javacpp.platform0>
+                <javacpp.platform1></javacpp.platform1>
+                <javacpp.platform2></javacpp.platform2>
+                <javacpp.platform3></javacpp.platform3>
+                <javacpp.platform4></javacpp.platform4>
+                <javacpp.platform5></javacpp.platform5>
+                <javacpp.platform6></javacpp.platform6>
+                <javacpp.platform7></javacpp.platform7>
+                <javacpp.platform8></javacpp.platform8>
+                <javacpp.platform9></javacpp.platform9>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp-platform-build</id>
+            <activation>
+                <file>
+                    <exists>${basedir}</exists>
+                </file>
+            </activation>
+            <properties>
+                <javacpp.platform0></javacpp.platform0>
+                <javacpp.platform1></javacpp.platform1>
+                <javacpp.platform2></javacpp.platform2>
+                <javacpp.platform3></javacpp.platform3>
+                <javacpp.platform4></javacpp.platform4>
+                <javacpp.platform5></javacpp.platform5>
+                <javacpp.platform6></javacpp.platform6>
+                <javacpp.platform7></javacpp.platform7>
+                <javacpp.platform8></javacpp.platform8>
+                <javacpp.platform9></javacpp.platform9>
+            </properties>
+        </profile>
     </profiles>
+
 </project>


### PR DESCRIPTION
To use the new functionality users will need to switch dependencies on `nd4j-native` to `nd4j-native-platform`, and `nd4j-cuda-7.5` to `nd4j-cuda-7.5-platform`, but that's it!

It works the same with either Maven, Gradle, or sbt: All binaries for all platforms get downloaded, added to uber JARs (for cross-platform deployment on Spark), etc. But it won't work when building against SNAPSHOT versions where binaries for all platforms are not available. In that case, we need to call Maven with `-Djavacpp.platform=linux-x86_64` or whatever platform we have binaries for. If this still sounds like something we want though, please merge!