### PR TITLE
Fixed build issues related to POM duplicate definitions.

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -204,10 +204,6 @@
             <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
 
     </dependencies>
 </project>

--- a/nd4j-parameter-server-parent/nd4j-parameter-server/pom.xml
+++ b/nd4j-parameter-server-parent/nd4j-parameter-server/pom.xml
@@ -120,12 +120,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
@@ -151,11 +145,6 @@
             <artifactId>zt-exec</artifactId>
             <version>1.9</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-parameter-server-model</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
POMs were polluted with duplicate definitions. I fixed it.