### PR TITLE
Add mavent-lint to the build to check for duplicate/redundant deps.

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -46,7 +46,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -14,17 +14,16 @@
     </properties>
 
     <build>
-		<testSourceDirectory>../../nd4j-tests/src/test/java</testSourceDirectory>
+                <testSourceDirectory>../../nd4j-tests/src/test/java</testSourceDirectory>
         <testResources>
             <testResource>
                 <directory>${project.basedir}/../../nd4j-tests/src/test/resources</directory>
             </testResource>
-		</testResources>
+                </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
@@ -157,7 +156,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <environmentVariables>
                         <LD_LIBRARY_PATH>${env.LD_LIBRARY_PATH}:${user.dir}:${env.LIBND4J_HOME}/blasbuild/cpu/blas/</LD_LIBRARY_PATH>

--- a/nd4j-backends/nd4j-tests/pom.xml
+++ b/nd4j-backends/nd4j-tests/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <scala.binary.version>2.10</scala.binary.version>
-        <junit.version>4.12</junit.version>
     </properties>
     <build>
         <plugins>
@@ -52,7 +51,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
         </dependency>
 
         <dependency>

--- a/nd4j-bytebuddy/pom.xml
+++ b/nd4j-bytebuddy/pom.xml
@@ -17,7 +17,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>

--- a/nd4j-jdbc/nd4j-jdbc-mysql/pom.xml
+++ b/nd4j-jdbc/nd4j-jdbc-mysql/pom.xml
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nd4j-jdbc/pom.xml
+++ b/nd4j-jdbc/pom.xml
@@ -40,7 +40,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>

--- a/nd4j-serde/nd4j-aeron/pom.xml
+++ b/nd4j-serde/nd4j-aeron/pom.xml
@@ -38,13 +38,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/nd4j-serde/nd4j-kryo/pom.xml
+++ b/nd4j-serde/nd4j-kryo/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,31 @@
                     <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>com.lewisd</groupId>
+              <artifactId>lint-maven-plugin</artifactId>
+              <version>0.0.8</version>
+              <configuration>
+                <failOnViolation>true</failOnViolation>
+                <onlyRunRules>
+                  <rule>DuplicateDep</rule>
+                  <rule>RedundantDepVersion</rule>
+                  <rule>RedundantPluginVersion</rule>
+                  <rule>VersionProp</rule>
+                  <rule>DotVersionProperty</rule>
+                </onlyRunRules>
+                <xmlOutputFile>${project.build.directory}/maven-lint-result.xml</xmlOutputFile>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>pom-lint</id>
+                  <phase>validate</phase>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
         </plugins>
 
         <pluginManagement>


### PR DESCRIPTION
Avoids issues like #1345

Please consider testing since this removes the hardcoding of a few versions.