### PR TITLE
Introduce MultiDataNormalization interface

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/AbstractMultiDataSetNormalizer.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/AbstractMultiDataSetNormalizer.java
@@ -4,10 +4,9 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Setter;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.dataset.api.preprocessor.stats.NormalizerStats;
 import org.nd4j.linalg.dataset.api.MultiDataSet;
-import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
 import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
+import org.nd4j.linalg.dataset.api.preprocessor.stats.NormalizerStats;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -19,7 +18,7 @@ import java.util.List;
  * @author Ede Meijer
  */
 @EqualsAndHashCode(callSuper = false)
-abstract class AbstractMultiDataSetNormalizer<S extends NormalizerStats> extends AbstractNormalizer<S> implements MultiDataSetPreProcessor, Serializable {
+abstract class AbstractMultiDataSetNormalizer<S extends NormalizerStats> extends AbstractNormalizer<S> implements MultiDataNormalization, Serializable {
     @Setter private List<S> featureStats;
     @Setter private List<S> labelStats;
     private boolean fitLabels = false;
@@ -148,6 +147,12 @@ abstract class AbstractMultiDataSetNormalizer<S extends NormalizerStats> extends
     }
 
     protected abstract S.Builder newBuilder();
+
+
+    @Override
+    public void transform(@NonNull MultiDataSet toPreProcess) {
+        preProcess(toPreProcess);
+    }
 
     /**
      * Pre process a MultiDataSet

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/MultiDataNormalization.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/MultiDataNormalization.java
@@ -1,0 +1,76 @@
+package org.nd4j.linalg.dataset.api.preprocessor;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.api.MultiDataSet;
+import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
+import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
+
+/**
+ * An interface for multi dataset normalizers.
+ * Data normalizers compute some sort of statistics
+ * over a MultiDataSet and scale the data in some way.
+ *
+ * @author Ede Meijer
+ */
+public interface MultiDataNormalization extends MultiDataSetPreProcessor {
+    /**
+     * Fit a multi dataset (only compute based on the statistics from this dataset)
+     *
+     * @param dataSet the dataset to compute on
+     */
+    void fit(MultiDataSet dataSet);
+
+    /**
+     * Iterates over a dataset
+     * accumulating statistics for normalization
+     *
+     * @param iterator the iterator to use for
+     *                 collecting statistics.
+     */
+    void fit(MultiDataSetIterator iterator);
+
+    @Override
+    void preProcess(MultiDataSet multiDataSet);
+
+    /**
+     * Transform the dataset
+     *
+     * @param toPreProcess the dataset to re process
+     */
+    void transform(MultiDataSet toPreProcess);
+
+    /**
+     * Undo (revert) the normalization applied by this DataNormalization instance (arrays are modified in-place)
+     *
+     * @param toRevert DataSet to revert the normalization on
+     */
+    void revert(MultiDataSet toRevert);
+
+    /**
+     * Undo (revert) the normalization applied by this DataNormalization instance to the specified features array
+     *
+     * @param features Features to revert the normalization on
+     */
+    void revertFeatures(INDArray[] features);
+
+    /**
+     * Undo (revert) the normalization applied by this DataNormalization instance to the specified labels array.
+     * If labels normalization is disabled (i.e., {@link #isFitLabel()} == false) then this is a no-op.
+     * Can also be used to undo normalization for network output arrays, in the case of regression.
+     *
+     * @param labels Labels array to revert the normalization on
+     */
+    void revertLabels(INDArray[] labels);
+
+    /**
+     * Flag to specify if the labels/outputs in the dataset should be also normalized. Default value is usually false.
+     */
+    void fitLabel(boolean fitLabels);
+
+    /**
+     * Whether normalization for the labels is also enabled. Most commonly used for regression, not classification.
+     *
+     * @return True if labels will be
+     */
+    boolean isFitLabel();
+}


### PR DESCRIPTION
This is the MultiDataSet counterpart of the DataNormalization interface. I needed to be able to revert features and labels with any MultiDataSet normalizer, and this interface was missing.