### PR TITLE
LossBinaryXENT computes the gradient incorrectly

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
@@ -27,7 +27,7 @@ public class LossBinaryXENT implements ILossFunction {
 
         } else {
             INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
-            scoreArr = Transforms.log(output, false).muli(labels);
+            scoreArr = Transforms.log(output, true).muli(labels);
             INDArray secondTerm = output.rsub(1);
             Transforms.log(secondTerm,false);
             secondTerm.muli(labels.rsub(1));


### PR DESCRIPTION
Basically, as is, LossBinaryXENT _always_ returns zero as the gradient when the target is zero. More discussion is at https://github.com/deeplearning4j/nd4j/issues/1328