### PR TITLE
Add weighted loss function support

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
@@ -6,7 +6,13 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.LogSoftMax;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorDeserializer;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorSerializer;
 import org.nd4j.linalg.ops.transforms.Transforms;
+import org.nd4j.shade.jackson.annotation.JsonInclude;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
+import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,16 +20,19 @@ import org.slf4j.LoggerFactory;
  * Created by susaneraly on 8/22/16.
  */
 @EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LossBinaryXENT implements ILossFunction {
 
+    @JsonSerialize(using = RowVectorSerializer.class)
+    @JsonDeserialize(using = RowVectorDeserializer.class)
     private final INDArray weights;
 
-    public LossBinaryXENT(){
+    public LossBinaryXENT() {
         this(null);
     }
 
-    public LossBinaryXENT(INDArray weights){
-        if( weights != null && !weights.isRowVector()){
+    public LossBinaryXENT(INDArray weights) {
+        if (weights != null && !weights.isRowVector()) {
             throw new IllegalArgumentException("Weights array must be a row vector");
         }
         this.weights = weights;
@@ -40,7 +49,7 @@ public class LossBinaryXENT implements ILossFunction {
             INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
             scoreArr = Transforms.log(output, true).muli(labels);
             INDArray secondTerm = output.rsub(1);
-            Transforms.log(secondTerm,false);
+            Transforms.log(secondTerm, false);
             secondTerm.muli(labels.rsub(1));
             scoreArr.addi(secondTerm);
         }
@@ -97,8 +106,8 @@ public class LossBinaryXENT implements ILossFunction {
         }
 
         //Weighted loss function
-        if(weights != null){
-            if(weights.length() != output.size(1)){
+        if (weights != null) {
+            if (weights.length() != output.size(1)) {
                 throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
             }
             grad.muliRowVector(weights);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
@@ -1,6 +1,7 @@
 package org.nd4j.linalg.lossfunctions.impl;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.LogSoftMax;
@@ -10,17 +11,20 @@ import org.nd4j.linalg.lossfunctions.serde.RowVectorDeserializer;
 import org.nd4j.linalg.lossfunctions.serde.RowVectorSerializer;
 import org.nd4j.linalg.ops.transforms.Transforms;
 import org.nd4j.shade.jackson.annotation.JsonInclude;
-import org.nd4j.shade.jackson.annotation.JsonProperty;
 import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
 import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Created by susaneraly on 8/22/16.
+ * Binary cross entropy loss function
+ * <a href="https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_error_function_and_logistic_regression">
+ * https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_error_function_and_logistic_regression</a>
+ * Labels are assumed to take values 0 or 1
+ *
+ * @author Susan Eraly
  */
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
 public class LossBinaryXENT implements ILossFunction {
 
     @JsonSerialize(using = RowVectorSerializer.class)
@@ -31,6 +35,13 @@ public class LossBinaryXENT implements ILossFunction {
         this(null);
     }
 
+    /**
+     * Binary cross entropy where each the output is (optionally) weighted/scaled by a fixed scalar value.
+     * Note that the weights array must be a row vector, of length equal to the labels/output dimension 1 size.
+     * A weight vector of 1s should give identical results to no weight vector.
+     *
+     * @param weights Weights array (row vector). May be null.
+     */
     public LossBinaryXENT(INDArray weights) {
         if (weights != null && !weights.isRowVector()) {
             throw new IllegalArgumentException("Weights array must be a row vector");
@@ -93,10 +104,7 @@ public class LossBinaryXENT implements ILossFunction {
         INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
 
         if ("softmax".equals(activationFn)) {
-            if(weights != null){
-                if(weights.length() != output.size(1)){
-                    throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
-                }
+            if (weights != null) {
                 INDArray temp = labels.mulRowVector(weights);
                 INDArray col = temp.sum(1);
                 grad = output.mulColumnVector(col).sub(temp);
@@ -141,6 +149,7 @@ public class LossBinaryXENT implements ILossFunction {
 
     @Override
     public String toString() {
-        return "LossBinaryXENT()";
+        if (weights == null) return "LossBinaryXENT()";
+        return "LossBinaryXENT(weights=" + weights + ")";
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossKLD.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossKLD.java
@@ -10,7 +10,9 @@ import org.nd4j.linalg.lossfunctions.LossUtil;
 import org.nd4j.linalg.ops.transforms.Transforms;
 
 /**
- * Created by susaneraly on 8/9/16.
+ * Kullback Leibler Divergence loss function
+ *
+ * @author Susan Eraly
  */
 @EqualsAndHashCode
 public class LossKLD implements ILossFunction {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL1.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL1.java
@@ -7,13 +7,20 @@ import org.nd4j.linalg.api.ops.impl.transforms.Sign;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossUtil;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorDeserializer;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorSerializer;
+import org.nd4j.shade.jackson.annotation.JsonInclude;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
+import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Created by susaneraly on 9/14/16.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LossL1 implements ILossFunction {
 
+    @JsonSerialize(using = RowVectorSerializer.class)
+    @JsonDeserialize(using = RowVectorDeserializer.class)
     private final INDArray weights;
 
     public LossL1(){

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL1.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL1.java
@@ -21,6 +21,9 @@ public class LossL1 implements ILossFunction {
     }
 
     public LossL1(INDArray weights){
+        if( weights != null && !weights.isRowVector()){
+            throw new IllegalArgumentException("Weights array must be a row vector");
+        }
         this.weights = weights;
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL1.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL1.java
@@ -78,20 +78,16 @@ public class LossL1 implements ILossFunction {
         INDArray outSubLabels = output.sub(labels);
         INDArray dlda = Nd4j.getExecutioner().execAndReturn(new Sign(outSubLabels));
 
+        if(weights != null){
+            dlda.muliRowVector(weights);
+        }
+
         INDArray gradients;
         if ("softmax".equals(activationFn)) {
             gradients = LossUtil.dLdZsoftmaxi(dlda, output);
         } else {
             INDArray sigmaPrimeZ = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()).derivative());
             gradients = dlda.muli(sigmaPrimeZ);
-        }
-
-        //Weighted loss function
-        if(weights != null){
-            if(weights.length() != output.size(1)){
-                throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
-            }
-            gradients.muliRowVector(weights);
         }
 
         if (mask != null) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL2.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL2.java
@@ -20,7 +20,9 @@ public class LossL2 implements ILossFunction {
     }
 
     public LossL2(INDArray weights){
-        if(!weights.isRowVector()) throw new IllegalArgumentException("Weights array must be a row vector");
+        if( weights != null && !weights.isRowVector()){
+            throw new IllegalArgumentException("Weights array must be a row vector");
+        }
         this.weights = weights;
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL2.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL2.java
@@ -6,17 +6,25 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossUtil;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorDeserializer;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorSerializer;
+import org.nd4j.shade.jackson.annotation.JsonInclude;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
+import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Created by susaneraly on 9/14/16.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LossL2 implements ILossFunction {
 
+    @JsonSerialize(using = RowVectorSerializer.class)
+    @JsonDeserialize(using = RowVectorDeserializer.class)
     private final INDArray weights;
 
     public LossL2(){
         this(null);
+
     }
 
     public LossL2(INDArray weights){

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAE.java
@@ -4,15 +4,25 @@ import lombok.EqualsAndHashCode;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**
- * Created by susaneraly on 8/15/16.
+ * Mean absolute error loss function: L = 1/N sum_i abs(predicted_i - actual_i)
+ * See also {@link LossL1} for a mathematically similar loss function (LossL1 does not have division by N, where N is output size)
+ *
+ * @author Susan Eraly
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class LossMAE extends LossL1 {
 
     public LossMAE(){
 
     }
 
+    /**
+     * Mean Absolute Error loss function where each the output is (optionally) weighted/scaled by a fixed scalar value.
+     * Note that the weights array must be a row vector, of length equal to the labels/output dimension 1 size.
+     * A weight vector of 1s should give identical results to no weight vector.
+     *
+     * @param weights Weights array (row vector). May be null.
+     */
     public LossMAE(INDArray weights){
         super(weights);
     }
@@ -41,6 +51,7 @@ public class LossMAE extends LossL1 {
 
     @Override
     public String toString() {
-        return "LossMAE()";
+        if(weights == null) return "LossMAE()";
+        return "LossMAE(weights=" + weights + ")";
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAE.java
@@ -9,6 +9,14 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 @EqualsAndHashCode
 public class LossMAE extends LossL1 {
 
+    public LossMAE(){
+
+    }
+
+    public LossMAE(INDArray weights){
+        super(weights);
+    }
+
     @Override
     public double computeScore(INDArray labels, INDArray preOutput, String activationFn, INDArray mask, boolean average) {
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAPE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAPE.java
@@ -1,6 +1,7 @@
 package org.nd4j.linalg.lossfunctions.impl;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.Abs;
@@ -17,7 +18,9 @@ import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 /**
  * Created by susaneraly on 8/15/16.
  */
-@EqualsAndHashCode @JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
 public class LossMAPE implements ILossFunction {
 
     @JsonSerialize(using = RowVectorSerializer.class)
@@ -28,8 +31,15 @@ public class LossMAPE implements ILossFunction {
         this(null);
     }
 
+    /**
+     * Mean Absolute Percentage Error loss function where each the output is (optionally) weighted/scaled by a fixed scalar value.
+     * Note that the weights array must be a row vector, of length equal to the labels/output dimension 1 size.
+     * A weight vector of 1s should give identical results to no weight vector.
+     *
+     * @param weights Weights array (row vector). May be null.
+     */
     public LossMAPE(INDArray weights) {
-        if( weights != null && !weights.isRowVector()){
+        if (weights != null && !weights.isRowVector()) {
             throw new IllegalArgumentException("Weights array must be a row vector");
         }
         this.weights = weights;
@@ -84,10 +94,7 @@ public class LossMAPE implements ILossFunction {
         dlda.divi(absLabels).muli(-100.0 / labels.size(1));
 
         //Weighted loss function
-        if(weights != null){
-            if(weights.length() != output.size(1)){
-                throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
-            }
+        if (weights != null) {
             dlda.muliRowVector(weights);
         }
 
@@ -109,7 +116,6 @@ public class LossMAPE implements ILossFunction {
     @Override
     public org.apache.commons.math3.util.Pair<Double, INDArray> computeGradientAndScore(INDArray labels, INDArray preOutput, String activationFn, INDArray mask, boolean average) {
         //TODO: probably a more efficient way to do this...
-        //Yes - will implement in round two. Just want to get done now.
 
         return new Pair<>(
                 computeScore(labels, preOutput, activationFn, mask, average),
@@ -118,7 +124,8 @@ public class LossMAPE implements ILossFunction {
 
     @Override
     public String toString() {
-        return "LossMAPE()";
+        if (weights == null) return "LossMAPE()";
+        return "LossMAPE(weights=" + weights + ")";
     }
 
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAPE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAPE.java
@@ -8,13 +8,20 @@ import org.nd4j.linalg.api.ops.impl.transforms.Sign;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossUtil;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorDeserializer;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorSerializer;
+import org.nd4j.shade.jackson.annotation.JsonInclude;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
+import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Created by susaneraly on 8/15/16.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LossMAPE implements ILossFunction {
 
+    @JsonSerialize(using = RowVectorSerializer.class)
+    @JsonDeserialize(using = RowVectorDeserializer.class)
     private final INDArray weights;
 
     public LossMAPE() {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAPE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAPE.java
@@ -83,20 +83,20 @@ public class LossMAPE implements ILossFunction {
         INDArray absLabels = Nd4j.getExecutioner().execAndReturn(new Abs(labels.dup()));
         dlda.divi(absLabels).muli(-100.0 / labels.size(1));
 
+        //Weighted loss function
+        if(weights != null){
+            if(weights.length() != output.size(1)){
+                throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
+            }
+            dlda.muliRowVector(weights);
+        }
+
         INDArray gradient;
         if ("softmax".equals(activationFn)) {
             gradient = LossUtil.dLdZsoftmaxi(dlda, output);
         } else {
             INDArray sigmaPrimeZ = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()).derivative());
             gradient = dlda.muli(sigmaPrimeZ);
-        }
-
-        //Weighted loss function
-        if(weights != null){
-            if(weights.length() != output.size(1)){
-                throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
-            }
-            gradient.muliRowVector(weights);
         }
 
         if (mask != null) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
@@ -2,6 +2,7 @@ package org.nd4j.linalg.lossfunctions.impl;
 
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.LogSoftMax;
@@ -17,23 +18,35 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Created by
- * Alex D Black
- * Susan Eraly
+ *
+ * Multi-Class Cross Entropy loss function:<br>
+ * L = sum_i actual_i * log( predicted_i )
+ *
+ * @author Alex Black, Susan Eraly
+ * @see LossNegativeLogLikelihood
  */
-@EqualsAndHashCode @JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
 public class LossMCXENT implements ILossFunction {
 
     @JsonSerialize(using = RowVectorSerializer.class)
     @JsonDeserialize(using = RowVectorDeserializer.class)
     private final INDArray weights;
 
-    public LossMCXENT(){
+    public LossMCXENT() {
         this(null);
     }
 
-    public LossMCXENT(INDArray weights){
-        if( weights != null && !weights.isRowVector()){
+    /**
+     * Multi-Class Cross Entropy loss function where each the output is (optionally) weighted/scaled by a fixed scalar value.
+     * Note that the weights array must be a row vector, of length equal to the labels/output dimension 1 size.
+     * A weight vector of 1s should give identical results to no weight vector.
+     *
+     * @param weights Weights array (row vector). May be null.
+     */
+    public LossMCXENT(INDArray weights) {
+        if (weights != null && !weights.isRowVector()) {
             throw new IllegalArgumentException("Weights array must be a row vector");
         }
         this.weights = weights;
@@ -52,8 +65,8 @@ public class LossMCXENT implements ILossFunction {
         }
 
         //Weighted loss function
-        if(weights != null){
-            if(weights.length() != scoreArr.size(1)){
+        if (weights != null) {
+            if (weights.length() != scoreArr.size(1)) {
                 throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + preOutput.size(1));
             }
             scoreArr.muliRowVector(weights);
@@ -91,8 +104,8 @@ public class LossMCXENT implements ILossFunction {
 
         if ("softmax".equals(activationFn)) {
             //Weighted loss function
-            if(weights != null){
-                if(weights.length() != output.size(1)){
+            if (weights != null) {
+                if (weights.length() != output.size(1)) {
                     throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
                 }
                 INDArray temp = labels.mulRowVector(weights);
@@ -107,14 +120,13 @@ public class LossMCXENT implements ILossFunction {
             grad.divi(output).muli(-1);
 
             //Weighted loss function
-            if(weights != null){
-                if(weights.length() != output.size(1)){
+            if (weights != null) {
+                if (weights.length() != output.size(1)) {
                     throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
                 }
                 grad.muliRowVector(weights);
             }
         }
-
 
 
         //Loss function with masking
@@ -137,6 +149,7 @@ public class LossMCXENT implements ILossFunction {
 
     @Override
     public String toString() {
-        return "LossMCXENT()";
+        if (weights == null) return "LossMCXENT()";
+        return "LossMCXENT(weights=" + weights + ")";
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
@@ -90,17 +90,15 @@ public class LossMCXENT implements ILossFunction {
         INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
 
         if ("softmax".equals(activationFn)) {
-
-
             //Weighted loss function
             if(weights != null){
                 if(weights.length() != output.size(1)){
                     throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
                 }
-//                grad.muliRowVector(weights);
-                grad = output.subi(labels.mulRowVector(weights));
+                INDArray temp = labels.mulRowVector(weights);
+                INDArray col = temp.sum(1);
+                grad = output.mulColumnVector(col).sub(temp);
             } else {
-
                 grad = output.subi(labels);
             }
         } else {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
@@ -26,6 +26,9 @@ public class LossMCXENT implements ILossFunction {
     }
 
     public LossMCXENT(INDArray weights){
+        if( weights != null && !weights.isRowVector()){
+            throw new IllegalArgumentException("Weights array must be a row vector");
+        }
         this.weights = weights;
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
@@ -7,7 +7,12 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.LogSoftMax;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorDeserializer;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorSerializer;
 import org.nd4j.linalg.ops.transforms.Transforms;
+import org.nd4j.shade.jackson.annotation.JsonInclude;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
+import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,9 +21,11 @@ import org.slf4j.LoggerFactory;
  * Alex D Black
  * Susan Eraly
  */
-@EqualsAndHashCode
+@EqualsAndHashCode @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LossMCXENT implements ILossFunction {
 
+    @JsonSerialize(using = RowVectorSerializer.class)
+    @JsonDeserialize(using = RowVectorDeserializer.class)
     private final INDArray weights;
 
     public LossMCXENT(){

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSE.java
@@ -1,42 +1,55 @@
 package org.nd4j.linalg.lossfunctions.impl;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**
- * Created by Alex on 08/08/2016.
+ * Mean Squared Error loss function: L = 1/N sum_i (actual_i - predicted)^2
+ * See also {@link LossL2} for a mathematically similar loss function (LossL2 does not have division by N, where N is output size)
+ *
+ * @author Susan Eraly
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class LossMSE extends LossL2 {
 
-    public LossMSE(){ }
+    public LossMSE() {
+    }
 
-    public LossMSE(INDArray weights){
+    /**
+     * Mean Squared Error loss function where each the output is (optionally) weighted/scaled by a fixed scalar value.
+     * Note that the weights array must be a row vector, of length equal to the labels/output dimension 1 size.
+     * A weight vector of 1s should give identical results to no weight vector.
+     *
+     * @param weights Weights array (row vector). May be null.
+     */
+    public LossMSE(INDArray weights) {
         super(weights);
     }
 
     @Override
     public double computeScore(INDArray labels, INDArray preOutput, String activationFn, INDArray mask, boolean average) {
 
-        double score = super.computeScore(labels,preOutput,activationFn,mask,average);
+        double score = super.computeScore(labels, preOutput, activationFn, mask, average);
         score /= (labels.size(1));
         return score;
     }
 
     @Override
     public INDArray computeScoreArray(INDArray labels, INDArray preOutput, String activationFn, INDArray mask) {
-        INDArray scoreArr = super.computeScoreArray(labels,preOutput,activationFn,mask);
+        INDArray scoreArr = super.computeScoreArray(labels, preOutput, activationFn, mask);
         return scoreArr.divi(labels.size(1));
     }
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, String activationFn, INDArray mask) {
-        INDArray gradients = super.computeGradient(labels,preOutput,activationFn,mask);
+        INDArray gradients = super.computeGradient(labels, preOutput, activationFn, mask);
         return gradients.divi(labels.size(1));
     }
 
     @Override
     public String toString() {
-        return "LossMSE()";
+        if (weights == null) return "LossMSE()";
+        return "LossMSE(weights=" + weights + ")";
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSE.java
@@ -9,6 +9,12 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 @EqualsAndHashCode
 public class LossMSE extends LossL2 {
 
+    public LossMSE(){ }
+
+    public LossMSE(INDArray weights){
+        super(weights);
+    }
+
     @Override
     public double computeScore(INDArray labels, INDArray preOutput, String activationFn, INDArray mask, boolean average) {
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSLE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSLE.java
@@ -1,6 +1,7 @@
 package org.nd4j.linalg.lossfunctions.impl;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
@@ -14,21 +15,32 @@ import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
 import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 
 /**
- * Created by susaneraly on 8/15/16.
+ * Mean Squared Logarithmic Error loss function: L = 1/N sum_i (log(1+predicted_i) - log(1+actual_i))^2
+ *
+ * @author Susan Eraly
  */
-@EqualsAndHashCode @JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
 public class LossMSLE implements ILossFunction {
 
     @JsonSerialize(using = RowVectorSerializer.class)
     @JsonDeserialize(using = RowVectorDeserializer.class)
     private final INDArray weights;
 
-    public LossMSLE(){
+    public LossMSLE() {
         this(null);
     }
 
-    public LossMSLE(INDArray weights){
-        if( weights != null && !weights.isRowVector()){
+    /**
+     * Mean Squared Logarithmic Error loss function where each the output is (optionally) weighted/scaled by a fixed scalar value.
+     * Note that the weights array must be a row vector, of length equal to the labels/output dimension 1 size.
+     * A weight vector of 1s should give identical results to no weight vector.
+     *
+     * @param weights Weights array (row vector). May be null.
+     */
+    public LossMSLE(INDArray weights) {
+        if (weights != null && !weights.isRowVector()) {
             throw new IllegalArgumentException("Weights array must be a row vector");
         }
         this.weights = weights;
@@ -48,7 +60,7 @@ public class LossMSLE implements ILossFunction {
             scoreArr.muliRowVector(weights);
         }
 
-        if (mask != null){
+        if (mask != null) {
             scoreArr.muliColumnVector(mask);
         }
         return scoreArr;
@@ -82,7 +94,7 @@ public class LossMSLE implements ILossFunction {
             INDArray logRatio = Transforms.log(p1.divi(labels.add(1.0)), false);
             dlda.muli(logRatio);
 
-            if(weights != null){
+            if (weights != null) {
                 dlda.muliRowVector(weights);
             }
 
@@ -95,7 +107,7 @@ public class LossMSLE implements ILossFunction {
             gradients.muli(logRatio);
 
             //Weighted loss function
-            if(weights != null){
+            if (weights != null) {
                 gradients.muliRowVector(weights);
             }
         }
@@ -119,7 +131,8 @@ public class LossMSLE implements ILossFunction {
 
     @Override
     public String toString() {
-        return "LossMSLE()";
+        if (weights == null) return "LossMSLE()";
+        return "LossMSLE(weights=" + weights + ")";
     }
 
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSLE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSLE.java
@@ -81,6 +81,11 @@ public class LossMSLE implements ILossFunction {
             INDArray dlda = p1.rdiv(2.0 / labels.size(1));
             INDArray logRatio = Transforms.log(p1.divi(labels.add(1.0)), false);
             dlda.muli(logRatio);
+
+            if(weights != null){
+                dlda.muliRowVector(weights);
+            }
+
             gradients = LossUtil.dLdZsoftmaxi(dlda, output);
         } else {
             INDArray p1 = output.addi(1.0);
@@ -88,14 +93,11 @@ public class LossMSLE implements ILossFunction {
             gradients = sigmaPrimeZ.divi(p1).muli(2.0 / labels.size(1));
             INDArray logRatio = Transforms.log(p1.divi(labels.add(1.0)), false);
             gradients.muli(logRatio);
-        }
 
-        //Weighted loss function
-        if(weights != null){
-            if(weights.length() != output.size(1)){
-                throw new IllegalStateException("Weights vector (length " + weights.length() + ") does not match output.size(1)=" + output.size(1));
+            //Weighted loss function
+            if(weights != null){
+                gradients.muliRowVector(weights);
             }
-            gradients.muliRowVector(weights);
         }
 
         if (mask != null) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSLE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSLE.java
@@ -6,14 +6,21 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossUtil;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorDeserializer;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorSerializer;
 import org.nd4j.linalg.ops.transforms.Transforms;
+import org.nd4j.shade.jackson.annotation.JsonInclude;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
+import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Created by susaneraly on 8/15/16.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LossMSLE implements ILossFunction {
 
+    @JsonSerialize(using = RowVectorSerializer.class)
+    @JsonDeserialize(using = RowVectorDeserializer.class)
     private final INDArray weights;
 
     public LossMSLE(){

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossNegativeLogLikelihood.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossNegativeLogLikelihood.java
@@ -1,5 +1,7 @@
 package org.nd4j.linalg.lossfunctions.impl;
 
+import org.nd4j.linalg.api.ndarray.INDArray;
+
 /**
  * Negative log likelihood loss function
  * <p>
@@ -7,6 +9,11 @@ package org.nd4j.linalg.lossfunctions.impl;
  */
 public class LossNegativeLogLikelihood extends LossMCXENT {
 
+    public LossNegativeLogLikelihood(){ }
+
+    public LossNegativeLogLikelihood(INDArray weights){
+        super(weights);
+    }
 
     @Override
     public String toString() {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossNegativeLogLikelihood.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossNegativeLogLikelihood.java
@@ -9,9 +9,10 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  */
 public class LossNegativeLogLikelihood extends LossMCXENT {
 
-    public LossNegativeLogLikelihood(){ }
+    public LossNegativeLogLikelihood() {
+    }
 
-    public LossNegativeLogLikelihood(INDArray weights){
+    public LossNegativeLogLikelihood(INDArray weights) {
         super(weights);
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/serde/RowVectorDeserializer.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/serde/RowVectorDeserializer.java
@@ -1,0 +1,31 @@
+package org.nd4j.linalg.lossfunctions.serde;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.shade.jackson.core.JsonParser;
+import org.nd4j.shade.jackson.databind.DeserializationContext;
+import org.nd4j.shade.jackson.databind.JsonDeserializer;
+import org.nd4j.shade.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/**
+ * Simple JSON deserializer for use in {@link org.nd4j.linalg.lossfunctions.ILossFunction} loss function weight serialization.
+ * Used in conjunction with {@link RowVectorSerializer}
+ *
+ * @author Alex Black
+ */
+public class RowVectorDeserializer extends JsonDeserializer<INDArray> {
+    @Override
+    public INDArray deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+        if (node == null) return null;
+        int size = node.size();
+        double[] d = new double[size];
+        for (int i = 0; i < size; i++) {
+            d[i] = node.get(i).asDouble();
+        }
+
+        return Nd4j.create(d);
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/serde/RowVectorSerializer.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/serde/RowVectorSerializer.java
@@ -1,0 +1,25 @@
+package org.nd4j.linalg.lossfunctions.serde;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.shade.jackson.core.JsonGenerator;
+import org.nd4j.shade.jackson.databind.JsonSerializer;
+import org.nd4j.shade.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Simple JSON serializer for use in {@link org.nd4j.linalg.lossfunctions.ILossFunction} weight serialization.
+ * Serializes an INDArray as a double[]
+ *
+ * @author Alex Black
+ */
+public class RowVectorSerializer extends JsonSerializer<INDArray> {
+    @Override
+    public void serialize(INDArray array, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        if (array.isView()) {
+            array = array.dup();
+        }
+        double[] dArr = array.data().asDouble();
+        jsonGenerator.writeObject(dArr);
+    }
+}

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/lossfunctions/LossFunctionJson.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/lossfunctions/LossFunctionJson.java
@@ -1,5 +1,7 @@
 package org.nd4j.linalg.lossfunctions;
 
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.shade.jackson.databind.DeserializationFeature;
 import org.nd4j.shade.jackson.databind.MapperFeature;
 import org.nd4j.shade.jackson.databind.ObjectMapper;
@@ -23,15 +25,32 @@ public class LossFunctionJson extends BaseNd4jTest {
     @Test
     public void testJsonSerialization() throws Exception {
 
+        INDArray w = Nd4j.create(new double[]{1.0,2.0,3.0});
+
         ILossFunction[] lossFns = new ILossFunction[]{
                 new LossBinaryXENT(),
+                new LossBinaryXENT(w),
+                new LossCosineProximity(),
                 new LossHinge(),
                 new LossKLD(),
+                new LossL1(),
+                new LossL1(w),
+                new LossL2(),
+                new LossL2(w),
                 new LossMAE(),
+                new LossMAE(w),
                 new LossMAPE(),
+                new LossMAPE(w),
                 new LossMCXENT(),
+                new LossMCXENT(w),
                 new LossMSE(),
-                new LossMSLE()
+                new LossMSE(w),
+                new LossMSLE(),
+                new LossMSLE(w),
+                new LossNegativeLogLikelihood(),
+                new LossNegativeLogLikelihood(w),
+                new LossPoisson(),
+                new LossSquaredHinge()
         };
 
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
***WIP DO NOT MERGE***

Adds weighted loss function support for: binary xent, l1, l2, mae, mape, mcxent, mse, msle, nll - but not cosine, hinge, KLD, poisson, squared hinge.

Weights are assumed to be a row vector, passed to loss function constructor.