### PR TITLE
Add support for reverting INDArray features and labels in MultiNormalizerStandardize

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/AbstractNormalizerStandardize.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/AbstractNormalizerStandardize.java
@@ -51,7 +51,7 @@ abstract class AbstractNormalizerStandardize {
 
     private INDArray filteredStd(DistributionStats stats) {
         /*
-            To avoid division by zero when the std deviation is zero, replace by zeros by one
+            To avoid division by zero when the std deviation is zero, replace zeros by one
          */
         INDArray stdCopy = stats.getStd();
         BooleanIndexing.replaceWhere(stdCopy, 1.0, Conditions.equals(0));

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/MultiNormalizerStandardize.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/MultiNormalizerStandardize.java
@@ -52,7 +52,7 @@ public class MultiNormalizerStandardize extends AbstractNormalizerStandardize im
     }
 
     /**
-     * FFit the model with a MultiDataSetIterator to calculate means and standard deviations with
+     * Fit the model with a MultiDataSetIterator to calculate means and standard deviations with
      *
      * @param iterator
      */
@@ -126,16 +126,33 @@ public class MultiNormalizerStandardize extends AbstractNormalizerStandardize im
     public void revert(@NonNull MultiDataSet data) {
         assertIsFit();
 
-        INDArray[] inputs = data.getFeatures();
-        for (int i = 0; i < inputs.length; i++) {
-            revert(inputs[i], featureStats.get(i));
-        }
+        revertFeatures(data.getFeatures());
         if (fitLabels) {
-            INDArray[] outputs = data.getLabels();
-            for (int i = 0; i < outputs.length; i++) {
-                revert(outputs[i], labelStats.get(i));
-            }
+            revertLabels(data.getLabels());
         }
+    }
+
+    public void revertFeatures(@NonNull INDArray[] features) {
+        for (int i = 0; i < features.length; i ++) {
+            revertFeatures(features[i], i);
+        }
+    }
+
+    public void revertFeatures(@NonNull INDArray features, int input) {
+        revert(features, featureStats.get(input));
+    }
+
+    public void revertLabels(@NonNull INDArray[] labels) {
+        for (int i = 0; i < labels.length; i ++) {
+            revertLabels(labels[i], i);
+        }
+    }
+
+    public void revertLabels(@NonNull INDArray labels, int output) {
+        if (!fitLabels) {
+            return;
+        }
+        revert(labels, labelStats.get(output));
     }
 
     public int numInputs() {

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/MultiNormalizerStandardizeTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/MultiNormalizerStandardizeTest.java
@@ -15,6 +15,7 @@ import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.ops.transforms.Transforms;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -75,11 +76,42 @@ public class MultiNormalizerStandardizeTest extends BaseNd4jTest {
     }
 
     @Test
-    public void testRevert() {
+    public void testRevertFeaturesINDArray() {
         SUT.fit(data);
 
         MultiDataSet transformed = data.copy();
+        SUT.preProcess(transformed);
 
+        INDArray reverted = transformed.getFeatures(0).dup();
+        SUT.revertFeatures(reverted, 0);
+
+        assertNotEquals(reverted, transformed.getFeatures(0));
+
+        SUT.revert(transformed);
+        assertEquals(reverted, transformed.getFeatures(0));
+    }
+
+    @Test
+    public void testRevertLabelsINDArray() {
+        SUT.fit(data);
+
+        MultiDataSet transformed = data.copy();
+        SUT.preProcess(transformed);
+
+        INDArray reverted = transformed.getLabels(0).dup();
+        SUT.revertLabels(reverted, 0);
+
+        assertNotEquals(reverted, transformed.getLabels(0));
+
+        SUT.revert(transformed);
+        assertEquals(reverted, transformed.getLabels(0));
+    }
+
+    @Test
+    public void testRevertMultiDataSet() {
+        SUT.fit(data);
+
+        MultiDataSet transformed = data.copy();
         SUT.preProcess(transformed);
 
         double diffBeforeRevert = getMaxRelativeDifference(data, transformed);


### PR DESCRIPTION
This functionality was missing in the MultiDataSet normalizer. Quite handy if you want to denormalize a model's outputs.