### PR TITLE
Forcing ews to -1 for permutei

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -4270,6 +4270,10 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             }
             this.attemptedToFindElementWiseStride = true;
         }
+        if (shapeInfo.get(2*rank + 2) > 0) {
+            //for the backend to work - no ews for permutei
+            this.shapeInformation = Nd4j.getShapeInfoProvider().createShapeInformation(newShape, newStride, this.offset(), -1 , newOrder);
+        }
 
         this.rows = size(0);
         this.columns = size(1);


### PR DESCRIPTION
https://github.com/deeplearning4j/nd4j/issues/1128

Doing a permute in place of an array that has ews = 1 just changes the strides and keeps the ews = 1. While the permute operation gives the correct answer downstream operations will give different results when a pairwise transform is invoked, like the reshape in the issue above.

