### PR TITLE
Fix build for CUDA 7.5 missing cusolverDnSorgqr and cusolverDnDorgqr

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/blas/impl/BaseLapack.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/blas/impl/BaseLapack.java
@@ -1,20 +1,18 @@
 package org.nd4j.linalg.api.blas.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import org.nd4j.linalg.api.blas.Lapack;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base lapack define float and double versions.
  *
  * @author Adam Gibson
  */
+@Slf4j
 public abstract class BaseLapack implements Lapack {
-
-    private static Logger logger = LoggerFactory.getLogger(BaseLapack.class);
 
     @Override
     public INDArray getrf(INDArray A) {
@@ -39,7 +37,7 @@ public abstract class BaseLapack implements Lapack {
         if (INFO.getInt(0) < 0) {
             throw new Error("Parameter #" + INFO.getInt(0) + " to getrf() was not valid");
         } else if (INFO.getInt(0) > 0) {
-            logger.warn("The matrix is singular - cannot be used for inverse op. Check L matrix at row "
+            log.warn("The matrix is singular - cannot be used for inverse op. Check L matrix at row "
                             + INFO.getInt(0));
         }
 
@@ -170,7 +168,7 @@ public abstract class BaseLapack implements Lapack {
         if (INFO.getInt(0) < 0) {
             throw new Error("Parameter #" + INFO.getInt(0) + " to gesvd() was not valid");
         } else if (INFO.getInt(0) > 0) {
-            logger.warn("The matrix contains singular elements. Check S matrix at row " + INFO.getInt(0));
+            log.warn("The matrix contains singular elements. Check S matrix at row " + INFO.getInt(0));
         }
     }
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java
@@ -2,7 +2,7 @@ package org.nd4j.linalg.jcublas.blas;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.logging.Level;
+import lombok.extern.slf4j.Slf4j;
 import org.bytedeco.javacpp.DoublePointer;
 import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.javacpp.IntPointer;
@@ -23,8 +23,6 @@ import org.nd4j.linalg.jcublas.CublasPointer;
 import org.nd4j.linalg.jcublas.context.CudaContext;
 import org.nd4j.nativeblas.NativeOps;
 import org.nd4j.nativeblas.NativeOpsHolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.bytedeco.javacpp.cuda.CUstream_st;
 import static org.bytedeco.javacpp.cusolver.*;
@@ -34,11 +32,11 @@ import static org.bytedeco.javacpp.cusolver.*;
  *
  * @author Adam Gibson
  */
+@Slf4j
 public class JcublasLapack extends BaseLapack {
 
     private NativeOps nativeOps = NativeOpsHolder.getInstance().getDeviceNativeOps();
     private Allocator allocator = AtomicAllocator.getInstance();
-    private static Logger logger = LoggerFactory.getLogger(JcublasLapack.class);
 
     private Method cusolverDnSorgqr, cusolverDnSorgqr_bufferSize, cusolverDnDorgqr, cusolverDnDorgqr_bufferSize;
 
@@ -50,7 +48,7 @@ public class JcublasLapack extends BaseLapack {
             cusolverDnDorgqr_bufferSize = c.getMethod("cusolverDnDorgqr_bufferSize", cusolverDnContext.class, int.class, int.class, int.class, FloatPointer.class, int.class, FloatPointer.class, IntPointer.class);
             cusolverDnDorgqr = c.getMethod("cusolverDnDorgqr", cusolverDnContext.class, int.class, int.class, int.class, FloatPointer.class, int.class, FloatPointer.class, FloatPointer.class, int.class, IntPointer.class);
         } catch (NoSuchMethodException | SecurityException ex) {
-            logger.warn("cusolverDnSorgqr() and cusolverDnDorgqr() are not available", ex);
+            log.warn("cusolverDnSorgqr() and cusolverDnDorgqr() are not available", ex);
         }
     }
 
@@ -58,7 +56,7 @@ public class JcublasLapack extends BaseLapack {
     public void sgetrf(int M, int N, INDArray A, INDArray IPIV, INDArray INFO) {
         INDArray a = A;
         if (Nd4j.dataType() != DataBuffer.Type.FLOAT)
-            logger.warn("FLOAT getrf called in DOUBLE environment");
+            log.warn("FLOAT getrf called in DOUBLE environment");
 
         if (A.ordering() == 'c')
             a = A.dup('f');
@@ -118,7 +116,7 @@ public class JcublasLapack extends BaseLapack {
         if (a != A)
             A.assign(a);
 
-        logger.info("A: {}", A);
+        log.info("A: {}", A);
     }
 
 
@@ -128,7 +126,7 @@ public class JcublasLapack extends BaseLapack {
         INDArray a = A;
 
         if (Nd4j.dataType() != DataBuffer.Type.DOUBLE)
-            logger.warn("FLOAT getrf called in FLOAT environment");
+            log.warn("FLOAT getrf called in FLOAT environment");
 
         if (A.ordering() == 'c')
             a = A.dup('f');
@@ -194,7 +192,7 @@ public class JcublasLapack extends BaseLapack {
         INDArray r = R;
 
         if (Nd4j.dataType() != DataBuffer.Type.FLOAT)
-            logger.warn("FLOAT getrf called in DOUBLE environment");
+            log.warn("FLOAT getrf called in DOUBLE environment");
 
         if (A.ordering() == 'c') 
             a = A.dup('f');
@@ -303,8 +301,8 @@ public class JcublasLapack extends BaseLapack {
         if ( r!=null && r != R )
             R.assign(r);
 
-        logger.info("A: {}", A);
-        if( R != null ) logger.info("R: {}", R);
+        log.info("A: {}", A);
+        if( R != null ) log.info("R: {}", R);
     }
 
     @Override
@@ -313,7 +311,7 @@ public class JcublasLapack extends BaseLapack {
         INDArray r = R;
 
         if (Nd4j.dataType() != DataBuffer.Type.DOUBLE)
-            logger.warn("DOUBLE getrf called in FLOAT environment");
+            log.warn("DOUBLE getrf called in FLOAT environment");
 
         if (A.ordering() == 'c')
             a = A.dup('f');
@@ -419,8 +417,8 @@ public class JcublasLapack extends BaseLapack {
         if ( r!=null && r != R )
             R.assign(r);
 
-        logger.info("A: {}", A);
-        if( R != null ) logger.info("R: {}", R);
+        log.info("A: {}", A);
+        if( R != null ) log.info("R: {}", R);
     }
 
 //=========================    
@@ -430,7 +428,7 @@ public class JcublasLapack extends BaseLapack {
         INDArray a = A;
 
         if (Nd4j.dataType() != DataBuffer.Type.FLOAT)
-            logger.warn("DOUBLE potrf called in FLOAT environment");
+            log.warn("DOUBLE potrf called in FLOAT environment");
 
         if (A.ordering() == 'c')
             a = A.dup('f');
@@ -505,7 +503,7 @@ public class JcublasLapack extends BaseLapack {
             }        
         }
 
-        logger.info("A: {}", A);
+        log.info("A: {}", A);
     }
 
     @Override
@@ -513,7 +511,7 @@ public class JcublasLapack extends BaseLapack {
         INDArray a = A;
 
         if (Nd4j.dataType() != DataBuffer.Type.DOUBLE)
-            logger.warn("FLOAT potrf called in DOUBLE environment");
+            log.warn("FLOAT potrf called in DOUBLE environment");
 
         if (A.ordering() == 'c')
             a = A.dup('f');
@@ -588,7 +586,7 @@ public class JcublasLapack extends BaseLapack {
             }        
         }
 
-        logger.info("A: {}", A);
+        log.info("A: {}", A);
     }
 
 
@@ -617,7 +615,7 @@ public class JcublasLapack extends BaseLapack {
         INDArray vt = VT;
 
         if (Nd4j.dataType() != DataBuffer.Type.FLOAT)
-            logger.warn("FLOAT gesvd called in DOUBLE environment");
+            log.warn("FLOAT gesvd called in DOUBLE environment");
 
         // cuda requires column ordering - we'll register a warning in case
         if (A.ordering() == 'c')
@@ -703,7 +701,7 @@ public class JcublasLapack extends BaseLapack {
         INDArray vt = VT;
 
         if (Nd4j.dataType() != DataBuffer.Type.DOUBLE)
-            logger.warn("DOUBLE gesvd called in FLOAT environment");
+            log.warn("DOUBLE gesvd called in FLOAT environment");
 
         // cuda requires column ordering - we'll register a warning in case
         if (A.ordering() == 'c')

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java
@@ -45,8 +45,8 @@ public class JcublasLapack extends BaseLapack {
         try {
             cusolverDnSorgqr_bufferSize = c.getMethod("cusolverDnSorgqr_bufferSize", cusolverDnContext.class, int.class, int.class, int.class, FloatPointer.class, int.class, FloatPointer.class, IntPointer.class);
             cusolverDnSorgqr = c.getMethod("cusolverDnSorgqr", cusolverDnContext.class, int.class, int.class, int.class, FloatPointer.class, int.class, FloatPointer.class, FloatPointer.class, int.class, IntPointer.class);
-            cusolverDnDorgqr_bufferSize = c.getMethod("cusolverDnDorgqr_bufferSize", cusolverDnContext.class, int.class, int.class, int.class, FloatPointer.class, int.class, FloatPointer.class, IntPointer.class);
-            cusolverDnDorgqr = c.getMethod("cusolverDnDorgqr", cusolverDnContext.class, int.class, int.class, int.class, FloatPointer.class, int.class, FloatPointer.class, FloatPointer.class, int.class, IntPointer.class);
+            cusolverDnDorgqr_bufferSize = c.getMethod("cusolverDnDorgqr_bufferSize", cusolverDnContext.class, int.class, int.class, int.class, DoublePointer.class, int.class, DoublePointer.class, IntPointer.class);
+            cusolverDnDorgqr = c.getMethod("cusolverDnDorgqr", cusolverDnContext.class, int.class, int.class, int.class, DoublePointer.class, int.class, DoublePointer.class, DoublePointer.class, int.class, IntPointer.class);
         } catch (NoSuchMethodException | SecurityException ex) {
             log.warn("cusolverDnSorgqr() and cusolverDnDorgqr() are not available", ex);
         }


### PR DESCRIPTION
Fixes #1761 

## What changes were proposed in this pull request?

Calls cusolverDnSorgqr and cusolverDnDorgqr via reflection to fix build with CUDA 7.5.

## How was this patch tested?

Build passes on both CUDA 7.5 and 8.0, but unit tests pass only on CUDA 8.0, as expected.