### PR TITLE
Add CompactHeapStringList

### DIFF
--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/TestCollections.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/TestCollections.java
@@ -1,0 +1,76 @@
+package org.nd4j.linalg.util;
+
+import org.junit.Test;
+import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.collection.CompactHeapStringList;
+import org.nd4j.linalg.factory.Nd4jBackend;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class TestCollections extends BaseNd4jTest {
+
+    public TestCollections(Nd4jBackend backend) {
+        super(backend);
+    }
+
+    @Test
+    public void testCompactHeapStringList() {
+
+        System.out.println(((double)2L * Integer.MAX_VALUE) / (1024L * 1024L * 1024L));
+
+        int[] reallocSizeBytes = new int[]{1024, 1048576};
+        int[] intReallocSizeBytes = new int[]{1024, 1048576};
+
+        int numElementsToTest = 10000;
+        int minLength = 1;
+        int maxLength = 1048;
+
+        Random r = new Random(12345);
+
+        List<String> compare = new ArrayList<>(numElementsToTest);
+        for (int i = 0; i < numElementsToTest; i++) {
+            int thisLength = minLength + r.nextInt(maxLength);
+            char[] c = new char[thisLength];
+            for (int j = 0; j < c.length; j++) {
+                c[j] = (char) r.nextInt(65536);
+            }
+            String s = new String(c);
+            compare.add(s);
+        }
+
+
+        for (int rb : reallocSizeBytes) {
+            for (int irb : intReallocSizeBytes) {
+                System.out.println(rb + "\t" + irb);
+                List<String> list = new CompactHeapStringList(rb, irb);
+
+
+                for (int i = 0; i < numElementsToTest; i++) {
+                    String s = compare.get(i);
+                    list.add(s);
+
+                    assertEquals(i+1, list.size());
+                    String s2 = list.get(i);
+                    assertEquals(s, s2);
+                    if(i % 1000 == 0){
+                        System.out.println(" - " + i );
+                    }
+                }
+
+                assertEquals(numElementsToTest, list.size());
+
+                assertEquals(list, compare);
+            }
+        }
+    }
+
+    @Override
+    public char ordering() {
+        return 'c';
+    }
+}

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/TestCollections.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/TestCollections.java
@@ -5,10 +5,7 @@ import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.collection.CompactHeapStringList;
 import org.nd4j.linalg.factory.Nd4jBackend;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -71,6 +68,14 @@ public class TestCollections extends BaseNd4jTest {
                 for( int i=0; i<numElementsToTest; i++ ){
                     assertEquals(i, list.indexOf(compare.get(i)));
                 }
+
+                Iterator<String> iter = list.iterator();
+                int count = 0;
+                while(iter.hasNext()){
+                    String s = iter.next();
+                    assertEquals(s, compare.get(count++));
+                }
+                assertEquals(numElementsToTest, count);
             }
         }
     }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/TestCollections.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/TestCollections.java
@@ -6,11 +6,13 @@ import org.nd4j.linalg.collection.CompactHeapStringList;
 import org.nd4j.linalg.factory.Nd4jBackend;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestCollections extends BaseNd4jTest {
 
@@ -20,8 +22,6 @@ public class TestCollections extends BaseNd4jTest {
 
     @Test
     public void testCompactHeapStringList() {
-
-        System.out.println(((double)2L * Integer.MAX_VALUE) / (1024L * 1024L * 1024L));
 
         int[] reallocSizeBytes = new int[]{1024, 1048576};
         int[] intReallocSizeBytes = new int[]{1024, 1048576};
@@ -46,8 +46,11 @@ public class TestCollections extends BaseNd4jTest {
 
         for (int rb : reallocSizeBytes) {
             for (int irb : intReallocSizeBytes) {
-                System.out.println(rb + "\t" + irb);
+//                System.out.println(rb + "\t" + irb);
                 List<String> list = new CompactHeapStringList(rb, irb);
+
+                assertTrue(list.isEmpty());
+                assertEquals(0, list.size());
 
 
                 for (int i = 0; i < numElementsToTest; i++) {
@@ -57,14 +60,17 @@ public class TestCollections extends BaseNd4jTest {
                     assertEquals(i+1, list.size());
                     String s2 = list.get(i);
                     assertEquals(s, s2);
-                    if(i % 1000 == 0){
-                        System.out.println(" - " + i );
-                    }
                 }
 
                 assertEquals(numElementsToTest, list.size());
 
                 assertEquals(list, compare);
+                assertEquals(compare, list);
+                assertEquals(compare, Arrays.asList(list.toArray()));
+
+                for( int i=0; i<numElementsToTest; i++ ){
+                    assertEquals(i, list.indexOf(compare.get(i)));
+                }
             }
         }
     }

--- a/nd4j-common/src/main/java/org/nd4j/linalg/collection/CompactHeapStringList.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/collection/CompactHeapStringList.java
@@ -1,0 +1,245 @@
+package org.nd4j.linalg.collection;
+
+import java.util.*;
+
+/**
+ * A {@code List<String>} that stores all contents in a single char[], to avoid the GC load for a large number of String
+ * objects.
+ *
+ * @author Alex Black
+ */
+public class CompactHeapStringList implements List<String> {
+
+    public static final int DEFAULT_REALLOCATION_BLOCK_SIZE_BYTES = 8*1024*1024;        //8MB
+    public static final int DEFAULT_INTEGER_REALLOCATION_BLOCK_SIZE_BYTES = 1024*1024;  //1MB - 262144 ints, 131k entries
+
+    private final int reallocationBlockSizeBytes;
+    private final int reallocationIntegerBlockSizeBytes;
+    private int usedCount = 0;
+    private int nextDataOffset = 0;
+    private char[] data;
+    private int[] offsetAndLength;
+
+    public CompactHeapStringList(){
+        this(DEFAULT_REALLOCATION_BLOCK_SIZE_BYTES, DEFAULT_INTEGER_REALLOCATION_BLOCK_SIZE_BYTES);
+    }
+
+    public CompactHeapStringList(int reallocationBlockSizeBytes, int intReallocationBlockSizeBytes){
+        this.reallocationBlockSizeBytes = reallocationBlockSizeBytes;
+        this.reallocationIntegerBlockSizeBytes = intReallocationBlockSizeBytes;
+    }
+
+    @Override
+    public int size() {
+        return usedCount;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return usedCount == 0;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return Arrays.asList(toArray()).iterator();
+    }
+
+    @Override
+    public String[] toArray() {
+        String[] str = new String[usedCount];
+        for( int i=0; i<usedCount; i++ ){
+            str[i] = get(i);
+        }
+        return str;
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public boolean add(String s) {
+        int length = s.length();
+        //3 possibilities:
+        //(a) doesn't fit in char[]
+        //(b) doesn't fit in int[]
+        //(c) fits OK in both
+
+        if(nextDataOffset + length > data.length){
+            //Allocate new data array, if possible
+            if( nextDataOffset > Integer.MAX_VALUE - length){
+                throw new UnsupportedOperationException("Cannot allocate new data char[]: required array size exceeds Integer.MAX_VALUE");
+            }
+            int newLength = data.length + Math.min(reallocationBlockSizeBytes, Integer.MAX_VALUE - data.length);
+            data = Arrays.copyOf(data, newLength);
+        }
+        if(2*(usedCount + 1) >= offsetAndLength.length){
+            if(offsetAndLength.length >= Integer.MAX_VALUE - 2 ){
+                //Should normally never happen
+                throw new UnsupportedOperationException("Cannot allocate new offset int[]: required array size exceeds Integer.MAX_VALUE");
+            }
+            int newLength = offsetAndLength.length + Math.min(reallocationIntegerBlockSizeBytes, Integer.MAX_VALUE - offsetAndLength.length);
+            offsetAndLength = Arrays.copyOf(offsetAndLength, newLength);
+        }
+
+
+        s.getChars(0,length,data,nextDataOffset);
+        nextDataOffset += length;
+
+        return true;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        //In principle we *could* do this with array copies
+        throw new UnsupportedOperationException("Remove not supported");
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends String> c) {
+        for(String s : c){
+            add(s);
+        }
+        return c.size() > 0;
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends String> c) {
+        //This is conceivably possible with array copies and adjusting the indices
+        throw new UnsupportedOperationException("Add all at specified index: Not supported");
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Remove all: Not supported");
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Retain all: Not supported");
+    }
+
+    @Override
+    public void clear() {
+        usedCount = 0;
+        data = new char[reallocationBlockSizeBytes];
+        offsetAndLength = new int[reallocationIntegerBlockSizeBytes];
+    }
+
+    @Override
+    public String get(int index) {
+        if(index >= usedCount){
+            throw new IllegalArgumentException("Invalid index: " + index + " >= size(). Size = " + usedCount);
+        }
+        int offset = offsetAndLength[2*index];
+        int length = offsetAndLength[2*index+1];
+        return new String(data,offset,length);
+    }
+
+    @Override
+    public String set(int index, String element) {
+        //Actually: this *could* be done with array copy ops...
+        throw new UnsupportedOperationException("Set specified index: not supported due to serialized storage structure");
+    }
+
+    @Override
+    public void add(int index, String element) {
+        //Actually: this *could* be done with array copy ops...
+        throw new UnsupportedOperationException("Set specified index: not supported due to serialized storage structure");
+    }
+
+    @Override
+    public String remove(int index) {
+        throw new UnsupportedOperationException("Remove: not supported");
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        if(!(o instanceof String) ){
+            return -1;
+        }
+
+        String str = (String)o;
+        char[] ch = str.toCharArray();
+
+
+        for( int i=0; i<usedCount; i++ ){
+            if(offsetAndLength[2*i+1] != ch.length){
+                //Can't be this one: lengths differ
+                continue;
+            }
+            int offset = offsetAndLength[2*i];
+
+            boolean matches = true;
+            for( int j=0; j<ch.length; j++ ){
+                if(data[offset+j] != ch[j]){
+                    matches = false;
+                    break;
+                }
+            }
+            if(matches){
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        if(!(o instanceof String) ){
+            return -1;
+        }
+
+        String str = (String)o;
+        char[] ch = str.toCharArray();
+
+
+        for( int i=usedCount-1; i>=0; i-- ){
+            if(offsetAndLength[2*i+1] != ch.length){
+                //Can't be this one: lengths differ
+                continue;
+            }
+            int offset = offsetAndLength[2*i];
+
+            boolean matches = true;
+            for( int j=0; j<ch.length; j++ ){
+                if(data[offset+j] != ch[j]){
+                    matches = false;
+                    break;
+                }
+            }
+            if(matches){
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    @Override
+    public ListIterator<String> listIterator() {
+        return Arrays.asList(toArray()).listIterator();
+    }
+
+    @Override
+    public ListIterator<String> listIterator(int index) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public List<String> subList(int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+}

--- a/nd4j-common/src/main/java/org/nd4j/linalg/collection/CompactHeapStringList.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/collection/CompactHeapStringList.java
@@ -60,7 +60,7 @@ public class CompactHeapStringList implements List<String> {
 
     @Override
     public Iterator<String> iterator() {
-        return Arrays.asList(toArray()).iterator();
+        return new CompactHeapStringListIterator();
     }
 
     @Override
@@ -249,7 +249,7 @@ public class CompactHeapStringList implements List<String> {
 
     @Override
     public ListIterator<String> listIterator() {
-        return Arrays.asList(toArray()).listIterator();
+        return new CompactHeapStringListIterator();
     }
 
     @Override
@@ -278,5 +278,60 @@ public class CompactHeapStringList implements List<String> {
                 return false;
         }
         return !(e1.hasNext() || e2.hasNext());
+    }
+
+    private class CompactHeapStringListIterator implements Iterator<String>, ListIterator<String> {
+        private int currIdx = 0;
+
+        @Override
+        public boolean hasNext() {
+            return currIdx < usedCount;
+        }
+
+        @Override
+        public String next() {
+            if(!hasNext()){
+                throw new NoSuchElementException("No next element");
+            }
+            return get(currIdx++);
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return currIdx > 0;
+        }
+
+        @Override
+        public String previous() {
+            if(!hasPrevious()){
+                throw new NoSuchElementException();
+            }
+            return get(currIdx--);
+        }
+
+        @Override
+        public int nextIndex() {
+            return currIdx;
+        }
+
+        @Override
+        public int previousIndex() {
+            return currIdx;
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(String s) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add(String s) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/nd4j-common/src/main/java/org/nd4j/linalg/collection/CompactHeapStringList.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/collection/CompactHeapStringList.java
@@ -4,17 +4,18 @@ import java.util.*;
 
 /**
  * A {@code List<String>} that stores all contents in a single char[], to avoid the GC load for a large number of String
- * objects.
+ * objects.<br>
  * <p>
  * Some restrictions to be aware of with the current implementation:<br>
+ * - The list is intended to be write-once (append only), except for clear() operations. That is: new Strings can be added
+ *   at the end, but they cannot be replaced or removed.<br>
  * - There is a limit of a maximum of {@link Integer#MAX_VALUE}/2 = 1073741823 Strings<br>
  * - There is a limit of the maximum total characters of {@link Integer#MAX_VALUE} (i.e., 2147483647 chars). This corresponds
- *   to a maximum of approximately 4GB of Strings.
+ *   to a maximum of approximately 4GB of Strings.<br>
  *
  * @author Alex Black
  */
 public class CompactHeapStringList implements List<String> {
-
     public static final int DEFAULT_REALLOCATION_BLOCK_SIZE_BYTES = 8*1024*1024;        //8MB
     public static final int DEFAULT_INTEGER_REALLOCATION_BLOCK_SIZE_BYTES = 1024*1024;  //1MB - 262144 ints, 131k entries
 
@@ -29,6 +30,11 @@ public class CompactHeapStringList implements List<String> {
         this(DEFAULT_REALLOCATION_BLOCK_SIZE_BYTES, DEFAULT_INTEGER_REALLOCATION_BLOCK_SIZE_BYTES);
     }
 
+    /**
+     *
+     * @param reallocationBlockSizeBytes    Number of bytes by which to increase the char[], when allocating a new storage array
+     * @param intReallocationBlockSizeBytes Number of bytes by which to increase the int[], when allocating a new storage array
+     */
     public CompactHeapStringList(int reallocationBlockSizeBytes, int intReallocationBlockSizeBytes){
         this.reallocationBlockSizeBytes = reallocationBlockSizeBytes;
         this.reallocationIntegerBlockSizeBytes = intReallocationBlockSizeBytes;
@@ -162,13 +168,13 @@ public class CompactHeapStringList implements List<String> {
 
     @Override
     public String set(int index, String element) {
-        //Actually: this *could* be done with array copy ops...
+        //This *could* be done with array copy ops...
         throw new UnsupportedOperationException("Set specified index: not supported due to serialized storage structure");
     }
 
     @Override
     public void add(int index, String element) {
-        //Actually: this *could* be done with array copy ops...
+        //This *could* be done with array copy ops...
         throw new UnsupportedOperationException("Set specified index: not supported due to serialized storage structure");
     }
 


### PR DESCRIPTION
This adds a ```List<String>``` implementation (write once, read many times) that can store up to 1B (or 4GB) of String objects on-heap using a total of 3 Objects.

This is designed to reduce GC load for cases such as ImageRecordReader.