### PR TITLE
Fix atan -> acos typo in Transforms.java (#1)

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/ops/transforms/Transforms.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/ops/transforms/Transforms.java
@@ -211,7 +211,7 @@ public class Transforms {
     }
 
     public static INDArray atan(INDArray arr) {
-        return acos(arr,Nd4j.copyOnOps);
+        return atan(arr,Nd4j.copyOnOps);
     }
 
 


### PR DESCRIPTION
Fixing a typo that would have run `acos` instead of `atan` when `atan` is called without an explicit boolean value.