### PR TITLE
Update LossBinaryXENT.java

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
@@ -27,7 +27,7 @@ public class LossBinaryXENT implements ILossFunction {
 
         } else {
             INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
-            scoreArr = Transforms.log(output, false).muli(labels);
+            scoreArr = Transforms.log(output, true).muli(labels);
             INDArray secondTerm = output.rsub(1);
             Transforms.log(secondTerm,false);
             secondTerm.muli(labels.rsub(1));


### PR DESCRIPTION
The log(output) at line 30 should not be done inline. Because, then line 31 does secondTerm = 1-log(activation(preOutput)) instead of 1-activation(preOutput) So, I just changed line 30 from Transforms.log(output, false) to Transforms.log(output, true)