### PR TITLE
Link nd4j-native statically with GCC on Mac OS X

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -237,6 +237,26 @@
             </properties>
         </profile>
         <profile>
+            <id>macosx</id>
+            <activation>
+                <os><family>mac os x</family></os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.bytedeco</groupId>
+                        <artifactId>javacpp</artifactId>
+                        <configuration>
+                            <compilerOptions>
+                                <compilerOption>-static-libgcc</compilerOption>
+                                <compilerOption>-static-libstdc++</compilerOption>
+                            </compilerOptions>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>mingw</id>
             <activation>
                 <os><family>windows</family></os>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Provide self-contained JAR files with GCC on Mac as well.

## How was this patch tested?

The build succeeds.