### PR TITLE
Tests fix

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -55,11 +55,11 @@
                         <includes>
                             <include>**/Nd4jTestSuite.java</include>
                         </includes>
-                        <excludes>
+<!--                        <excludes>
                             <exclude>**/Test*.java</exclude>
                             <exclude>**/*Test.java</exclude>
                             <exclude>**/*TestCase.java</exclude>
-                        </excludes>
+                        </excludes> -->
                     </configuration>
                 </plugin>
                 <plugin>

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/NormalizerMinMaxScalerTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/NormalizerMinMaxScalerTest.java
@@ -96,6 +96,7 @@ public class NormalizerMinMaxScalerTest  extends BaseNd4jTest {
         myNormalizer.revert(transformed);
         INDArray delta = Transforms.abs(transformed.getFeatures().sub(sampleDataSet.getFeatures())).div(sampleDataSet.getFeatures());
         double maxdeltaPerc = delta.max(0,1).mul(100).getDouble(0,0);
+        System.out.println("Delta: " + maxdeltaPerc);
         assertTrue(maxdeltaPerc < tolerancePerc);
 
     }
@@ -121,6 +122,7 @@ public class NormalizerMinMaxScalerTest  extends BaseNd4jTest {
         myNormalizer.revert(transformed);
         INDArray delta = Transforms.abs(transformed.getFeatures().sub(sampleDataSet.getFeatures())).div(sampleDataSet.getFeatures());
         double maxdeltaPerc = delta.max(0,1).mul(100).getDouble(0,0);
+        System.out.println("Delta: " + maxdeltaPerc);
         assertTrue(maxdeltaPerc < tolerancePerc);
     }
 


### PR DESCRIPTION
Cancel exclusion for nd4j-tests, to get all nd4j-tests running via `mvn test`