### PR TITLE
R119 init order

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOpsHolder.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOpsHolder.java
@@ -1,6 +1,8 @@
 package org.nd4j.nativeblas;
 
 import lombok.Getter;
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.javacpp.Pointer;
 import org.nd4j.context.Nd4jContext;
 import org.nd4j.linalg.factory.Nd4j;
 import org.slf4j.Logger;
@@ -22,9 +24,9 @@ public class NativeOpsHolder {
     private NativeOpsHolder() {
         try {
             Properties props = Nd4jContext.getInstance().getConf();
-            Class<? extends NativeOps> nativeOpsClazz =
-                            Class.forName(System.getProperty(Nd4j.NATIVE_OPS, props.get(Nd4j.NATIVE_OPS).toString()))
-                                            .asSubclass(NativeOps.class);
+
+            String name = System.getProperty(Nd4j.NATIVE_OPS, props.get(Nd4j.NATIVE_OPS).toString());
+            Class<? extends NativeOps> nativeOpsClazz = Class.forName(name).asSubclass(NativeOps.class);
             deviceNativeOps = nativeOpsClazz.newInstance();
 
             deviceNativeOps.initializeDevicesAndFunctions();
@@ -34,7 +36,12 @@ public class NativeOpsHolder {
                 numThreads = Integer.parseInt(numThreadsString);
                 deviceNativeOps.setOmpNumThreads(numThreads);
             } else {
-                deviceNativeOps.setOmpNumThreads(deviceNativeOps.getCores(Runtime.getRuntime().availableProcessors()));
+                int cores = Loader.totalCores();
+                int chips = Loader.totalChips();
+                if (chips > 0 && cores > 0) {
+                    deviceNativeOps.setOmpNumThreads(Math.max(1, cores / chips));
+                } else
+                    deviceNativeOps.setOmpNumThreads(deviceNativeOps.getCores(Runtime.getRuntime().availableProcessors()));
             }
             //deviceNativeOps.setOmpNumThreads(4);
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/tad/DeviceTADManager.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/tad/DeviceTADManager.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Semaphore;
 public class DeviceTADManager extends BasicTADManager {
     protected List<Map<TadDescriptor, Pair<DataBuffer, DataBuffer>>> tadCache = new ArrayList<>();
     private Semaphore lock = new Semaphore(1);
-    private Configuration configuration = CudaEnvironment.getInstance().getConfiguration();
 
     public DeviceTADManager() {
         int numDevices = Nd4j.getAffinityManager().getNumberOfDevices();

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/concurrency/CudaAffinityManager.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/concurrency/CudaAffinityManager.java
@@ -28,9 +28,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author raver119@gmail.com
  */
 public class CudaAffinityManager extends BasicAffinityManager {
-
-    private static final Configuration configuration = CudaEnvironment.getInstance().getConfiguration();
-
     private static Logger logger = LoggerFactory.getLogger(CudaAffinityManager.class);
 
     private Map<Long, Integer> affinityMap = new ConcurrentHashMap<>();
@@ -41,6 +38,7 @@ public class CudaAffinityManager extends BasicAffinityManager {
 
     public CudaAffinityManager() {
         super();
+
     }
 
     /**
@@ -126,7 +124,7 @@ public class CudaAffinityManager extends BasicAffinityManager {
      */
     @Override
     public void attachThreadToDevice(long threadId, Integer deviceId) {
-        List<Integer> devices = new ArrayList<>(configuration.getAvailableDevices());
+        List<Integer> devices = new ArrayList<>(CudaEnvironment.getInstance().getConfiguration().getAvailableDevices());
         logger.debug("Manually mapping thread [{}] to device [{}], out of [{}] devices...", threadId, deviceId,
                         devices.size());
         affinityMap.put(threadId, deviceId);
@@ -140,20 +138,20 @@ public class CudaAffinityManager extends BasicAffinityManager {
      */
     protected Integer getNextDevice(long threadId) {
         Integer device = null;
-        if (!configuration.isForcedSingleGPU() && getNumberOfDevices() > 0) {
+        if (!CudaEnvironment.getInstance().getConfiguration().isForcedSingleGPU() && getNumberOfDevices() > 0) {
             // simple round-robin here
             synchronized (this) {
-                device = configuration.getAvailableDevices().get(devPtr.getAndIncrement());
+                device = CudaEnvironment.getInstance().getConfiguration().getAvailableDevices().get(devPtr.getAndIncrement());
 
                 // We check only for number of entries here, not their actual values
-                if (devPtr.get() >= configuration.getAvailableDevices().size())
+                if (devPtr.get() >= CudaEnvironment.getInstance().getConfiguration().getAvailableDevices().size())
                     devPtr.set(0);
 
                 logger.debug("Mapping thread [{}] to device [{}], out of [{}] devices...", threadId, device,
-                                configuration.getAvailableDevices().size());
+                        CudaEnvironment.getInstance().getConfiguration().getAvailableDevices().size());
             }
         } else {
-            device = configuration.getAvailableDevices().get(0);
+            device = CudaEnvironment.getInstance().getConfiguration().getAvailableDevices().get(0);
             logger.debug("Single device is forced, mapping to device [{}]", device);
         }
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/conf/Configuration.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/conf/Configuration.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.nd4j.jita.allocator.enums.Aggressiveness;
 import org.nd4j.jita.allocator.enums.AllocationStatus;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.nativeblas.NativeOps;
 import org.nd4j.nativeblas.NativeOpsHolder;
 
@@ -176,7 +177,7 @@ public class Configuration implements Serializable {
 
     private final AtomicBoolean initialized = new AtomicBoolean(false);
 
-    private NativeOps nativeOps = NativeOpsHolder.getInstance().getDeviceNativeOps();
+    private NativeOps nativeOps;
 
     public boolean isInitialized() {
         return initialized.get();
@@ -372,6 +373,10 @@ public class Configuration implements Serializable {
     }
 
     public Configuration() {
+        Nd4j.getAffinityManager();
+
+        nativeOps = NativeOpsHolder.getInstance().getDeviceNativeOps();
+
         int cnt = nativeOps.getAvailableDevices();
         if (cnt == 0)
             throw new RuntimeException("No CUDA devices were found in system");

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/constant/ProtectedCudaShapeInfoProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/constant/ProtectedCudaShapeInfoProvider.java
@@ -25,8 +25,6 @@ public class ProtectedCudaShapeInfoProvider extends BaseShapeInfoProvider {
 
     private Semaphore lock = new Semaphore(1);
 
-    private Configuration configuration = CudaEnvironment.getInstance().getConfiguration();
-
     protected static final ConstantProtector protector = ConstantProtector.getInstance();
 
     private static ProtectedCudaShapeInfoProvider ourInstance = new ProtectedCudaShapeInfoProvider();
@@ -62,7 +60,7 @@ public class ProtectedCudaShapeInfoProvider extends BaseShapeInfoProvider {
             DataBuffer buffer = super.createShapeInformation(shape, stride, offset, elementWiseStride, order);
             buffer.setConstant(true);
 
-            if (configuration.getMemoryModel() == Configuration.MemoryModel.IMMEDIATE) {
+            if (CudaEnvironment.getInstance().getConfiguration().getMemoryModel() == Configuration.MemoryModel.IMMEDIATE) {
                 Nd4j.getConstantHandler().moveToConstantSpace(buffer);
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -430,11 +430,11 @@
               <artifactId>formatter-maven-plugin</artifactId>
               <version>2.0.0</version>
               <executions>
-                <!--<execution>
+                <execution>
                   <goals>
                     <goal>validate</goal>
                   </goals>
-                </execution>-->
+                </execution>
               </executions>
               <configuration>
                 <configFile>${nd4jBasedir}/contrib/formatter.xml</configFile>

--- a/pom.xml
+++ b/pom.xml
@@ -430,11 +430,11 @@
               <artifactId>formatter-maven-plugin</artifactId>
               <version>2.0.0</version>
               <executions>
-                <execution>
+                <!--<execution>
                   <goals>
                     <goal>validate</goal>
                   </goals>
-                </execution>
+                </execution>-->
               </executions>
               <configuration>
                 <configFile>${nd4jBasedir}/contrib/formatter.xml</configFile>


### PR DESCRIPTION
Fix for CudaEnvironment & backends init order (no more Nd4j.create(1)) 