### PR TITLE
R119 tests fixes

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -604,6 +604,10 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
 
         }
 
+        // getting tadOnlyShape for result
+        Pair<DataBuffer, DataBuffer> zBuffers = tadManager.getTADOnlyShapeInfo(ret, new int[]{dimension});
+
+
         //System.out.println("shapePointers: " + Arrays.toString(shapeInfoPointers));
 
         Pointer dZ = AtomicAllocator.getInstance().getPointer(ret, context);
@@ -639,7 +643,9 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
                 context.getBufferSpecial(),
                 AddressRetriever.retrieveHostPointer(toConcat[0].shapeInfoDataBuffer()),
                 AddressRetriever.retrieveHostPointer(ret.shapeInfoDataBuffer()),
-                new LongPointer(hostShapeInfoPointers)
+                new LongPointer(hostShapeInfoPointers),
+                AtomicAllocator.getInstance().getPointer(zBuffers.getFirst(), context), // getting zTADShape
+                AtomicAllocator.getInstance().getPointer(zBuffers.getSecond(), context) // getting zOffset
         );
 
         if(ret.data().dataType() == DataBuffer.Type.DOUBLE) {

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/jcuda/jcublas/ops/CudaAccumTests.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/jcuda/jcublas/ops/CudaAccumTests.java
@@ -7,6 +7,10 @@ import org.nd4j.jita.allocator.enums.AllocationStatus;
 import org.nd4j.jita.conf.Configuration;
 import org.nd4j.jita.conf.CudaEnvironment;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.accum.Max;
+import org.nd4j.linalg.api.ops.impl.accum.Mean;
+import org.nd4j.linalg.api.ops.impl.accum.Min;
+import org.nd4j.linalg.api.ops.impl.accum.Sum;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.ArrayUtil;
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/jcuda/jcublas/ops/CudaTransformsTests.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/jcuda/jcublas/ops/CudaTransformsTests.java
@@ -7,6 +7,7 @@ import org.nd4j.jita.allocator.enums.AllocationStatus;
 import org.nd4j.jita.conf.Configuration;
 import org.nd4j.jita.conf.CudaEnvironment;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.transforms.*;
 import org.nd4j.linalg.convolution.Convolution;
 import org.nd4j.linalg.convolution.OldConvolution;
 import org.nd4j.linalg.factory.Nd4j;

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/jcuda/jcublas/ops/HalfOpsTests.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/jcuda/jcublas/ops/HalfOpsTests.java
@@ -24,6 +24,7 @@ import org.nd4j.linalg.ops.transforms.Transforms;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.*;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/jcuda/jcublas/ops/ShufflesTests.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/jcuda/jcublas/ops/ShufflesTests.java
@@ -6,6 +6,11 @@ import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.ArrayUtil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/org/nd4j/linalg/jcublas/buffer/CudaFloatDataBufferTest.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/test/java/org/nd4j/linalg/jcublas/buffer/CudaFloatDataBufferTest.java
@@ -13,6 +13,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.jcublas.context.CudaContext;
 import org.nd4j.linalg.util.ArrayUtil;
 
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/nd4j-backends/nd4j-tests/pom.xml
+++ b/nd4j-backends/nd4j-tests/pom.xml
@@ -86,7 +86,7 @@
 
         <dependency>
             <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
+            <artifactId>nd4j-cuda-8.0</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/NDArrayTestsFortran.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/NDArrayTestsFortran.java
@@ -416,6 +416,7 @@ public  class NDArrayTestsFortran  extends BaseNd4jTest {
         INDArray column2 = Nd4j.create(new float[]{3, 4});
         INDArray testColumn = n.getColumn(0);
         INDArray testColumn1 = n.getColumn(1);
+        log.info("testColumn shape: {}", Arrays.toString(testColumn.shapeInfoDataBuffer().asInt()));
         assertEquals(column, testColumn);
         assertEquals(column2, testColumn1);
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/crash/CrashTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/crash/CrashTest.java
@@ -2,6 +2,7 @@ package org.nd4j.linalg.crash;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/concat/ConcatTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/concat/ConcatTests.java
@@ -1,5 +1,6 @@
 package org.nd4j.linalg.shape.concat;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.math3.util.Pair;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -22,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Adam Gibson
  */
+@Slf4j
 @RunWith(Parameterized.class)
 public class ConcatTests extends BaseNd4jTest {
 


### PR DESCRIPTION
- TAD-related updates for CUDA
- Concat now uses pre-calculated TAD as well as all other kernels now.