### PR TITLE
fix field detection for activation function JSON serialization of act…

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/IActivation.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/IActivation.java
@@ -3,6 +3,7 @@ package org.nd4j.linalg.activations;
 import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.activations.impl.*;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.shade.jackson.annotation.JsonAutoDetect;
 import org.nd4j.shade.jackson.annotation.JsonSubTypes;
 import org.nd4j.shade.jackson.annotation.JsonTypeInfo;
 
@@ -27,6 +28,7 @@ import java.io.Serializable;
         @JsonSubTypes.Type(value = ActivationSoftSign.class, name = "SoftSign"),
         @JsonSubTypes.Type(value = ActivationTanH.class, name = "TanH")
 })
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
 public interface IActivation extends Serializable {
 
     /**

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/impl/ActivationELU.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/impl/ActivationELU.java
@@ -25,10 +25,12 @@ import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 @EqualsAndHashCode
 @Getter
 public class ActivationELU extends BaseActivationFunction {
-    private double alpha;
+    public static final double DEFAULT_ALPHA = 1.0;
+
+    private double alpha = DEFAULT_ALPHA;
 
     public ActivationELU() {
-        this.alpha = 1.00;
+        this(DEFAULT_ALPHA);
     }
 
     public ActivationELU (double alpha) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/impl/ActivationLReLU.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/impl/ActivationLReLU.java
@@ -21,10 +21,12 @@ import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 @EqualsAndHashCode
 @Getter
 public class ActivationLReLU extends BaseActivationFunction {
-    private double alpha;
+    public static final double DEFAULT_ALPHA = 0.01;
+
+    private double alpha = DEFAULT_ALPHA;
 
     public ActivationLReLU() {
-        this.alpha = 0.01;
+        this(DEFAULT_ALPHA);
     }
 
     public ActivationLReLU (double alpha) {

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/activations/TestActivationJson.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/activations/TestActivationJson.java
@@ -1,0 +1,111 @@
+package org.nd4j.linalg.activations;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.activations.impl.*;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
+import org.nd4j.shade.jackson.databind.*;
+
+import java.util.*;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Alex on 30/12/2016.
+ */
+@RunWith(Parameterized.class)
+public class TestActivationJson extends BaseNd4jTest {
+
+    public TestActivationJson(Nd4jBackend backend) {
+        super(backend);
+    }
+
+    @Override
+    public char ordering() {
+        return 'c';
+    }
+
+    private ObjectMapper mapper;
+
+    @Before
+    public void initMapper(){
+        mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    @Test
+    public void testJson() throws Exception {
+
+        IActivation[] activations = new IActivation[]{
+                new ActivationCube(),
+                new ActivationELU(0.25),
+                new ActivationHardSigmoid(),
+                new ActivationHardTanH(),
+                new ActivationIdentity(),
+                new ActivationLReLU(0.25),
+                new ActivationReLU(),
+                new ActivationRReLU(0.25,0.5),
+                new ActivationSigmoid(),
+                new ActivationSoftmax(),
+                new ActivationSoftPlus(),
+                new ActivationSoftSign(),
+                new ActivationTanH()
+        };
+
+        String[][] expectedFields = new String[][]{
+                {}, //Cube
+                {"alpha"}, //ELU
+                {}, //Hard sigmoid
+                {}, //Hard TanH
+                {}, //Identity
+                {"alpha"},  //Leaky Relu
+                {}, //relu
+                {"l","u"},  //rrelu
+                {}, //sigmoid
+                {}, //Softmax
+                {}, //Softplus
+                {}, //Softsign
+                {}  //Tanh
+
+        };
+
+        for( int i=0; i<activations.length; i++ ){
+            String asJson = mapper.writeValueAsString(activations[i]);
+            System.out.println(asJson);
+
+            JsonNode node = mapper.readTree(asJson);
+            JsonNode content = node.elements().next();
+
+            Iterator<String> fieldNamesIter = content.fieldNames();
+            List<String> actualFieldsByName = new ArrayList<>();
+            while(fieldNamesIter.hasNext()){
+                actualFieldsByName.add(fieldNamesIter.next());
+            }
+
+            String[] expFields = expectedFields[i];
+
+            String msg = activations[i].toString() + "\tExpected fields: " + Arrays.toString(expFields) + "\tActual fields: " + actualFieldsByName;
+            assertEquals(msg, expFields.length, actualFieldsByName.size());
+
+            for(String s : expFields){
+                msg = "Expected field \"" + s + "\", was not found in " + activations[i].toString();
+                assertTrue(msg, actualFieldsByName.contains(s));
+            }
+
+            //Test conversion from JSON:
+            IActivation act = mapper.readValue(asJson, IActivation.class);
+            assertEquals(activations[i], act);
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
…ivation functions; add json tests

Previously, the array fields were being incorrectly included in the serialization due to the getters (on the interface) being incorrectly picked up by jackson.

```
{
  "Cube" : {
    "gradientViewArray" : null,
    "parametersViewArray" : null
  }
}
```