### PR TITLE
[WIP] Fix issues from infer run

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -3859,7 +3859,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
         int[] shape = resolution.getShapes();
 
-        if(indexes[0] instanceof SpecifiedIndex) {
+        if(shape != null && indexes[0] instanceof SpecifiedIndex) {
             INDArray ret = create(shape);
             int count = 0;
             if(isVector()) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/compression/CompressedDataBuffer.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/compression/CompressedDataBuffer.java
@@ -93,15 +93,16 @@ public class CompressedDataBuffer extends BaseDataBuffer {
                     temp[i] = s.readByte();
                 }
 
-                Pointer pointer = new BytePointer(temp);
-                CompressionDescriptor descriptor = new CompressionDescriptor();
-                descriptor.setCompressedLength(compressedLength);
-                descriptor.setCompressionAlgorithm(compressionAlgorithm);
-                descriptor.setOriginalLength(originalLength);
-                descriptor.setNumberOfElements(numberOfElements);
+                try(Pointer pointer = new BytePointer(temp)){
+                    CompressionDescriptor descriptor = new CompressionDescriptor();
+                    descriptor.setCompressedLength(compressedLength);
+                    descriptor.setCompressionAlgorithm(compressionAlgorithm);
+                    descriptor.setOriginalLength(originalLength);
+                    descriptor.setNumberOfElements(numberOfElements);
 
-                CompressedDataBuffer compressedBuffer = new CompressedDataBuffer(pointer, descriptor);
-                return Nd4j.getCompressor().decompress(compressedBuffer);
+                    CompressedDataBuffer compressedBuffer = new CompressedDataBuffer(pointer, descriptor);
+                    return Nd4j.getCompressor().decompress(compressedBuffer);
+                }
 
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MiniBatchFileDataSetIterator.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MiniBatchFileDataSetIterator.java
@@ -198,7 +198,7 @@ public class MiniBatchFileDataSetIterator implements DataSetIterator {
         DataOutputStream dosLabels = new DataOutputStream(dataOutLabels);
         Nd4j.write(write.getLabels(), dosLabels);
         dosLabels.flush();
-        dos.close();
+        dosLabels.close();
         ret[0] = new File(rootDir,dataSetId + ".bin").getAbsolutePath();
         ret[1] = new File(rootDir,dataSetId + ".labels.bin").getAbsolutePath();
         return ret;

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InFileAndMemoryDataSetCache.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InFileAndMemoryDataSetCache.java
@@ -48,7 +48,7 @@ public class InFileAndMemoryDataSetCache implements DataSetCache {
             }
         } else if (fileCache.contains(key)) {
             dataSet = fileCache.get(key);
-            if (!memoryCache.contains(key)) {
+            if (dataSet != null && !memoryCache.contains(key)) {
                 memoryCache.put(key, dataSet);
             }
         }

--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/compression/impl/Gzip.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/compression/impl/Gzip.java
@@ -63,17 +63,14 @@ public class Gzip extends AbstractCompressor {
 
     @Override
     public DataBuffer compress(DataBuffer buffer) {
-        try {
-            ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            GZIPOutputStream gzip = new GZIPOutputStream(stream);
-            DataOutputStream dos = new DataOutputStream(gzip);
+        try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
+             GZIPOutputStream gzip = new GZIPOutputStream(stream);
+             DataOutputStream dos = new DataOutputStream(gzip)){
 
             buffer.write(dos);
-            dos.flush();
-            dos.close();
 
             byte[] bytes = stream.toByteArray();
-//            logger.info("Bytes: {}", Arrays.toString(bytes));
+            //            logger.info("Bytes: {}", Arrays.toString(bytes));
             BytePointer pointer = new BytePointer(bytes);
             CompressionDescriptor descriptor = new CompressionDescriptor(buffer, this);
             descriptor.setCompressedLength(bytes.length);

--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/compression/impl/Gzip.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/compression/impl/Gzip.java
@@ -63,14 +63,17 @@ public class Gzip extends AbstractCompressor {
 
     @Override
     public DataBuffer compress(DataBuffer buffer) {
-        try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
-             GZIPOutputStream gzip = new GZIPOutputStream(stream);
-             DataOutputStream dos = new DataOutputStream(gzip)){
+        try {
+            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            GZIPOutputStream gzip = new GZIPOutputStream(stream);
+            DataOutputStream dos = new DataOutputStream(gzip);
 
             buffer.write(dos);
+            dos.flush();
+            dos.close();
 
             byte[] bytes = stream.toByteArray();
-            //            logger.info("Bytes: {}", Arrays.toString(bytes));
+//            logger.info("Bytes: {}", Arrays.toString(bytes));
             BytePointer pointer = new BytePointer(bytes);
             CompressionDescriptor descriptor = new CompressionDescriptor(buffer, this);
             descriptor.setCompressedLength(bytes.length);


### PR DESCRIPTION
Fixes #1297.

Among places underlines by infer, one of the common patterns is 

```
BufferedOutputStream bs = ...
DataOutputStream dos = new DataOutputStream(dos);
<do stg with dos>
dos.close();
```

[Infer](https://github.com/facebook/infer), in this case, reports the innermost resource as un-closed even though in most situations the flush & close of the outermost resource does close the innermost. That's because an exception during the flush of one of the outer streams will leave any stream constructed by the nested calls inside it open.

I did not address those cases because a consistent tackling of this issue would most likely be a codebase-wide refactor to `try .. with` construct (ideally tool-powered).

Suggested reviewer @raver119 