### PR TITLE
Fix old version of mvn-invoker plugin which was transitively imported, with  old assumptions on location of mvn on windows.

### DIFF
--- a/nd4j-shade/jackson/pom.xml
+++ b/nd4j-shade/jackson/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
               <groupId>org.apache.portals.jetspeed-2</groupId>
               <artifactId>jetspeed-mvn-maven-plugin</artifactId>
-              <version>2.2.2</version>
+              <version>2.3.1</version>
               <executions>
                 <execution>
                   <id>compile-and-pack</id>
@@ -34,6 +34,13 @@
                   </goals>
                 </execution>
               </executions>
+              <dependencies>
+                <dependency>
+                  <groupId>org.apache.maven.shared</groupId>
+                  <artifactId>maven-invoker</artifactId>
+                  <version>2.2</version>
+                </dependency>
+              </dependencies>
               <configuration>
                 <targets combine.children="merge">
 


### PR DESCRIPTION
See also https://issues.apache.org/jira/browse/MRELEASE-902