### PR TITLE
get rid of excessive nonnull for aggregates

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/aggregates/impl/AggregateCBOW.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/aggregates/impl/AggregateCBOW.java
@@ -32,7 +32,7 @@ public class AggregateCBOW extends BaseAggregate {
      * @param numLabels
      * @param trainWords
      */
-    public AggregateCBOW(INDArray syn0, INDArray syn1, INDArray syn1Neg, INDArray expTable, INDArray negTable, int wordIdx, int[] idxSyn0, int[] idxSyn1, int[] codes, int negativeRounds, int ngStarter, int vectorLength, double alpha, long nextRandom, int vocabSize, int numLabels, boolean trainWords, INDArray inferenceVector) {
+    public AggregateCBOW(@NonNull INDArray syn0, INDArray syn1, INDArray syn1Neg, @NonNull INDArray expTable, INDArray negTable, int wordIdx, int[] idxSyn0, int[] idxSyn1, int[] codes, int negativeRounds, int ngStarter, int vectorLength, double alpha, long nextRandom, int vocabSize, int numLabels, boolean trainWords, INDArray inferenceVector) {
         this(syn0, syn1, syn1Neg, expTable, negTable, wordIdx, idxSyn0, idxSyn1, codes, negativeRounds, ngStarter, vectorLength, alpha, nextRandom, vocabSize);
 
         indexingArguments.set(9, numLabels);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/aggregates/impl/AggregateGEMM.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/aggregates/impl/AggregateGEMM.java
@@ -16,7 +16,7 @@ public class AggregateGEMM extends BaseAggregate {
         // no-op
     }
 
-    public AggregateGEMM(@NonNull int Order, @NonNull int TransA, @NonNull int TransB, @NonNull int M,@NonNull int N, @NonNull int K, @NonNull double alpha, @NonNull INDArray A, @NonNull int lda, @NonNull INDArray B, @NonNull int ldb, @NonNull double beta, @NonNull INDArray C, @NonNull int ldc) {
+    public AggregateGEMM(int Order, int TransA, int TransB, int M, int N, int K, double alpha, @NonNull INDArray A, int lda, @NonNull INDArray B, int ldb, double beta, @NonNull INDArray C, int ldc) {
         this.arguments.add(A);
         this.arguments.add(B);
         this.arguments.add(C);


### PR DESCRIPTION
get rid of excessive nonnull for aggregates, they were used on primitives, which was a copy-paste issue