### PR TITLE
Cleanup: squid:S1185, Remove unnecessary override methods

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseAccumulation.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseAccumulation.java
@@ -233,9 +233,4 @@ public abstract class BaseAccumulation extends BaseOp implements Accumulation {
     public IComplexNumber getFinalResultComplex(){
         return finalResultComplex;
     }
-
-    @Override
-    public void setZ(INDArray z) {
-        super.setZ(z);
-    }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/Bias.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/Bias.java
@@ -164,11 +164,6 @@ public class Bias extends BaseAccumulation {
     }
 
     @Override
-    public void init(INDArray x, INDArray y, INDArray z, long n) {
-        super.init(x, y, z, n);
-    }
-
-    @Override
     public double combineSubResults(double first, double second){
         return first + second;
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/LogSoftMax.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/LogSoftMax.java
@@ -133,11 +133,6 @@ public class LogSoftMax extends BaseTransformOp {
     }
 
     @Override
-    public void init(INDArray x, INDArray y, INDArray z, long n) {
-        super.init(x, y, z, n);
-    }
-
-    @Override
     public boolean isExecSpecial() {
         return true;
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/CopyOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/CopyOp.java
@@ -132,17 +132,7 @@ public class CopyOp extends BaseTransformOp {
     }
 
     @Override
-    public void exec(int... dimensions) {
-        super.exec(dimensions);
-    }
-
-    @Override
     public boolean isPassThrough() {
         return false;
-    }
-
-    @Override
-    public void init(INDArray x, INDArray y, INDArray z, long n) {
-        super.init(x, y, z, n);
     }
 }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda-7.5/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -788,16 +788,6 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
     }
 
     @Override
-    public double[] getDoublesAt(long offset, long inc, int length) {
-        return super.getDoublesAt(offset, inc, length);
-    }
-
-    @Override
-    public double[] getDoublesAt(long offset, int length) {
-        return super.getDoublesAt(offset, length);
-    }
-
-    @Override
     public float getFloat(long i) {
         allocator.synchronizeHostData(this);
 
@@ -805,16 +795,6 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
 
         return super.getFloat(i);
         //return wrappedBuffer.getFloat((int)(offset + i) * getElementSize());
-    }
-
-    @Override
-    public float[] getFloatsAt(long offset, long inc, int length) {
-        return super.getFloatsAt(offset, inc, length);
-    }
-
-    @Override
-    public float[] getFloatsAt(long offset, int length) {
-        return super.getFloatsAt(offset, length);
     }
 
     @Override

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuAffinityManager.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuAffinityManager.java
@@ -6,28 +6,5 @@ import org.nd4j.linalg.api.concurrency.BasicAffinityManager;
  * @author raver119@gmail.com
  */
 public class CpuAffinityManager extends BasicAffinityManager {
-    @Override
-    public Integer getDeviceForCurrentThread() {
-        return super.getDeviceForCurrentThread();
-    }
 
-    @Override
-    public Integer getDeviceForThread(Thread thread) {
-        return super.getDeviceForThread(thread);
-    }
-
-    @Override
-    public Integer getDeviceForThread(long threadId) {
-        return super.getDeviceForThread(threadId);
-    }
-
-    @Override
-    public void attachThreadToDevice(Thread thread, Integer deviceId) {
-        super.attachThreadToDevice(thread, deviceId);
-    }
-
-    @Override
-    public void attachThreadToDevice(long threadId, Integer deviceId) {
-        super.attachThreadToDevice(threadId, deviceId);
-    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1185 - Overriding methods should do more than simply call the same method in the super class
 You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1185

Please let me know if you have any questions.
Ayman Elkfrawy