### PR TITLE
Nd4j.java += create() for 3D arrays

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -3065,6 +3065,20 @@ public class Nd4j {
         return INSTANCE.create(data, ordering);
     }
 
+    /** Create from 3D array. Fast & handy for Recurrent NN. */
+    public static INDArray create(float[][][] tensor) {
+        float[] flat = ArrayUtil.flatten(tensor);
+        int[] shape = new int[] {tensor.length, tensor[0].length, tensor[0][0].length};
+        return Nd4j.create(flat, shape, 'c');
+    }
+
+    /** Create from 3D array. Fast & handy for Recurrent NN. */
+    public static INDArray create(double[][][] tensor) {
+        double[] flat = ArrayUtil.flatten(tensor);
+        int[] shape = new int[] {tensor.length, tensor[0].length, tensor[0][0].length};
+        return Nd4j.create(flat, shape, 'c');
+    }
+
 
     /**
      * Create an ndarray based on the given data layout


### PR DESCRIPTION
RNNs need 3D arrays all the time, so this makes it more convenient, fast, and clearer for new users.

Uses the efficient new flatten in ArrayUtil for 3D arrays.  PL #1493  -- include this FIRST!
Row-major ordering (C).

-gforman44