### PR TITLE
Fixed NullPointerException inside Nd4j.rand(1,1) call with jcublas

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
@@ -61,7 +61,7 @@ public class DefaultOpExecutioner implements OpExecutioner {
         // check for INT datatype arrays
         interceptIntDataType(op);
 
-        if (op.x().isCompressed())
+        if (op.x() != null && op.x().isCompressed())
             Nd4j.getCompressor().decompressi(op.x());
 
         if (op.y() != null && op.y().isCompressed())


### PR DESCRIPTION
**Added check for null on op.x().**

**Before that fix, it crashes with the next stacktrace:**

java.lang.NullPointerException
	at org.nd4j.linalg.api.ops.executioner.DefaultOpExecutioner.checkForCompression(DefaultOpExecutioner.java:64)
	at org.nd4j.linalg.jcublas.ops.executioner.CudaExecutioner.exec(CudaExecutioner.java:2196)
	at org.nd4j.linalg.jcublas.ops.executioner.CudaGridExecutioner.exec(CudaGridExecutioner.java:1032)
	at org.nd4j.linalg.factory.Nd4j.rand(Nd4j.java:2770)

**Call of rand() looks like the next:** 
INDArray S0 = Nd4j.rand(4, 1);