### PR TITLE
added ability to allow the user to set format of decimal with tests. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Several of these modules are different backend options for ND4J (including GPUs)
 - scala-notebook = Integration with Scala Notebook
 
 ---
+
+## Building Specific Modules
+
+It is possible to build the project without the native bindings. This can be done
+by specic targeting of the project to build.
+
+```
+mvn clean package test -pl :nd4j-api
+```
+
 ## Documentation
 
 Documentation is available at [nd4j.org](http://nd4j.org/). Access the [JavaDocs](http://nd4j.org/doc/) for more detail.
@@ -77,7 +87,7 @@ Add the local compiled file dependency (choose the module for your backend) to y
 #### Yum Install / Load RPM (Fedora or CentOS)
 Create a yum repo and run yum install to load the Red Hat Package Management (RPM) files. First create the repo file to setup the configuration locally.
 
-    $ sudo vi /etc/yum.repos.d/dl4j.repo 
+    $ sudo vi /etc/yum.repos.d/dl4j.repo
 
 Add the following to the dl4j.repo file:
 
@@ -123,4 +133,4 @@ Or, run the following command to execute only specified tests in TestSuite with 
 2. If you feel uncomfortable or uncertain about an issue or your changes, feel free to contact us on Gitter using the link above.
 3. Fork [the repository](https://github.com/deeplearning4j/nd4j.git) on GitHub to start making your changes to the **master** branch (or branch off of it).
 4. Write a test, which shows that the bug was fixed or that the feature works as expected.
-5. Send a pull request, and bug us on Gitter until it gets merged and published. 
+5. Send a pull request, and bug us on Gitter until it gets merged and published.

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/string/NDArrayStrings.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/string/NDArrayStrings.java
@@ -21,14 +21,19 @@ public class NDArrayStrings {
     private DecimalFormat decimalFormat = new DecimalFormat(decFormatNum + decFormatRest);
 
     public NDArrayStrings(String sep) {
-        this(", ",2);
+        this(", ",2,"#,###,##0");
     }
 
     public NDArrayStrings(int precision) {
-        this(", ",precision);
+        this(", ",precision, "#,###,##0");
     }
-    
+
     public NDArrayStrings(String sep, int precision) {
+        this(sep, precision, "#,###,##0");
+    }
+
+    public NDArrayStrings(String sep, int precision, String decFormat) {
+        this.decFormatNum = decFormat;
         this.sep = sep;
         if (precision != 0) {
             this.decFormatRest = ".";
@@ -45,7 +50,7 @@ public class NDArrayStrings {
     }
 
     public NDArrayStrings() {
-        this(", ",2);
+        this(", ",2,"#,###,##0");
     }
 
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/string/TestFormatting.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/string/TestFormatting.java
@@ -1,5 +1,6 @@
 package org.nd4j.linalg.api.string;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -25,6 +26,27 @@ public class TestFormatting extends BaseNd4jTest {
         System.out.println(new NDArrayStrings().format(arr));
 
     }
+
+    @Test
+    public void testNd4jArrayString(){
+
+        //2d array
+        INDArray arr = Nd4j.create(new float[]{1f,20000000f,40.838383f,3f}, new int[]{2,2});
+
+        //default
+        String expected1 = "[[         1.00,20,000,000.00],\n" +
+                " [        40.84,         3.00]]";
+        String serializedData1 = new NDArrayStrings(",",2).format(arr);
+        Assert.assertTrue(serializedData1.equals(expected1));
+
+        //remove commas
+        String expected2 = "[[       1.00,20000000.00],\n" +
+                " [      40.84,       3.00]]";
+        String serializedData2 = new NDArrayStrings(",",2,"######0").format(arr);
+        Assert.assertTrue(serializedData2.equals(expected2));
+
+    }
+
 
     @Override
     public char ordering() {


### PR DESCRIPTION
I attempted to add a test but when I added the tests they would not get run as part of the test phase. I have tested the implementation using the following test:

```
    @Test
    public void testNd4jArrayString(){

        //2d array
        INDArray arr = Nd4j.create(new float[]{1f,20000000f,40.838383f,3f}, new int[]{2,2});

        //default
        String expected1 = "[[         1.00,20,000,000.00],\n" +
                " [        40.84,         3.00]]";
        String serializedData1 = new NDArrayStrings(",",2).format(arr);
        Assert.assertTrue(serializedData1.equals(expected1));

        //remove commas
        String expected2 = "[[       1.00,20000000.00],\n" +
                " [      40.84,       3.00]]";
        String serializedData2 = new NDArrayStrings(",",2,"######0").format(arr);
        Assert.assertTrue(serializedData2.equals(expected2));

    }
```