### PR TITLE
Remove unnecessary com.sun import

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InFileDataSetCache.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InFileDataSetCache.java
@@ -1,6 +1,5 @@
 package org.nd4j.linalg.dataset.api.iterator.cache;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.nd4j.linalg.dataset.DataSet;
 
 import java.io.File;


### PR DESCRIPTION
An unnecessary import from com.sun prevents nd4j from building on certain JDKs.