### PR TITLE
Fix NullPointerException in MultiNormalizerHybrid on missing features/labels

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/MultiNormalizerHybrid.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/MultiNormalizerHybrid.java
@@ -304,11 +304,13 @@ public class MultiNormalizerHybrid extends AbstractNormalizer implements MultiDa
     private void preProcess(INDArray[] arrays, INDArray[] masks, NormalizerStrategy globalStrategy,
                     Map<Integer, NormalizerStrategy> perArrayStrategy, Map<Integer, NormalizerStats> stats) {
 
-        for (int i = 0; i < arrays.length; i++) {
-            NormalizerStrategy strategy = getStrategy(globalStrategy, perArrayStrategy, i);
-            if (strategy != null) {
-                //noinspection unchecked
-                strategy.preProcess(arrays[i], masks == null ? null : masks[i], stats.get(i));
+        if (arrays != null) {
+            for (int i = 0; i < arrays.length; i++) {
+                NormalizerStrategy strategy = getStrategy(globalStrategy, perArrayStrategy, i);
+                if (strategy != null) {
+                    //noinspection unchecked
+                    strategy.preProcess(arrays[i], masks == null ? null : masks[i], stats.get(i));
+                }
             }
         }
     }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/MultiNormalizerHybridTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/MultiNormalizerHybridTest.java
@@ -19,8 +19,6 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Parameterized.class)
 public class MultiNormalizerHybridTest extends BaseNd4jTest {
-    private static final double TOLERANCE_PERC = 0.01; // 0.01% of correct value
-
     private MultiNormalizerHybrid SUT;
     private MultiDataSet data;
     private MultiDataSet dataCopy;
@@ -109,11 +107,24 @@ public class MultiNormalizerHybridTest extends BaseNd4jTest {
         assertEquals(timeSeriesCopy, timeSeries);
     }
 
-    private void assertSmallDifference(double expected, double actual) {
-        double delta = Math.abs(expected - actual);
-        double deltaPerc = (delta / expected) * 100;
-        assertTrue(String.format("Failed to assert that expected value %f is close to actual value %f", expected,
-                        actual), deltaPerc < TOLERANCE_PERC);
+    @Test
+    public void testDataSetWithoutLabels() {
+        SUT.standardizeAllInputs().standardizeAllOutputs().fit(data);
+
+        data.setLabels(null);
+        data.setLabelsMaskArray(null);
+
+        SUT.preProcess(data);
+    }
+
+    @Test
+    public void testDataSetWithoutFeatures() {
+        SUT.standardizeAllInputs().standardizeAllOutputs().fit(data);
+
+        data.setFeatures(null);
+        data.setFeaturesMaskArrays(null);
+
+        SUT.preProcess(data);
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds a null check in MultiNormalizerHybrid to prevent NullPointerExceptions when either the features array of the labels array of a MultiDataSet is null. In practice this can happen during inference when no labels are present.

Also removed some dead code from the unit test case.

## How was this patch tested?

Added unit tests to cover the check.
