### PR TITLE
BooleanIndexing goes native

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -26,7 +26,6 @@ import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.complex.IComplexNDArray;
 import org.nd4j.linalg.api.complex.IComplexNumber;
 import org.nd4j.linalg.api.instrumentation.Instrumentation;
-import org.nd4j.linalg.api.iter.NdIndexIterator;
 import org.nd4j.linalg.api.iter.FirstAxisIterator;
 import org.nd4j.linalg.api.ops.impl.accum.Max;
 import org.nd4j.linalg.api.ops.impl.accum.*;
@@ -2953,7 +2952,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public INDArray assignIf(INDArray arr, Condition condition) {
-        BooleanIndexing.assignWhere(this, arr, condition);
+        BooleanIndexing.assignIf(this, arr, condition);
         return this;
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -2943,6 +2943,32 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     }
 
 
+    /**
+     * Assign all elements from given ndarray that are matching given condition,
+     * ndarray to this ndarray
+     *
+     * @param arr       the elements to assign
+     * @param condition
+     * @return this
+     */
+    @Override
+    public INDArray assignIf(INDArray arr, Condition condition) {
+        BooleanIndexing.assignWhere(this, arr, condition);
+        return this;
+    }
+
+    /**
+     * Replaces all elements in this ndarray that are matching give condition, with corresponding elements from given array
+     *
+     * @param arr
+     * @param condition
+     * @return
+     */
+    @Override
+    public INDArray replaceWhere(INDArray arr, Condition condition) {
+        BooleanIndexing.replaceWhere(this, arr, condition);
+        return this;
+    }
 
     @Override
     public int linearIndex(int i) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
@@ -236,6 +236,26 @@ public interface INDArray extends Serializable  {
      */
     INDArray assign(INDArray arr);
 
+     /**
+     * Assign all elements from given ndarray that are matching given condition,
+     * ndarray to this ndarray
+     *
+     * @param arr the elements to assign
+     * @return this
+     */
+     INDArray assignIf(INDArray arr, Condition condition);
+
+
+     /**
+     * Replaces all elements in this ndarray that are matching give condition, with corresponding elements from given array
+      *
+     * @param arr
+     * @param condition
+     * @return
+     */
+     INDArray replaceWhere(INDArray arr, Condition condition);
+
+
     /**
      * Insert the number linearly in to the ndarray
      *

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/ASum.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/ASum.java
@@ -25,9 +25,9 @@ import org.nd4j.linalg.api.ops.BaseAccumulation;
 import org.nd4j.linalg.api.ops.Op;
 
 /**
- * Sum the components
+ * Absolute sum the components
  *
- * @author Adam Gibson
+ * @author raver119@gmail.com
  */
 public class ASum extends BaseAccumulation {
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/MatchCondition.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/MatchCondition.java
@@ -1,0 +1,141 @@
+/*
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.accum;
+
+import org.nd4j.linalg.api.complex.IComplexNumber;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.BaseAccumulation;
+import org.nd4j.linalg.api.ops.Op;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.conditions.Condition;
+
+/**
+ * Absolute sum the components
+ *
+ * @author raver119@gmail.com
+ */
+public class MatchCondition extends BaseAccumulation {
+
+    double compare;
+    double eps;
+    int mode;
+
+    public MatchCondition() {
+    }
+
+
+    public MatchCondition(INDArray x, Condition condition) {
+        this(x, Nd4j.EPS_THRESHOLD, condition);
+    }
+
+    public MatchCondition(INDArray x, double eps, Condition condition) {
+        super(x);
+        this.compare = condition.getValue();
+        this.mode = condition.condtionNum();
+        this.eps = eps;
+
+        this.extraArgs = new Object[] {compare, eps, (double) mode};
+    }
+
+    @Override
+    public int opNum() {
+        return 12;
+    }
+
+    @Override
+    public String name() {
+        return "match_condition";
+    }
+
+     @Override
+    public Op opForDimension(int index, int dimension) {
+       return null;
+    }
+
+    @Override
+    public Op opForDimension(int index, int... dimension) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber op(IComplexNumber origin, IComplexNumber other) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber op(IComplexNumber origin, float other) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber op(IComplexNumber origin, double other) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber op(IComplexNumber origin) {
+        return null;
+    }
+
+    @Override
+    public double update(double accum, double x) {
+        return 0;
+    }
+
+    @Override
+    public double update(double accum, double x, double y) {
+        return 0;
+    }
+
+    @Override
+    public float update(float accum, float x) {
+        return 0;
+    }
+
+    @Override
+    public float update(float accum, float x, float y) {
+        return 0;
+    }
+
+    @Override
+    public IComplexNumber update(IComplexNumber accum, double x) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber update(IComplexNumber accum, double x, double y) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber update(IComplexNumber accum, IComplexNumber x) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber update(IComplexNumber accum, IComplexNumber x, IComplexNumber y) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber update(IComplexNumber accum, IComplexNumber x, double y) {
+        return null;
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/comparison/CompareAndReplace.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/comparison/CompareAndReplace.java
@@ -26,7 +26,7 @@ import org.nd4j.linalg.api.ops.Op;
 import org.nd4j.linalg.indexing.conditions.Condition;
 
 /**
- * Element-wise Compare-and-set implementation as Op
+ * Element-wise Compare-and-Replace implementation as Op
  *
  * @author raver119@gmail.com
  */

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/comparison/CompareAndReplace.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/comparison/CompareAndReplace.java
@@ -1,0 +1,143 @@
+/*
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.comparison;
+
+import org.nd4j.linalg.api.complex.IComplexNumber;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.BaseTransformOp;
+import org.nd4j.linalg.api.ops.Op;
+import org.nd4j.linalg.indexing.conditions.Condition;
+
+/**
+ * Element-wise Compare-and-set implementation as Op
+ *
+ * @author raver119@gmail.com
+ */
+public class CompareAndReplace extends BaseTransformOp {
+
+    private double compare;
+    private double set;
+    private double eps;
+    private int mode;
+
+
+    public CompareAndReplace() {
+
+    }
+
+
+
+
+    public CompareAndReplace(INDArray x, INDArray y, Condition condition) {
+        this(x, y, x, condition);
+    }
+
+    public CompareAndReplace(INDArray x, INDArray y, INDArray z, Condition condition) {
+        super(x, y, z, x.lengthLong());
+        this.compare = condition.getValue();
+        this.set = 0;
+        this.mode = condition.condtionNum();
+        init(x, y, z, x.lengthLong());
+    }
+
+
+
+    @Override
+    public int opNum() {
+        return 46;
+    }
+
+    @Override
+    public String name() {
+        return "car";
+    }
+
+    @Override
+    public IComplexNumber op(IComplexNumber origin, double other) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber op(IComplexNumber origin, float other) {
+        return null;
+    }
+
+    @Override
+    public IComplexNumber op(IComplexNumber origin, IComplexNumber other) {
+        return null;
+    }
+
+    @Override
+    public float op(float origin, float other) {
+        return 0;
+    }
+
+    @Override
+    public double op(double origin, double other) {
+        return 0;
+    }
+
+    @Override
+    public double op(double origin) {
+        return 0;
+    }
+
+    @Override
+    public float op(float origin) {
+        return 0;
+    }
+
+    @Override
+    public IComplexNumber op(IComplexNumber origin) {
+        return null;
+
+    }
+
+    /**
+     * A copy of this operation for a particular dimension of the input
+     *
+     * @param index     the index of the op to iterate over
+     * @param dimension the dimension to ge the input for
+     * @return the operation for that dimension
+     */
+    @Override
+    public Op opForDimension(int index, int dimension) {
+        return null;
+    }
+
+    /**
+     * A copy of this operation for a particular dimension of the input
+     *
+     * @param index     the index of the op to iterate over
+     * @param dimension the dimension to ge the input for
+     * @return the operation for that dimension
+     */
+    @Override
+    public Op opForDimension(int index, int... dimension) {
+        return null;
+    }
+
+    @Override
+    public void init(INDArray x, INDArray y, INDArray z, long n) {
+        super.init(x,y,z,n);
+        this.extraArgs = new Object[]{compare, set, eps, (double) mode};
+    }
+}
+

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/comparison/CompareAndSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/comparison/CompareAndSet.java
@@ -19,10 +19,13 @@
 
 package org.nd4j.linalg.api.ops.impl.transforms.comparison;
 
+import lombok.NonNull;
 import org.nd4j.linalg.api.complex.IComplexNumber;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseTransformOp;
 import org.nd4j.linalg.api.ops.Op;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.conditions.Condition;
 
 /**
  * Element-wise Compare-and-set implementation as Op
@@ -34,24 +37,62 @@ public class CompareAndSet extends BaseTransformOp {
     private double compare;
     private double set;
     private double eps;
+    private int mode;
+
 
     public CompareAndSet() {
 
     }
 
     public CompareAndSet(INDArray x, double compare, double set, double eps) {
+        this(x, compare, set, eps, null);
+    }
+
+    public CompareAndSet(INDArray x, double compare, double set, double eps, Condition condition) {
         super(x);
         this.compare = compare;
         this.set = set;
         this.eps = eps;
+        if (condition == null)
+            this.mode = 0;
+        else
+            this.mode = condition.condtionNum();
+
         init(x, null, x, x.length());
     }
+
+
+    public CompareAndSet(INDArray x, double set, Condition condition) {
+        this(x, x, set, condition);
+    }
+
+    public CompareAndSet(INDArray x, INDArray z, double set, Condition condition) {
+        super(x, null, z, x.lengthLong());
+        this.compare = condition.getValue();
+        this.set = set;
+        this.mode = condition.condtionNum();
+        init(x, null, z, x.lengthLong());
+    }
+
+    public CompareAndSet(INDArray x, INDArray y, Condition condition) {
+        this(x, y, x, condition);
+    }
+
+    public CompareAndSet(INDArray x, INDArray y, INDArray z, Condition condition) {
+        super(x, y, z, x.lengthLong());
+        this.compare = condition.getValue();
+        this.set = 0;
+        this.mode = condition.condtionNum();
+        init(x, y, z, x.lengthLong());
+    }
+
 
     public CompareAndSet(INDArray x, INDArray z, double compare, double set, double eps) {
         super(x,z);
         this.compare = compare;
         this.set = set;
         this.eps = eps;
+        this.mode = 0;
         init(x, null, z, x.length());
     }
 
@@ -60,6 +101,7 @@ public class CompareAndSet extends BaseTransformOp {
         this.compare = compare;
         this.set = set;
         this.eps = eps;
+        this.mode = 0;
         init(x, null, x, n);
     }
 
@@ -138,7 +180,7 @@ public class CompareAndSet extends BaseTransformOp {
     @Override
     public void init(INDArray x, INDArray y, INDArray z, long n) {
         super.init(x,y,z,n);
-        this.extraArgs = new Object[]{compare, set, eps, (double) n};
+        this.extraArgs = new Object[]{compare, set, eps, (double) mode};
     }
 }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
@@ -787,6 +787,16 @@ public class Shape {
     }
 
 
+    public static long getTADLength(int[] shape, int... dimensions) {
+        int tadLength = 1;
+        for (int i = 0; i < dimensions.length; i++) {
+            tadLength *= shape[dimensions[i]];
+        }
+
+        return tadLength;
+    }
+
+
     /**
      *
      * @param shape

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
@@ -20,13 +20,16 @@
 package org.nd4j.linalg.indexing;
 
 import com.google.common.base.Function;
+import lombok.NonNull;
 import org.nd4j.linalg.api.complex.IComplexNDArray;
 import org.nd4j.linalg.api.complex.IComplexNumber;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndReplace;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndSet;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.api.shape.loop.coordinatefunction.CoordinateFunction;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.conditions.BaseCondition;
 import org.nd4j.linalg.indexing.conditions.Condition;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -124,20 +127,60 @@ public class BooleanIndexing {
      * @param function  the function to apply the op to
      */
     public static void applyWhere(final INDArray to, final Condition condition, final Function<Number, Number> function) {
-        double number = function.apply(new Double(0.0)).doubleValue();
+        if (condition instanceof BaseCondition) {
+            // for all static conditions we go native
+
+            double number = function.apply(new Double(0.0)).doubleValue();
+
+            Nd4j.getExecutioner().exec(new CompareAndSet(to, number, condition));
+
+        } else {
+            // keep original java implementation for dynamic
+
+            Shape.iterate(to, new CoordinateFunction() {
+                @Override
+                public void process(int[]... coord) {
+                    if (condition.apply(to.getDouble(coord[0])))
+                        to.putScalar(coord[0], function.apply(to.getDouble(coord[0])).floatValue());
+
+                }
+            });
+        }
+    }
+
+    /**
+     * This method does element-wise assing for 2 equal-sized matrices, for each element that matches Condition
+     *
+     * @param to
+     * @param from
+     * @param condition
+     */
+    public static void assignWhere(@NonNull INDArray to,@NonNull INDArray from, @NonNull Condition condition) {
+        if (!(condition instanceof BaseCondition))
+            throw new UnsupportedOperationException("Only static Conditions are supported");
+
+        if (to.lengthLong() != from.lengthLong())
+            throw new IllegalStateException("Mis matched length for to and from");
+
+        Nd4j.getExecutioner().exec(new CompareAndSet(to, from, condition));
+    }
 
 
-        Nd4j.getExecutioner().exec(new CompareAndSet(to, number, condition));
+    /**
+     * This method does element-wise assing for 2 equal-sized matrices, for each element that matches Condition
+     *
+     * @param to
+     * @param from
+     * @param condition
+     */
+    public static void replaceWhere(@NonNull INDArray to,@NonNull INDArray from, @NonNull Condition condition) {
+        if (!(condition instanceof BaseCondition))
+            throw new UnsupportedOperationException("Only static Conditions are supported");
 
-        /*Shape.iterate(to, new CoordinateFunction() {
-            @Override
-            public void process(int[]... coord) {
-                if(condition.apply(to.getDouble(coord[0])))
-                    to.putScalar(coord[0], function.apply(to.getDouble(coord[0])).floatValue());
+        if (to.lengthLong() != from.lengthLong())
+            throw new IllegalStateException("Mis matched length for to and from");
 
-            }
-        });
-        */
+        Nd4j.getExecutioner().exec(new CompareAndReplace(to, from, condition));
     }
 
     /**

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
@@ -23,8 +23,10 @@ import com.google.common.base.Function;
 import org.nd4j.linalg.api.complex.IComplexNDArray;
 import org.nd4j.linalg.api.complex.IComplexNumber;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndSet;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.api.shape.loop.coordinatefunction.CoordinateFunction;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.conditions.Condition;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -122,7 +124,12 @@ public class BooleanIndexing {
      * @param function  the function to apply the op to
      */
     public static void applyWhere(final INDArray to, final Condition condition, final Function<Number, Number> function) {
-        Shape.iterate(to, new CoordinateFunction() {
+        double number = function.apply(new Double(0.0)).doubleValue();
+
+
+        Nd4j.getExecutioner().exec(new CompareAndSet(to, number, condition));
+
+        /*Shape.iterate(to, new CoordinateFunction() {
             @Override
             public void process(int[]... coord) {
                 if(condition.apply(to.getDouble(coord[0])))
@@ -130,6 +137,7 @@ public class BooleanIndexing {
 
             }
         });
+        */
     }
 
     /**

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
@@ -110,6 +110,61 @@ public class BooleanIndexing {
     }
 
     /**
+     * And over the whole ndarray given some condition, with respect to dimensions
+     *
+     * @param n    the ndarray to test
+     * @param condition the condition to test against
+     * @return true if all of the elements meet the specified
+     * condition false otherwise
+     */
+    public static boolean[] and(final INDArray n, final Condition condition, int... dimension) {
+        if (!(condition instanceof BaseCondition))
+            throw new UnsupportedOperationException("Only static Conditions are supported");
+
+        MatchCondition op = new MatchCondition(n, condition);
+        INDArray arr = Nd4j.getExecutioner().exec(op, dimension);
+        boolean[] result = new boolean[arr.length()];
+
+        long tadLength = Shape.getTADLength(n.shape(), dimension);
+
+        for (int i = 0; i < arr.length(); i++) {
+            if (arr.getDouble(i) == tadLength)
+                result[i] = true;
+            else
+                result[i] = false;
+        }
+
+        return result;
+    }
+
+
+    /**
+     * Or over the whole ndarray given some condition, with respect to dimensions
+     *
+     * @param n    the ndarray to test
+     * @param condition the condition to test against
+     * @return true if all of the elements meet the specified
+     * condition false otherwise
+     */
+    public static boolean[] or(final INDArray n, final Condition condition, int... dimension) {
+        if (!(condition instanceof BaseCondition))
+            throw new UnsupportedOperationException("Only static Conditions are supported");
+
+        MatchCondition op = new MatchCondition(n, condition);
+        INDArray arr = Nd4j.getExecutioner().exec(op, dimension);
+        boolean[] result = new boolean[arr.length()];
+
+        for (int i = 0; i < arr.length(); i++) {
+            if (arr.getDouble(i) > 0 )
+                result[i] = true;
+            else
+                result[i] = false;
+        }
+
+        return result;
+    }
+
+    /**
      * Or over the whole ndarray given some condition
      *
      * @param n

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
@@ -155,7 +155,7 @@ public class BooleanIndexing {
      * @param from
      * @param condition
      */
-    public static void assignWhere(@NonNull INDArray to,@NonNull INDArray from, @NonNull Condition condition) {
+    public static void assignIf(@NonNull INDArray to, @NonNull INDArray from, @NonNull Condition condition) {
         if (!(condition instanceof BaseCondition))
             throw new UnsupportedOperationException("Only static Conditions are supported");
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/AbsValueGreaterThan.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/AbsValueGreaterThan.java
@@ -10,6 +10,16 @@ public class AbsValueGreaterThan extends BaseCondition {
         super(value);
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 7;
+    }
+
     @Override
     public Boolean apply(Number input) {
         return FastMath.abs(input.doubleValue()) > value.doubleValue();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/AbsValueLessThan.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/AbsValueLessThan.java
@@ -10,6 +10,16 @@ public class AbsValueLessThan extends BaseCondition {
         super(value);
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 6;
+    }
+
     @Override
     public Boolean apply(Number input) {
         return FastMath.abs(input.doubleValue()) < value.doubleValue();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/And.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/And.java
@@ -32,6 +32,21 @@ public class And implements Condition {
         this.conditions = conditions;
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return -1;
+    }
+
+    @Override
+    public double getValue() {
+        return -1;
+    }
+
     @Override
     public Boolean apply(Number input) {
         boolean ret = conditions[0].apply(input);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/BaseCondition.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/BaseCondition.java
@@ -34,6 +34,11 @@ public abstract class  BaseCondition implements Condition {
         this.complexNumber = Nd4j.createComplexNumber(value, 0);
     }
 
+    @Override
+    public double getValue() {
+        return value.doubleValue();
+    }
+
     public BaseCondition(IComplexNumber complexNumber) {
         this.complexNumber = complexNumber;
         this.value = complexNumber.absoluteValue();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Condition.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Condition.java
@@ -27,8 +27,17 @@ import org.nd4j.linalg.api.complex.IComplexNumber;
  */
 public interface Condition extends Function<Number, Boolean> {
 
-    @Override
-    public Boolean apply(Number input);
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    int condtionNum();
 
-    public Boolean apply(IComplexNumber input);
+    double getValue();
+
+    @Override
+    Boolean apply(Number input);
+
+    Boolean apply(IComplexNumber input);
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/ConditionEquals.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/ConditionEquals.java
@@ -34,6 +34,21 @@ public class ConditionEquals implements Condition {
         this.conditions = conditions;
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return -1;
+    }
+
+    @Override
+    public double getValue() {
+        return -1;
+    }
+
     @Override
     public Boolean apply(Number input) {
         boolean ret = conditions[0].apply(input);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Conditions.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Conditions.java
@@ -60,6 +60,10 @@ public class Conditions {
         return new EqualsCondition(value);
     }
 
+    public static Condition notEquals(Number value) {
+        return new NotEqualsCondition(value);
+    }
+
     public static Condition greaterThan(IComplexNumber value) {
         return new GreaterThan(value);
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Conditions.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Conditions.java
@@ -42,9 +42,15 @@ public class Conditions {
         return new EqualsCondition(value);
     }
 
+    public static Condition epsNotEquals(Number value) {
+        return new EpsilonNotEquals(value);
+    }
+
     public static Condition epsEquals(Number value) {
         return new EqualsCondition(value);
     }
+
+
 
     public static Condition equals(IComplexNumber value) {
         return new EqualsCondition(value);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/EpsilonEquals.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/EpsilonEquals.java
@@ -34,6 +34,16 @@ public class EpsilonEquals extends BaseCondition {
         super(complexNumber);
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 0;
+    }
+
     @Override
     public Boolean apply(Number input) {
         return Math.abs(input.floatValue() - value.floatValue()) < Nd4j.EPS_THRESHOLD;

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/EpsilonNotEquals.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/EpsilonNotEquals.java
@@ -20,17 +20,17 @@
 package org.nd4j.linalg.indexing.conditions;
 
 import org.nd4j.linalg.api.complex.IComplexNumber;
+import org.nd4j.linalg.factory.Nd4j;
 
 /**
  * Created by agibsonccc on 10/8/14.
  */
-public class LessThan extends BaseCondition {
-
-    public LessThan(Number value) {
+public class EpsilonNotEquals extends BaseCondition {
+    public EpsilonNotEquals(Number value) {
         super(value);
     }
 
-    public LessThan(IComplexNumber complexNumber) {
+    public EpsilonNotEquals(IComplexNumber complexNumber) {
         super(complexNumber);
     }
 
@@ -41,16 +41,17 @@ public class LessThan extends BaseCondition {
      */
     @Override
     public int condtionNum() {
-        return 2;
+        return 1;
     }
 
     @Override
     public Boolean apply(Number input) {
-        return input.doubleValue() < value.doubleValue();
+        return Math.abs(input.floatValue() - value.floatValue()) < Nd4j.EPS_THRESHOLD;
     }
 
     @Override
     public Boolean apply(IComplexNumber input) {
-        return input.absoluteValue().doubleValue() < complexNumber.absoluteValue().doubleValue();
+        return Math.abs(input.absoluteValue().floatValue() - input.absoluteValue().floatValue()) < Nd4j.EPS_THRESHOLD;
+
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/EqualsCondition.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/EqualsCondition.java
@@ -35,6 +35,16 @@ public class EqualsCondition extends BaseCondition {
         super(complexNumber);
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 0;
+    }
+
     @Override
     public Boolean apply(Number input) {
         if (Nd4j.dtype == DataBuffer.Type.DOUBLE)

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/GreaterThan.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/GreaterThan.java
@@ -33,6 +33,16 @@ public class GreaterThan extends BaseCondition {
         super(complexNumber);
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 3;
+    }
+
     @Override
     public Boolean apply(Number input) {
         return input.doubleValue() > value.doubleValue();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/GreaterThanOrEqual.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/GreaterThanOrEqual.java
@@ -33,6 +33,16 @@ public class GreaterThanOrEqual extends BaseCondition {
         super(complexNumber);
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 5;
+    }
+
     @Override
     public Boolean apply(Number input) {
         return input.floatValue() >= value.floatValue();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/IsInfinite.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/IsInfinite.java
@@ -26,6 +26,22 @@ import org.nd4j.linalg.api.complex.IComplexNumber;
  */
 public class IsInfinite implements Condition {
 
+
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 8;
+    }
+
+    @Override
+    public double getValue() {
+        return -1;
+    }
+
     @Override
     public Boolean apply(Number input) {
         return Float.isInfinite(input.floatValue());

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/IsInfinite.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/IsInfinite.java
@@ -24,8 +24,12 @@ import org.nd4j.linalg.api.complex.IComplexNumber;
 /**
  * Created by agibsonccc on 10/8/14.
  */
-public class IsInfinite implements Condition {
+public class IsInfinite extends BaseCondition{
 
+
+    public IsInfinite() {
+        super(-1);
+    }
 
     /**
      * Returns condition ID for native side
@@ -35,11 +39,6 @@ public class IsInfinite implements Condition {
     @Override
     public int condtionNum() {
         return 8;
-    }
-
-    @Override
-    public double getValue() {
-        return -1;
     }
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/IsNaN.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/IsNaN.java
@@ -26,7 +26,11 @@ import org.nd4j.linalg.api.complex.IComplexNumber;
  *
  * @author Adam Gibson
  */
-public class IsNaN implements Condition {
+public class IsNaN extends BaseCondition {
+
+    public IsNaN() {
+        super(-1);
+    }
 
     /**
      * Returns condition ID for native side
@@ -38,10 +42,6 @@ public class IsNaN implements Condition {
         return 9;
     }
 
-    @Override
-    public double getValue() {
-        return -1;
-    }
 
     @Override
     public Boolean apply(Number input) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/IsNaN.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/IsNaN.java
@@ -28,6 +28,21 @@ import org.nd4j.linalg.api.complex.IComplexNumber;
  */
 public class IsNaN implements Condition {
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 9;
+    }
+
+    @Override
+    public double getValue() {
+        return -1;
+    }
+
     @Override
     public Boolean apply(Number input) {
         return Double.isNaN(input.doubleValue());

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/LessThanOrEqual.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/LessThanOrEqual.java
@@ -34,6 +34,16 @@ public class LessThanOrEqual extends BaseCondition {
         super(complexNumber);
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return 4;
+    }
+
     @Override
     public Boolean apply(Number input) {
         return input.floatValue() <= value.doubleValue();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Not.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Not.java
@@ -28,6 +28,21 @@ public class Not implements Condition {
 
     private Condition opposite;
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return -1;
+    }
+
+    @Override
+    public double getValue() {
+        return -1;
+    }
+
     public Not(Condition condition) {
         this.opposite = condition;
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/NotEqualsCondition.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/NotEqualsCondition.java
@@ -26,12 +26,12 @@ import org.nd4j.linalg.factory.Nd4j;
 /**
  * Created by agibsonccc on 10/8/14.
  */
-public class EqualsCondition extends BaseCondition {
-    public EqualsCondition(Number value) {
+public class NotEqualsCondition extends BaseCondition {
+    public NotEqualsCondition(Number value) {
         super(value);
     }
 
-    public EqualsCondition(IComplexNumber complexNumber) {
+    public NotEqualsCondition(IComplexNumber complexNumber) {
         super(complexNumber);
     }
 
@@ -42,7 +42,7 @@ public class EqualsCondition extends BaseCondition {
      */
     @Override
     public int condtionNum() {
-        return 10;
+        return 11;
     }
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Or.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/conditions/Or.java
@@ -34,6 +34,21 @@ public class Or implements Condition {
         this.conditions = conditions;
     }
 
+    /**
+     * Returns condition ID for native side
+     *
+     * @return
+     */
+    @Override
+    public int condtionNum() {
+        return -1;
+    }
+
+    @Override
+    public double getValue() {
+        return -1;
+    }
+
     @Override
     public Boolean apply(Number input) {
         boolean ret = conditions[0].apply(input);

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
@@ -362,6 +362,45 @@ public class BooleanIndexingTest extends BaseNd4jTest {
         assertEquals(1, val);
     }
 
+    @Test
+    public void testMatchConditionAlongDimension1() throws Exception {
+        INDArray array = Nd4j.ones(3, 10);
+        array.getRow(2).assign(0.0);
+
+        boolean result[] = BooleanIndexing.and(array, Conditions.equals(0.0), 1);
+        boolean comp[] = new boolean[]{false, false, true};
+
+        System.out.println("Result: " + Arrays.toString(result));
+        assertArrayEquals(comp, result);
+    }
+
+    @Test
+    public void testMatchConditionAlongDimension2() throws Exception {
+        INDArray array = Nd4j.ones(3, 10);
+        array.getRow(2).assign(0.0).putScalar(0, 1.0);
+
+        System.out.println("Array: " + array);
+
+        boolean result[] = BooleanIndexing.or(array, Conditions.lessThan(0.9), 1);
+        boolean comp[] = new boolean[]{false, false, true};
+
+        System.out.println("Result: " + Arrays.toString(result));
+        assertArrayEquals(comp, result);
+    }
+
+    @Test
+    public void testMatchConditionAlongDimension3() throws Exception {
+        INDArray array = Nd4j.ones(3, 10);
+        array.getRow(2).assign(0.0).putScalar(0, 1.0);
+
+        boolean result[] = BooleanIndexing.and(array, Conditions.lessThan(0.0), 1);
+        boolean comp[] = new boolean[]{false, false, false};
+
+        System.out.println("Result: " + Arrays.toString(result));
+        assertArrayEquals(comp, result);
+    }
+
+
     @Override
     public char ordering() {
         return 'c';

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndReplace;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
@@ -139,7 +140,9 @@ public class BooleanIndexingTest extends BaseNd4jTest {
 
         BooleanIndexing.applyWhere(array,Conditions.isNan(),new Value(1e-16f));
 
-        //System.out.println("Array contains: " + Arrays.toString(array.data().asFloat()));
+        System.out.println("Array contains: " + Arrays.toString(array.data().asFloat()));
+
+        assertFalse(BooleanIndexing.or(array, Conditions.isNan()));
 
         assertTrue(BooleanIndexing.or(array, Conditions.equals(1e-12f)));
 
@@ -231,6 +234,17 @@ public class BooleanIndexingTest extends BaseNd4jTest {
     }
 
     @Test
+    public void testConditionalAssign1() throws Exception {
+        INDArray array1 = Nd4j.create(new double[]{1, 2, 3, 4, 5, 6, 7});
+        INDArray array2 = Nd4j.create(new double[]{7, 6, 5, 4, 3, 2, 1});
+        INDArray comp = Nd4j.create(new double[]{1, 2, 3, 4, 3, 2, 1});
+
+        BooleanIndexing.replaceWhere(array1, array2, Conditions.greaterThan(4));
+
+        assertEquals(comp, array1);
+    }
+
+    @Test
     public void testCaSTransform1() throws Exception {
         INDArray array = Nd4j.create(new double[]{1, 2, 0, 4, 5});
         INDArray comp = Nd4j.create(new double[]{1, 2, 3, 4, 5});
@@ -255,7 +269,17 @@ public class BooleanIndexingTest extends BaseNd4jTest {
         INDArray array = Nd4j.create(new double[]{1, 2, 0, 4, 5});
         INDArray comp = Nd4j.create(new double[]{1, 2, 3, 4, 5});
 
-        Nd4j.getExecutioner().exec(new CompareAndSet(array, comp, Conditions.lessThan(1)));
+        Nd4j.getExecutioner().exec(new CompareAndSet(array, comp, Conditions.lessThan(5)));
+
+        assertEquals(comp, array);
+    }
+
+    @Test
+    public void testCaRPairwiseTransform1() throws Exception {
+        INDArray array = Nd4j.create(new double[]{1, 2, 0, 4, 5});
+        INDArray comp = Nd4j.create(new double[]{1, 2, 3, 4, 5});
+
+        Nd4j.getExecutioner().exec(new CompareAndReplace(array, comp, Conditions.lessThan(1)));
 
         assertEquals(comp, array);
     }
@@ -263,10 +287,21 @@ public class BooleanIndexingTest extends BaseNd4jTest {
     @Test
     public void testCaSPairwiseTransform2() throws Exception {
         INDArray x = Nd4j.create(new double[]{1, 2, 0, 4, 5});
+        INDArray y = Nd4j.create(new double[]{2, 4, 3, 0, 5});
+        INDArray comp = Nd4j.create(new double[]{2, 4, 3, 4, 5});
+
+        Nd4j.getExecutioner().exec(new CompareAndSet(x, y, Conditions.epsNotEquals(0.0)));
+
+        assertEquals(comp, x);
+    }
+
+    @Test
+    public void testCaRPairwiseTransform2() throws Exception {
+        INDArray x = Nd4j.create(new double[]{1, 2, 0, 4, 5});
         INDArray y = Nd4j.create(new double[]{2, 4, 3, 4, 5});
         INDArray comp = Nd4j.create(new double[]{2, 4, 0, 4, 5});
 
-        Nd4j.getExecutioner().exec(new CompareAndSet(x, y, Conditions.epsNotEquals(0.0)));
+        Nd4j.getExecutioner().exec(new CompareAndReplace(x, y, Conditions.epsNotEquals(0.0)));
 
         assertEquals(comp, x);
     }
@@ -275,9 +310,20 @@ public class BooleanIndexingTest extends BaseNd4jTest {
     public void testCaSPairwiseTransform3() throws Exception {
         INDArray x = Nd4j.create(new double[]{1, 2, 0, 4, 5});
         INDArray y = Nd4j.create(new double[]{2, 4, 3, 4, 5});
+        INDArray comp = Nd4j.create(new double[]{2, 4, 3, 4, 5});
+
+        Nd4j.getExecutioner().exec(new CompareAndReplace(x, y, Conditions.lessThan(4)));
+
+        assertEquals(comp, x);
+    }
+
+    @Test
+    public void testCaRPairwiseTransform3() throws Exception {
+        INDArray x = Nd4j.create(new double[]{1, 2, 0, 4, 5});
+        INDArray y = Nd4j.create(new double[]{2, 4, 3, 4, 5});
         INDArray comp = Nd4j.create(new double[]{2, 2, 3, 4, 5});
 
-        Nd4j.getExecutioner().exec(new CompareAndSet(x, y, Conditions.lessThan(2)));
+        Nd4j.getExecutioner().exec(new CompareAndReplace(x, y, Conditions.lessThan(2)));
 
         assertEquals(comp, x);
     }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
@@ -167,7 +167,12 @@ public class BooleanIndexingTest extends BaseNd4jTest {
 
         array.slice(4).putScalar(2, 1e-5f);
 
+
+        System.out.println(array);
+
         assertFalse(BooleanIndexing.and(array, Conditions.equals(0f)));
+
+
     }
 
     @Test

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
@@ -5,8 +5,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
+import org.nd4j.linalg.indexing.conditions.Condition;
 import org.nd4j.linalg.indexing.conditions.Conditions;
 import org.nd4j.linalg.indexing.functions.Value;
 
@@ -226,6 +228,58 @@ public class BooleanIndexingTest extends BaseNd4jTest {
         System.out.println("Array after being patched: " + Arrays.toString(array.data().asFloat()));
 
         assertFalse(BooleanIndexing.and(array, Conditions.equals(0f)));
+    }
+
+    @Test
+    public void testCaSTransform1() throws Exception {
+        INDArray array = Nd4j.create(new double[]{1, 2, 0, 4, 5});
+        INDArray comp = Nd4j.create(new double[]{1, 2, 3, 4, 5});
+
+        Nd4j.getExecutioner().exec(new CompareAndSet(array, 3, Conditions.equals(0)));
+
+        assertEquals(comp, array);
+    }
+
+    @Test
+    public void testCaSTransform2() throws Exception {
+        INDArray array = Nd4j.create(new double[]{1, 2, 0, 4, 5});
+        INDArray comp = Nd4j.create(new double[]{3, 2, 3, 4, 5});
+
+        Nd4j.getExecutioner().exec(new CompareAndSet(array, 3.0, Conditions.lessThan(2)));
+
+        assertEquals(comp, array);
+    }
+
+    @Test
+    public void testCaSPairwiseTransform1() throws Exception {
+        INDArray array = Nd4j.create(new double[]{1, 2, 0, 4, 5});
+        INDArray comp = Nd4j.create(new double[]{1, 2, 3, 4, 5});
+
+        Nd4j.getExecutioner().exec(new CompareAndSet(array, comp, Conditions.lessThan(1)));
+
+        assertEquals(comp, array);
+    }
+
+    @Test
+    public void testCaSPairwiseTransform2() throws Exception {
+        INDArray x = Nd4j.create(new double[]{1, 2, 0, 4, 5});
+        INDArray y = Nd4j.create(new double[]{2, 4, 3, 4, 5});
+        INDArray comp = Nd4j.create(new double[]{2, 4, 0, 4, 5});
+
+        Nd4j.getExecutioner().exec(new CompareAndSet(x, y, Conditions.epsNotEquals(0.0)));
+
+        assertEquals(comp, x);
+    }
+
+    @Test
+    public void testCaSPairwiseTransform3() throws Exception {
+        INDArray x = Nd4j.create(new double[]{1, 2, 0, 4, 5});
+        INDArray y = Nd4j.create(new double[]{2, 4, 3, 4, 5});
+        INDArray comp = Nd4j.create(new double[]{2, 2, 3, 4, 5});
+
+        Nd4j.getExecutioner().exec(new CompareAndSet(x, y, Conditions.lessThan(2)));
+
+        assertEquals(comp, x);
     }
 
     @Override

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/indexing/BooleanIndexingTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.accum.MatchCondition;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndReplace;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndSet;
 import org.nd4j.linalg.factory.Nd4j;
@@ -326,6 +327,34 @@ public class BooleanIndexingTest extends BaseNd4jTest {
         Nd4j.getExecutioner().exec(new CompareAndReplace(x, y, Conditions.lessThan(2)));
 
         assertEquals(comp, x);
+    }
+
+
+    @Test
+    public void testMatchConditionAllDimensions1() throws Exception {
+        INDArray array = Nd4j.create(new double[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+        int val = (int) Nd4j.getExecutioner().exec(new MatchCondition(array, Conditions.lessThan(5)), Integer.MAX_VALUE).getDouble(0);
+
+        assertEquals(5, val);
+    }
+
+    @Test
+    public void testMatchConditionAllDimensions2() throws Exception {
+        INDArray array = Nd4j.create(new double[]{0, 1, 2, 3, Double.NaN, 5, 6, 7, 8, 9});
+
+        int val = (int) Nd4j.getExecutioner().exec(new MatchCondition(array, Conditions.isNan()), Integer.MAX_VALUE).getDouble(0);
+
+        assertEquals(1, val);
+    }
+
+    @Test
+    public void testMatchConditionAllDimensions3() throws Exception {
+        INDArray array = Nd4j.create(new double[]{0, 1, 2, 3, Double.NEGATIVE_INFINITY, 5, 6, 7, 8, 9});
+
+        int val = (int) Nd4j.getExecutioner().exec(new MatchCondition(array, Conditions.isInfinite()), Integer.MAX_VALUE).getDouble(0);
+
+        assertEquals(1, val);
     }
 
     @Override


### PR DESCRIPTION
***WIP; DO NOT MERGE***

Changes for BooleanIndexing:

- applyWhere with static functions/conditions goes native
- new INDArray methods added: assignIf(array, condition) and replaceWhere(array, condtion), for conditional pairwise assign. Which is similar to forward fill in python.
- Boolean and/or along all dimensions, and along TADs