### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/NdArrayJSONWriter.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/NdArrayJSONWriter.java
@@ -9,7 +9,10 @@ import java.io.IOException;
  * Created by susaneraly on 6/18/16.
  */
 public class NdArrayJSONWriter {
-    public static void write(INDArray thisnD,String filePath) {
+    private NdArrayJSONWriter() {
+    }
+
+    public static void write(INDArray thisnD, String filePath) {
         //TO DO: Add precision support in toString
         //TO DO: Write to file one line at time
         String lineOne = "{\n";

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/OpExecutionerUtil.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/OpExecutionerUtil.java
@@ -12,6 +12,9 @@ import java.util.Arrays;
  */
 public class OpExecutionerUtil {
 
+    private OpExecutionerUtil() {
+    }
+
     /** Can we do the op (X = Op(X)) directly on the arrays without breaking X up into 1d tensors first?
      * In general, this is possible if the elements of X are contiguous in the buffer, OR if every element
      * of X is at position offset+i*elementWiseStride in the buffer

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
@@ -50,6 +50,9 @@ public class Shape {
 
     private static Logger logger = LoggerFactory.getLogger(Shape.class);
 
+    private Shape() {
+    }
+
     /**
      * Create a copy of the matrix
      * where the new offset is zero

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/checkutil/NDArrayCreationUtil.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/checkutil/NDArrayCreationUtil.java
@@ -23,6 +23,9 @@ import java.util.List;
  * @author Alex Black
  */
 public class NDArrayCreationUtil {
+    private NDArrayCreationUtil() {
+    }
+
     /** Get an array of INDArrays (2d) all with the specified shape. Pair<INDArray,String> returned to aid
      * debugging: String contains information on how to reproduce the matrix (i.e., which function, and arguments)
      * Each NDArray in the returned array has been obtained by applying an operation such as transpose, tensorAlongDimension,

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/convolution/OldConvolution.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/convolution/OldConvolution.java
@@ -7,6 +7,9 @@ import org.nd4j.linalg.indexing.NDArrayIndex;
 
 public class OldConvolution {
 
+    private OldConvolution() {
+    }
+
     /**
      *
      * @param col

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/PCA.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/PCA.java
@@ -33,6 +33,9 @@ import org.nd4j.linalg.indexing.NDArrayIndex;
  */
 public class PCA {
 
+    private PCA() {
+    }
+
     /**
      * Reduce the dimension of x
      * to the specified number of dimensions.

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/heartbeat/utils/TaskUtils.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/heartbeat/utils/TaskUtils.java
@@ -9,6 +9,9 @@ import org.nd4j.linalg.heartbeat.reports.Task;
  * @author raver119@gmail.com
  */
 public class TaskUtils {
+    private TaskUtils() {
+    }
+
     public static Task buildTask(INDArray[] array, INDArray[] labels) {
         Task task = new Task();
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/ops/transforms/Transforms.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/ops/transforms/Transforms.java
@@ -49,6 +49,8 @@ import java.util.List;
 public class Transforms {
 
 
+    private Transforms() {
+    }
 
     /**
      * Cosine similarity

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/NDArrayMath.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/NDArrayMath.java
@@ -10,6 +10,9 @@ import java.util.Arrays;
 public class NDArrayMath {
 
 
+    private NDArrayMath() {
+    }
+
     /**
      * Compute the offset for a given slice
      * @param arr the array to compute

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/NDArrayUtil.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/NDArrayUtil.java
@@ -10,6 +10,9 @@ import org.nd4j.linalg.factory.Nd4j;
  */
 public class NDArrayUtil {
 
+    private NDArrayUtil() {
+    }
+
     public static INDArray toNDArray(int[][] nums) {
         if (Nd4j.dataType() == DataBuffer.Type.DOUBLE) {
             double[] doubles = ArrayUtil.toDoubles(nums);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/util/OpUtil.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/util/OpUtil.java
@@ -6,6 +6,9 @@ package org.nd4j.linalg.jcublas.util;
  */
 public class OpUtil {
 
+    private OpUtil() {
+    }
+
     /**
      * Return op for the given character
      * throws an @link{IllegalArgumentException}

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/ndarray/TestJSON.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/ndarray/TestJSON.java
@@ -27,8 +27,7 @@ public class TestJSON extends BaseNd4jTest{
     @Test
     public void TestReadWrite() {
         INDArray origArr = Nd4j.rand('c',10,10).muli(100); //since we write only two decimal points..
-        NdArrayJSONWriter jsonWriter = new NdArrayJSONWriter();
-        jsonWriter.write(origArr,"someArr.json");
+        NdArrayJSONWriter.write(origArr,"someArr.json");
 
         NdArrayJSONReader jsonReader = new NdArrayJSONReader();
         INDArray readBack = jsonReader.read(new File("someArr.json"));
@@ -47,8 +46,7 @@ public class TestJSON extends BaseNd4jTest{
     @Test
     public void TestReadWriteSimple() {
         INDArray origArr = Nd4j.rand(1,1).muli(100); //since we write only two decimal points..
-        NdArrayJSONWriter jsonWriter = new NdArrayJSONWriter();
-        jsonWriter.write(origArr,"someArr.json");
+        NdArrayJSONWriter.write(origArr,"someArr.json");
 
         NdArrayJSONReader jsonReader = new NdArrayJSONReader();
         INDArray readBack = jsonReader.read(new File("someArr.json"));
@@ -67,8 +65,7 @@ public class TestJSON extends BaseNd4jTest{
     @Test
     public void TestReadWriteNd() {
         INDArray origArr = Nd4j.rand(13,2,11,3,7,19).muli(100); //since we write only two decimal points..
-        NdArrayJSONWriter jsonWriter = new NdArrayJSONWriter();
-        jsonWriter.write(origArr,"someArr.json");
+        NdArrayJSONWriter.write(origArr,"someArr.json");
 
         NdArrayJSONReader jsonReader = new NdArrayJSONReader();
         INDArray readBack = jsonReader.read(new File("someArr.json"));
@@ -88,8 +85,7 @@ public class TestJSON extends BaseNd4jTest{
     @Test
     public void TestWierdShape() {
         INDArray origArr = Nd4j.rand(1,1,2,1,1).muli(100); //since we write only two decimal points..
-        NdArrayJSONWriter jsonWriter = new NdArrayJSONWriter();
-        jsonWriter.write(origArr,"someArr.json");
+        NdArrayJSONWriter.write(origArr,"someArr.json");
 
         NdArrayJSONReader jsonReader = new NdArrayJSONReader();
         INDArray readBack = jsonReader.read(new File("someArr.json"));

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/ndarray/TestJSONC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/ndarray/TestJSONC.java
@@ -26,8 +26,7 @@ public class TestJSONC extends BaseNd4jTest{
     @Test
     public void TestReadWrite() {
         INDArray origArr = Nd4j.rand('c',10,10).muli(100); //since we write only two decimal points..
-        NdArrayJSONWriter jsonWriter = new NdArrayJSONWriter();
-        jsonWriter.write(origArr,"someArr.json");
+        NdArrayJSONWriter.write(origArr,"someArr.json");
 
         NdArrayJSONReader jsonReader = new NdArrayJSONReader();
         INDArray readBack = jsonReader.read(new File("someArr.json"));
@@ -46,9 +45,7 @@ public class TestJSONC extends BaseNd4jTest{
     @Test
     public void TestReadWriteSimple() {
         INDArray origArr = Nd4j.rand(1,1).muli(100); //since we write only two decimal points..
-        NdArrayJSONWriter jsonWriter = new NdArrayJSONWriter();
-        jsonWriter.write(origArr,"someArr.json");
-
+        NdArrayJSONWriter.write(origArr,"someArr.json");
         NdArrayJSONReader jsonReader = new NdArrayJSONReader();
         INDArray readBack = jsonReader.read(new File("someArr.json"));
         System.out.println("=========================================================================");
@@ -66,8 +63,7 @@ public class TestJSONC extends BaseNd4jTest{
     @Test
     public void TestReadWriteNd() {
         INDArray origArr = Nd4j.rand(13,2,11,3,7,19).muli(100); //since we write only two decimal points..
-        NdArrayJSONWriter jsonWriter = new NdArrayJSONWriter();
-        jsonWriter.write(origArr,"someArr.json");
+        NdArrayJSONWriter.write(origArr,"someArr.json");
 
         NdArrayJSONReader jsonReader = new NdArrayJSONReader();
         INDArray readBack = jsonReader.read(new File("someArr.json"));
@@ -86,8 +82,7 @@ public class TestJSONC extends BaseNd4jTest{
     @Test
     public void TestWierdShape() {
         INDArray origArr = Nd4j.rand(1,1,2,1,1).muli(100); //since we write only two decimal points..
-        NdArrayJSONWriter jsonWriter = new NdArrayJSONWriter();
-        jsonWriter.write(origArr,"someArr.json");
+        NdArrayJSONWriter.write(origArr,"someArr.json");
 
         NdArrayJSONReader jsonReader = new NdArrayJSONReader();
         INDArray readBack = jsonReader.read(new File("someArr.json"));

--- a/nd4j-bytebuddy/src/main/java/org/nd4j/bytebuddy/arithmetic/stackmanipulation/OpStackManipulation.java
+++ b/nd4j-bytebuddy/src/main/java/org/nd4j/bytebuddy/arithmetic/stackmanipulation/OpStackManipulation.java
@@ -15,6 +15,9 @@ import org.nd4j.bytebuddy.arithmetic.ByteBuddyIntArithmetic;
  * @author Adam Gibson
  */
 public class OpStackManipulation {
+    private OpStackManipulation() {
+    }
+
     /**
      * Stack manipulation for addition
      * @return

--- a/nd4j-bytebuddy/src/main/java/org/nd4j/bytebuddy/shape/ShapeMapper.java
+++ b/nd4j-bytebuddy/src/main/java/org/nd4j/bytebuddy/shape/ShapeMapper.java
@@ -31,6 +31,9 @@ import java.util.List;
  */
 public class ShapeMapper {
 
+    private ShapeMapper() {
+    }
+
     /**
      * Get an ind2sub instance
      * based on the ordering and rank

--- a/nd4j-bytebuddy/src/main/java/org/nd4j/bytebuddy/util/OpCodeUtil.java
+++ b/nd4j-bytebuddy/src/main/java/org/nd4j/bytebuddy/util/OpCodeUtil.java
@@ -7,6 +7,9 @@ package org.nd4j.bytebuddy.util;
  */
 public class OpCodeUtil {
 
+    private OpCodeUtil() {
+    }
+
     /**
      * Get the a load reference code starting at 42.
      * See:

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/NioUtil.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/NioUtil.java
@@ -9,6 +9,9 @@ import java.nio.*;
  */
 public class NioUtil {
 
+    private NioUtil() {
+    }
+
     public enum BufferType {
         INT,FLOAT,DOUBLE
     }

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/Paths.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/Paths.java
@@ -33,6 +33,9 @@ public class Paths {
 
     public final static String PATH_ENV_VARIABLE  = "PATH";
 
+    private Paths() {
+    }
+
     /**
      * Check if a file exists in the path
      * @param name the name of the file

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/ReflectionUtil.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/ReflectionUtil.java
@@ -26,6 +26,9 @@ package org.nd4j.linalg.util;
  */
 public final class ReflectionUtil {
 
+    private ReflectionUtil() {
+    }
+
     /**
      * Create a class array from the given array of objects
      *

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/SerializationUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/SerializationUtils.java
@@ -29,6 +29,9 @@ import java.io.*;
  */
 public class SerializationUtils {
 
+	private SerializationUtils() {
+	}
+
 	@SuppressWarnings("unchecked")
 	public static <T> T readObject(File file) {
 		try {

--- a/nd4j-serde/nd4j-base64/src/main/java/org/nd4j/serde/base64/Nd4jBase64.java
+++ b/nd4j-serde/nd4j-base64/src/main/java/org/nd4j/serde/base64/Nd4jBase64.java
@@ -13,6 +13,9 @@ import java.io.*;
  */
 public class Nd4jBase64 {
 
+    private Nd4jBase64() {
+    }
+
     /**
      * Returns a set of arrays
      * from base 64 that is tab delimited.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118

 Please let me know if you have any questions.
Ayman Elkfrawy.