### PR TITLE
Fix: squid:S2095, Resources should be closed

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2138,10 +2138,18 @@ public class Nd4j {
         InputStream is = null;
         try {
             is = new FileInputStream(file);
+            return readTxtString(is, sep);
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
+        } finally {
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
         }
-        return readTxtString(is,sep);
     }
 
     /**

--- a/nd4j-serde/nd4j-kryo/src/main/java/org/nd4j/Nd4jSerializer.java
+++ b/nd4j-serde/nd4j-kryo/src/main/java/org/nd4j/Nd4jSerializer.java
@@ -32,6 +32,12 @@ public class Nd4jSerializer extends Serializer<INDArray> {
             Nd4j.write(object,dos);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            try {
+                dos.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 
@@ -57,6 +63,12 @@ public class Nd4jSerializer extends Serializer<INDArray> {
             return Nd4j.read(dis);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            try {
+                dis.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
This pull request fixes the previous pull request problem which was solving the sonar rule:
squid:S2095 - “Resources should be closed”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095

Please let me know if you have any questions.
Ayman Elkfrawy.