### PR TITLE
Fix: squid:S2583, Conditions should not unconditionally evaluate to "…

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/complex/BaseComplexNDArray.java
@@ -3288,12 +3288,10 @@ public abstract class BaseComplexNDArray extends BaseNDArray implements IComplex
      */
     @Override
     public boolean equals(Object o) {
-        IComplexNDArray n = null;
-        if (!(o instanceof IComplexNDArray))
+        if (!(o instanceof IComplexNDArray)) {
             return false;
-
-        if (n == null)
-            n = (IComplexNDArray) o;
+        }
+        IComplexNDArray n = (IComplexNDArray) o;
 
         //epsilon equals
         if (isScalar() && n.isScalar()) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -3776,13 +3776,10 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public boolean equals(Object o) {
-        INDArray n = null;
-
         if (!(o instanceof INDArray))
             return false;
 
-        if (n == null)
-            n = (INDArray) o;
+        INDArray n = (INDArray) o;
 
         //epsilon equals
         if (isScalar() && n.isScalar()) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Or.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Or.java
@@ -50,7 +50,7 @@ public class Or implements Condition {
         if (!ret)
             return false;
         for (int i = 1; i < conditions.length; i++) {
-            ret = ret || conditions[i].apply(input);
+            ret = conditions[i].apply(input);
         }
         return ret;
     }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/JCudaExecutioner.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/JCudaExecutioner.java
@@ -712,9 +712,6 @@ public class JCudaExecutioner extends DefaultOpExecutioner {
             }
         }
         else {
-            if (dimension == null)
-                dimension = new int[] {0};
-
             Arrays.sort(dimension);
 
             Pointer z = AtomicAllocator.getInstance().getPointer(op.z(), context);

--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/util/LibUtils.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/util/LibUtils.java
@@ -86,27 +86,17 @@ public final class LibUtils
         String libName = LibUtils.createLibName(baseName);
 
         Throwable throwable = null;
-        final boolean tryResource = true;
-        if (tryResource)
-        {
-            try
-            {
-                loadLibraryResource(libName);
-                return;
-            }
-            catch (Throwable t)
-            {
-                throwable = t;
-            }
+        try {
+            loadLibraryResource(libName);
+            return;
+        } catch (Throwable t) {
+            throwable = t;
         }
 
-        try
-        {
+        try {
             System.loadLibrary(libName);
             return;
-        }
-        catch (Throwable t)
-        {
+        } catch (Throwable t) {
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
 

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/ArrayUtil.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/ArrayUtil.java
@@ -807,9 +807,6 @@ public class ArrayUtil {
 
         if (index >= data.length)
             throw new IllegalArgumentException("Unable to remove index " + index + " was >= data.length");
-
-        if (data == null)
-            return null;
         if (data.length < 1)
             return data;
         if (index < 0)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2583 - “ Conditions should not unconditionally evaluate to "TRUE" or to "FALSE" ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2583

 Please let me know if you have any questions.
Ayman Elkfrawy"