### PR TITLE
fix bug: epsi makes copy like eps

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -1324,13 +1324,13 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      * Returns an ndarray with 1 if the element is epsilon equals
      *
      * @param other the number to compare
-     * @return a copied ndarray with the given
+     * @return a ndarray with the given
      * binary conditions
      */
     @Override
     public INDArray epsi(Number other) {
         INDArray otherArr = Nd4j.valueArrayOf(shape(),other.doubleValue());
-        return eps(otherArr);
+        return epsi(otherArr);
     }
 
     /**


### PR DESCRIPTION
### What steps will reproduce the problem?

```
INDArray a = Nd4j.create(new double[]{4.0, 2.0});
System.out.println(a.epsi(4.00000001));
System.out.println(a);
```
### What is the expected result?
```
[1.00, 0.00]
[1.00, 0.00]
```
### What do you get instead?
```
[1.00, 0.00]
[4.00, 2.00]
```
| Q  | A |
| ------------- | ------------- |
| Nd4j version  | 0.7.2  |
| Backend  | CpuBackend  |
| Java version  | 1.8.0_121  |