### PR TITLE
Fix for "cannot convert int[] to int" compile-time error

### DIFF
--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
@@ -1936,7 +1936,7 @@ public class Nd4jTestsC extends BaseNd4jTest {
     @Test
     public void testTile() {
         INDArray x = Nd4j.linspace(1, 4, 4).reshape(2, 2);
-        INDArray repeated = x.repeat(new int[] {2});
+        INDArray repeated = x.repeat(1, new int[] {2});
         assertEquals(8, repeated.length());
         INDArray repeatAlongDimension = x.repeat(1, new int[] {2});
         INDArray assertionRepeat = Nd4j.create(new double[][] {{1, 1, 2, 2}, {3, 3, 4, 4}});


### PR DESCRIPTION
Fix for "cannot convert int[] to int" compile-time error occurring inside `d4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java`.

Problem was line 1939:

```INDArray repeated = x.repeat(new int[] {2});```

which should be

```INDArray repeated = x.repeat(1, new int[] {2});```

FTFY.