### PR TITLE
Use GCC instead of Clang to build nd4j-native on Mac OS X

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -215,6 +215,28 @@
 
     <profiles>
         <profile>
+            <id>macosx-gcc6</id>
+            <activation>
+                <file>
+                    <exists>/usr/local/bin/g++-6</exists>
+                </file>
+            </activation>
+            <properties>
+                <javacpp.platform.compiler>/usr/local/bin/g++-6</javacpp.platform.compiler>
+            </properties>
+        </profile>
+        <profile>
+            <id>macosx-gcc5</id>
+            <activation>
+                <file>
+                    <exists>/usr/local/bin/g++-5</exists>
+                </file>
+            </activation>
+            <properties>
+                <javacpp.platform.compiler>/usr/local/bin/g++-5</javacpp.platform.compiler>
+            </properties>
+        </profile>
+        <profile>
             <id>mingw</id>
             <activation>
                 <os><family>windows</family></os>


### PR DESCRIPTION
Fixes #1753 

## What changes were proposed in this pull request?

To build the JNI wrapper for nd4j-native generated by JavaCPP, use GCC instead of Clang, which doesn't work with cnpy

## How was this patch tested?

Build passes on Mac