### PR TITLE
Fix LossKLD

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossKLD.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossKLD.java
@@ -8,8 +8,6 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossUtil;
 import org.nd4j.linalg.ops.transforms.Transforms;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Created by susaneraly on 8/9/16.
@@ -19,6 +17,11 @@ public class LossKLD implements ILossFunction {
 
     private INDArray scoreArray(INDArray labels, INDArray preOutput, String activationFn, INDArray mask) {
         INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
+
+        // Clip output and labels to be between Nd4j.EPS_THREsHOLD and 1, i.e. a valid non-zero probability
+        output = Transforms.min(Transforms.max(output, Nd4j.EPS_THRESHOLD, false), 1, false);
+        labels = Transforms.min(Transforms.max(labels, Nd4j.EPS_THRESHOLD, true), 1, false);
+
         INDArray logRatio = Transforms.log(output.rdivi(labels), false);
 
         INDArray scoreArr = logRatio.muli(labels);


### PR DESCRIPTION
This was running into NaNs pretty instantly because KL Divergence expects non-zero probabilities.

This changes the score calculation to be exactly the same as it is in Keras (https://github.com/fchollet/keras/blob/master/keras/objectives.py#L51).

I'm not quite sure if the computeGradient method is correct, as is as well. But introducing this change at least results in not NaN scores.