### PR TITLE
Fix bug in normalizer when trying to add fully masked time series data to a running mean/std calculator

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DistributionStats.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DistributionStats.java
@@ -97,14 +97,14 @@ public class DistributionStats {
             data = DataSetUtil.tailor2d(data, mask);
 
             // Using https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
-            int count = data.size(0);
-            if (count == 0) {
+            if (data == null) {
                 // Nothing to add. Either data is empty or completely masked. Just skip it, otherwise we will get
                 // division by 0 exceptions.
                 return this;
             }
             INDArray mean = data.mean(0);
             INDArray variance = data.var(false, 0);
+            int count = data.size(0);
 
             if (runningMean == null) {
                 // First batch
@@ -136,6 +136,9 @@ public class DistributionStats {
          * online.
          */
         public DistributionStats build() {
+            if (runningMean == null) {
+                throw new RuntimeException("No data was added, statistics cannot be determined");
+            }
             return new DistributionStats(runningMean.dup(), Transforms.sqrt(runningVariance, true));
         }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DistributionStats.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DistributionStats.java
@@ -97,9 +97,14 @@ public class DistributionStats {
             data = DataSetUtil.tailor2d(data, mask);
 
             // Using https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+            int count = data.size(0);
+            if (count == 0) {
+                // Nothing to add. Either data is empty or completely masked. Just skip it, otherwise we will get
+                // division by 0 exceptions.
+                return this;
+            }
             INDArray mean = data.mean(0);
             INDArray variance = data.var(false, 0);
-            int count = data.size(0);
 
             if (runningMean == null) {
                 // First batch

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSetUtil.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSetUtil.java
@@ -85,6 +85,11 @@ public class DataSetUtil {
              */
             INDArray columnMask = Nd4j.toFlattened('c', mask).transpose();
             int actualSamples = columnMask.sumNumber().intValue();
+            if (actualSamples == 0) {
+                // All samples are masked, so we can only return null to represent an empty data set
+                return null;
+            }
+
             INDArray in2dMask = Nd4j.create(actualSamples, features);
             int i = 0;
             //definitely a faster way to do this as you can skip the rest of the timesteps after the first zero in the mask

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/TestMultiDataSetIterator.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/TestMultiDataSetIterator.java
@@ -4,6 +4,7 @@ import org.nd4j.linalg.dataset.api.MultiDataSet;
 import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -16,17 +17,11 @@ public class TestMultiDataSetIterator implements MultiDataSetIterator {
     private MultiDataSetPreProcessor preProcessor;
 
     /**
-     * Makes an iterator from the given dataset
+     * Makes an iterator from the given datasets. DataSets are expected to are batches of exactly 1 example.
      * ONLY for use in tests in nd4j
-     * Initializes with a default batch of 5
      */
-    public TestMultiDataSetIterator(MultiDataSet dataset) {
-        this(dataset, 5);
-
-    }
-
-    public TestMultiDataSetIterator(MultiDataSet dataset, int batch) {
-        list = new ArrayList<>(dataset.asList());
+    public TestMultiDataSetIterator(int batch, MultiDataSet... dataset) {
+        list = Arrays.asList(dataset);
         this.batch = batch;
     }
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/MultiNormalizerStandardizeTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/MultiNormalizerStandardizeTest.java
@@ -1,11 +1,13 @@
 package org.nd4j.linalg.dataset;
 
+import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.api.DataSetUtil;
 import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
 import org.nd4j.linalg.dataset.api.iterator.TestMultiDataSetIterator;
 import org.nd4j.linalg.dataset.api.preprocessor.MultiNormalizerStandardize;
@@ -87,6 +89,18 @@ public class MultiNormalizerStandardizeTest extends BaseNd4jTest {
 
         double diffAfterRevert = getMaxRelativeDifference(data, transformed);
         assertTrue(diffAfterRevert < TOLERANCE_PERC);
+    }
+
+    @Test
+    public void testFullyMaskedData() {
+        data = new MultiDataSet(
+            new INDArray[]{Nd4j.create(new float[]{1, 2}).reshape(1, 1, 2)},
+            new INDArray[]{Nd4j.create(new float[]{2, 3}).reshape(1, 1, 2)},
+            new INDArray[]{Nd4j.create(new float[]{1, 1}).reshape(1, 2)},
+            new INDArray[]{Nd4j.create(new float[]{0, 0}).reshape(1, 2)}
+        );
+
+        SUT.fit(data);
     }
 
     private double getMaxRelativeDifference(MultiDataSet a, MultiDataSet b) {

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/MultiNormalizerStandardizeTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/MultiNormalizerStandardizeTest.java
@@ -1,6 +1,5 @@
 package org.nd4j.linalg.dataset;
 
-import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +14,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.ops.transforms.Transforms;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -69,7 +69,7 @@ public class MultiNormalizerStandardizeTest extends BaseNd4jTest {
 
     @Test
     public void testMultipleInputsAndOutputsWithIterator() {
-        MultiDataSetIterator iter = new TestMultiDataSetIterator(data, 5);
+        MultiDataSetIterator iter = new TestMultiDataSetIterator(1, data);
         SUT.fit(iter);
         assertExpectedMeanStd();
     }
@@ -93,14 +93,24 @@ public class MultiNormalizerStandardizeTest extends BaseNd4jTest {
 
     @Test
     public void testFullyMaskedData() {
-        data = new MultiDataSet(
-            new INDArray[]{Nd4j.create(new float[]{1, 2}).reshape(1, 1, 2)},
-            new INDArray[]{Nd4j.create(new float[]{2, 3}).reshape(1, 1, 2)},
-            new INDArray[]{Nd4j.create(new float[]{1, 1}).reshape(1, 2)},
-            new INDArray[]{Nd4j.create(new float[]{0, 0}).reshape(1, 2)}
+        MultiDataSetIterator iter = new TestMultiDataSetIterator(
+            1,
+            new MultiDataSet(
+                new INDArray[]{Nd4j.create(new float[]{1}).reshape(1, 1, 1)},
+                new INDArray[]{Nd4j.create(new float[]{2}).reshape(1, 1, 1)}
+            ),
+            new MultiDataSet(
+                new INDArray[]{Nd4j.create(new float[]{2}).reshape(1, 1, 1)},
+                new INDArray[]{Nd4j.create(new float[]{4}).reshape(1, 1, 1)},
+                null,
+                new INDArray[]{Nd4j.create(new float[]{0}).reshape(1, 1)}
+            )
         );
 
-        SUT.fit(data);
+        SUT.fit(iter);
+
+        // The label mean should be 2, as the second row with 3 is masked.
+        assertEquals(2f, SUT.getLabelMean(0).getFloat(0), 1e-6);
     }
 
     private double getMaxRelativeDifference(MultiDataSet a, MultiDataSet b) {


### PR DESCRIPTION
When normalizing time series, it's possible that for a given data set all inputs or outputs are masked. In this case, there is nothing to add to the running mean or std, and trying to do so will result in exceptions. This fixes that.