### PR TITLE
Prevent array unpacking on toString() with env variable.

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -4591,7 +4591,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         else if(isCompressed() && compressDebug)
             return "COMPRESSED ARRAY. SYSTEM PROPERTY compressdebug is true. This is to prevent auto decompression from being triggered.";
         else if(preventUnpack)
-            return "STRING UNPACK DISABLED.";
+            return "Array string unpacking is disabled.";
         return new NDArrayStrings().format(this);
 
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -63,6 +63,7 @@ import java.util.Set;
 
 import static org.nd4j.linalg.factory.Nd4j.compressDebug;
 import static org.nd4j.linalg.factory.Nd4j.createUninitialized;
+import static org.nd4j.linalg.factory.Nd4j.preventUnpack;
 
 
 /**
@@ -4585,10 +4586,12 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public String toString() {
-        if(!isCompressed())
+        if(!isCompressed() && !preventUnpack)
             return new NDArrayStrings().format(this);
         else if(isCompressed() && compressDebug)
             return "COMPRESSED ARRAY. SYSTEM PROPERTY compressdebug is true. This is to prevent auto decompression from being triggered.";
+        else if(preventUnpack)
+            return "STRING UNPACK DISABLED.";
         return new NDArrayStrings().format(this);
 
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -141,7 +141,7 @@ public class Nd4j {
     public static boolean resourceManagerOn = false;
     private static boolean allowsOrder = false;
     public static boolean compressDebug = false;
-    public static boolean preventUnpack = System.getenv("ND4J_PREVENT_UNPACK").isEmpty();
+    public static boolean preventUnpack = System.getenv("ND4J_PREVENT_UNPACK")==null ? false : true;
     public static Nd4jBackend backend;
     public static RandomFactory randomFactory;
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -141,6 +141,7 @@ public class Nd4j {
     public static boolean resourceManagerOn = false;
     private static boolean allowsOrder = false;
     public static boolean compressDebug = false;
+    public static boolean preventUnpack = System.getenv("ND4J_PREVENT_UNPACK").isEmpty();
     public static Nd4jBackend backend;
     public static RandomFactory randomFactory;
 


### PR DESCRIPTION
![screen shot 2016-12-20 at 5 38 19 pm](https://cloud.githubusercontent.com/assets/1445295/21374968/3e4b182a-c6df-11e6-877f-d8688dd44186.png)

With very large arrays the IDE can freeze when calling `toString()` because the entire array is unpacked and printed. The environment variable `ND4J_PREVENT_UNPACK` when set will prevent this.