### PR TITLE
Fix determining column rank when merging MultiDataSets

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MultiDataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MultiDataSet.java
@@ -437,7 +437,7 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
     }
 
     private static Pair<INDArray,INDArray> merge(INDArray[][] arrays, INDArray[][] masks, int column){
-        int rank = arrays[column][0].rank();
+        int rank = arrays[0][column].rank();
         if(rank == 2){
             return new Pair<>(merge2d(arrays,column),null);
         } else if(rank == 3) {


### PR DESCRIPTION
The indexing into the arrays was in the wrong order, resulting into ArrayIndexOutOfBoundsExceptions when merging MultiDataSets with more than 2 inputs or outputs.

Fixes https://github.com/deeplearning4j/deeplearning4j/issues/2326