### PR TITLE
Fix: squid:S1149, Synchronized classes Vector and StringBuffer should…

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/exception/BlasOpErrorMessage.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/exception/BlasOpErrorMessage.java
@@ -19,7 +19,7 @@ public class BlasOpErrorMessage implements Serializable {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer().append("Op " + op.name() + " of length " + op.n()).append(" will fail with x of " + shapeInfo(op.x()));
+        StringBuilder sb = new StringBuilder().append("Op " + op.name() + " of length " + op.n()).append(" will fail with x of " + shapeInfo(op.x()));
         if(op.y() != null) {
             sb.append(" y of " + shapeInfo(op.y()));
         }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
@@ -1586,7 +1586,7 @@ public class Shape {
         IntBuffer shapeBuff = shapeOf(buffer);
         int rank = Shape.rank(buffer);
         IntBuffer strideBuff = stride(buffer);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("Rank: " + rank + ",");
         sb.append("Offset: " + Shape.offset(buffer) + "\n");
         sb.append(" Order: " + Shape.order(buffer));
@@ -1790,7 +1790,7 @@ public class Shape {
      * @return
      */
     public static String toString(IntBuffer buffer) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for(int i = 0; i < buffer.capacity(); i++) {
             sb.append(buffer.get(i));
             if(i < buffer.capacity() - 1)

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -1951,7 +1951,7 @@ public class Nd4j {
     public static void writeNumpy(INDArray write, String filePath, String split) throws IOException {
         BufferedWriter writer = new BufferedWriter(new FileWriter(filePath));
         for (int i = 0; i < write.rows(); i++) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             INDArray row = write.getRow(i);
             for (int j = 0; j < row.columns(); j++) {
                 sb.append(row.getDouble(j));

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/string/NDArrayStrings.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/string/NDArrayStrings.java
@@ -60,7 +60,7 @@ public class NDArrayStrings {
     }
 
     private String format(INDArray arr,int rank, int offset) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if(arr.isScalar()) {
             if(arr instanceof IComplexNDArray)
                 return ((IComplexNDArray) arr).getComplex(0).toString();

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -616,7 +616,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("[");
         for(int i = 0; i < length(); i++) {
             sb.append(getDouble(i));

--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -1258,7 +1258,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
 
     @Override
     public String toString() {
-        StringBuffer ret = new StringBuffer();
+        StringBuilder ret = new StringBuilder();
         ret.append("[");
         for(int i = 0; i < length(); i++) {
             ret.append(getNumber(i));

--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/util/LibUtils.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/util/LibUtils.java
@@ -205,7 +205,7 @@ public final class LibUtils
         String resourceFolder = os + "-" + arch;
         String libPrefix = createLibPrefix();
         String libExtension = createLibExtension();
-        StringBuffer sb = new StringBuffer()
+        StringBuilder sb = new StringBuilder()
                 .append(libName.getPackage().getName().replace(".","/") + "/")
                 .append(resourceFolder).append("/").append(libPrefix).append("jni" + libName.getSimpleName() + ".")
                 .append(libExtension);

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/Bernoulli.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/Bernoulli.java
@@ -25,6 +25,8 @@ package org.nd4j.linalg.util;
  */
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -36,7 +38,7 @@ class Bernoulli {
      * The list of all Bernoulli numbers as a vector, n=0,2,4,....
      */
 
-    static Vector<Rational> a = new Vector<Rational>();
+    static List<Rational> a = new ArrayList<Rational>();
 
     public Bernoulli() {
         if (a.size() == 0) {
@@ -81,7 +83,7 @@ class Bernoulli {
                     set(i, doubleSum(i));
                 }
             }
-            return a.elementAt(nindx);
+            return a.get(nindx);
         }
     }
     /* Generate a new B_n by a standard double sum.

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/Factorial.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/Factorial.java
@@ -25,6 +25,8 @@ package org.nd4j.linalg.util;
  */
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -35,7 +37,7 @@ class Factorial {
     /**
      * The list of all factorials as a vector.
      */
-    static Vector<BigInteger> a = new Vector<>();
+    static List<BigInteger> a = new ArrayList<>();
 
     /**
      * ctor().
@@ -58,8 +60,8 @@ class Factorial {
         while (a.size() <= n) {
             final int lastn = a.size() - 1;
             final BigInteger nextn = new BigInteger("" + (lastn + 1));
-            a.add(a.elementAt(lastn).multiply(nextn));
+            a.add(a.get(lastn).multiply(nextn));
         }
-        return a.elementAt(n);
+        return a.get(n);
     }
 } /* Factorial */

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/MathUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/MathUtils.java
@@ -1126,7 +1126,7 @@ public class MathUtils {
      * double in the vector
      */
     public static int distanceFinderZValue(double[] vector) {
-        StringBuffer binaryBuffer = new StringBuffer();
+        StringBuilder binaryBuffer = new StringBuilder();
         List<String> binaryReps = new ArrayList<String>(vector.length);
         for (int i = 0; i < vector.length; i++) {
             double d = vector[i];

--- a/nd4j-serde/nd4j-base64/src/main/java/org/nd4j/serde/base64/Nd4jBase64.java
+++ b/nd4j-serde/nd4j-base64/src/main/java/org/nd4j/serde/base64/Nd4jBase64.java
@@ -40,7 +40,7 @@ public class Nd4jBase64 {
      * @throws IOException
      */
     public static String arraysToBase64(INDArray[] arrays) throws IOException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         //tab separate the outputs for de serialization
         for(INDArray outputArr : arrays) {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149

 Please let me know if you have any questions.
Ayman Elkfrawy.