### PR TITLE
Deprecate normalize now that  NormalizerStandardize and NormalizerMinMaxScaler exist

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -586,6 +586,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
         getFeatures().putRow(example, feature);
     }
 
+    @Deprecated
     @Override
     public void normalize() {
         FeatureUtil.normalizeMatrix(getFeatures());
@@ -619,8 +620,10 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
 
 
     /**
+     * @Deprecated
      * Subtract by the column means and divide by the standard deviation
      */
+    @Deprecated
     @Override
     public void normalizeZeroMeanZeroUnitVariance() {
         INDArray columnMeans = getFeatures().mean(0);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
@@ -83,12 +83,14 @@ public interface DataSet extends Iterable<org.nd4j.linalg.dataset.DataSet>, Seri
 
     void addFeatureVector(INDArray feature, int example);
 
+    @Deprecated
     void normalize();
 
     void binarize();
 
     void binarize(double cutoff);
 
+    @Deprecated
     void normalizeZeroMeanZeroUnitVariance();
 
     int numInputs();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/FeatureUtil.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/FeatureUtil.java
@@ -58,6 +58,7 @@ public class FeatureUtil {
         return ret;
     }
 
+    @Deprecated
     public static void normalizeMatrix(INDArray toNormalize) {
         INDArray columnMeans = toNormalize.mean(0);
         toNormalize.subiRowVector(columnMeans);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/FeatureUtil.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/FeatureUtil.java
@@ -58,7 +58,6 @@ public class FeatureUtil {
         return ret;
     }
 
-    @Deprecated
     public static void normalizeMatrix(INDArray toNormalize) {
         INDArray columnMeans = toNormalize.mean(0);
         toNormalize.subiRowVector(columnMeans);


### PR DESCRIPTION
Addressing #1050 

@eraly are these methods ready to be deprecated now that you've added  NormalizerStandardize and NormalizerMinMaxScaler?

@AlexDBlack looping you in 