### PR TITLE
fix merge bug in dataset.merge

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -227,7 +227,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
 
                 break;
             case 4:
-                labelsOut = merge4dCnnData(featuresToMerge);
+                labelsOut = merge4dCnnData(labelsToMerge);
                 labelsMaskOut = null;
                 break;
             default:


### PR DESCRIPTION
Wrong merge happening. Should be labels not inputs.