### PR TITLE
Base Transform Op shape check

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformOp.java
@@ -32,6 +32,7 @@ public abstract class BaseTransformOp extends BaseOp implements TransformOp {
     public BaseTransformOp(INDArray x, INDArray z) {
         super(x, z);
         LinAlgExceptions.assertSameLength(x,z);
+        LinAlgExceptions.assertSameShape(x,z);
     }
 
     public BaseTransformOp() {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/LinAlgExceptions.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/LinAlgExceptions.java
@@ -20,7 +20,8 @@
 package org.nd4j.linalg.util;
 
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.shape.Shape;
+
+import java.util.Arrays;
 
 /**
  * Linear algebra exceptions
@@ -35,6 +36,11 @@ public class LinAlgExceptions {
      */
     public static void assertSameLength(INDArray n, INDArray n2) {
         if (n.length() != n2.length())
+            throw new IllegalStateException("Mis matched lengths");
+    }
+
+    public static void assertSameShape(INDArray n, INDArray n2) {
+        if( !Arrays.equals( n.shape(),n2.shape() ) )
             throw new IllegalStateException("Mis matched shapes");
     }
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
@@ -94,7 +94,7 @@ public class LoneTest extends BaseNd4jTest {
         INDArray arr1 = Nd4j.create(1,1);
         INDArray arr2 = Nd4j.create(1,8);
         INDArray arr3 = Nd4j.create(1,1);
-        INDArray arr4 = Nd4j.concat(0,arr1,arr2,arr3,arr4);
-        assertTrue(arr4.maxNumber().floatValue() <= Nd4j.EPS_THRESHOLD);
+        INDArray arr4 = Nd4j.concat(1,arr1,arr2,arr3);
+        assertTrue(arr4.sumNumber().floatValue() <= Nd4j.EPS_THRESHOLD);
     }
 }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
@@ -11,6 +11,7 @@ import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -85,5 +86,15 @@ public class LoneTest extends BaseNd4jTest {
             jj = colVector.get(NDArrayIndex.interval(i,i+10));
             jj = colVector.get(NDArrayIndex.interval(i,i+10));
         }
+    }
+
+    @Test
+    public void concatScalarVectorIssue() {
+        //A bug was found when the first array that concat sees is a scalar and the rest vectors + scalars
+        INDArray arr1 = Nd4j.create(1,1);
+        INDArray arr2 = Nd4j.create(1,8);
+        INDArray arr3 = Nd4j.create(1,1);
+        INDArray arr4 = Nd4j.concat(0,arr1,arr2,arr3,arr4);
+        assertTrue(arr4.maxNumber().floatValue() <= Nd4j.EPS_THRESHOLD);
     }
 }


### PR DESCRIPTION
https://github.com/deeplearning4j/nd4j/issues/959

Currently we only check if length is equal if a base transform has two nd arrays as arguments. Mismatched shapes even with the same length can cause JVM crashes. Changed so that it now throws an exception