### PR TITLE
Enable default compression for DataSet save().

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -68,7 +68,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
 
     private List<Serializable> exampleMetaData;
 
-    private String defaultCompression = "GZIP";
+    private String defaultCompression = "FLOAT16";
     private transient boolean preProcessed = false;
 
     public DataSet() {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -493,7 +493,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
 
     @Override
     public void save(OutputStream to) {
-        save(to, defaultCompression);
+        saveUncompressed(to);
     }
 
     public void save(File to, String compressionAlgorithm) {
@@ -507,7 +507,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
 
     @Override
     public void save(File to) {
-        save(to, defaultCompression);
+        saveUncompressed(to);
     }
 
     public void saveUncompressed(OutputStream to) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -1547,11 +1547,32 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      */
     @Override
     public long getMemoryFootprint() {
+        // we need to decompress array before checking its size
+        decompress();
+
         long reqMem = features.lengthLong() * Nd4j.sizeOfDataType();
         reqMem += labels == null ? 0 : labels.lengthLong() * Nd4j.sizeOfDataType();
         reqMem += featuresMask == null ? 0 : featuresMask.lengthLong() * Nd4j.sizeOfDataType();
         reqMem += labelsMask == null ? 0 : labelsMask.lengthLong() * Nd4j.sizeOfDataType();
 
         return reqMem;
+    }
+
+    /**
+     * Thia method checks, if dataset is compressed, and applies decompression to it
+     */
+    @Override
+    public void decompress() {
+        if (features != null && features.isCompressed())
+            Nd4j.getCompressor().decompressi(features);
+
+        if (labels != null && labels.isCompressed())
+            Nd4j.getCompressor().decompressi(labels);
+
+        if (featuresMask != null && featuresMask.isCompressed())
+            Nd4j.getCompressor().decompressi(featuresMask);
+
+        if (labelsMask != null && labelsMask.isCompressed())
+            Nd4j.getCompressor().decompressi(labelsMask);
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MultiDataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MultiDataSet.java
@@ -674,6 +674,9 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
     public long getMemoryFootprint() {
         long reqMem = 0;
 
+        // we need to decompress all arrays before checking its size
+        decompress();
+
         for (INDArray f: features)
             reqMem += f == null ? 0 : f.lengthLong() * Nd4j.sizeOfDataType();
 
@@ -690,5 +693,31 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
                 reqMem += f == null ? 0 : f.lengthLong() * Nd4j.sizeOfDataType();
 
         return reqMem;
+    }
+
+    /**
+     * Thia method checks, if dataset is compressed, and applies decompression to it
+     */
+    @Override
+    public void decompress() {
+        if (features != null)
+            for (int i = 0; i < features.length; i++)
+                if (features[i] != null && features[i].isCompressed())
+                    Nd4j.getCompressor().decompressi(features[i]);
+
+        if (featuresMaskArrays != null)
+            for (int i = 0; i < featuresMaskArrays.length; i++)
+                if (featuresMaskArrays[i] != null && featuresMaskArrays[i].isCompressed())
+                    Nd4j.getCompressor().decompressi(featuresMaskArrays[i]);
+
+        if (labels != null)
+            for (int i = 0; i < labels.length; i++)
+                if (labels[i] != null && labels[i].isCompressed())
+                    Nd4j.getCompressor().decompressi(labels[i]);
+
+        if (labelsMaskArrays != null)
+            for (int i = 0; i < labelsMaskArrays.length; i++)
+                if (labelsMaskArrays[i] != null && labelsMaskArrays[i].isCompressed())
+                    Nd4j.getCompressor().decompressi(labelsMaskArrays[i]);
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
@@ -324,4 +324,9 @@ public interface DataSet extends Iterable<org.nd4j.linalg.dataset.DataSet>, Seri
      * @return
      */
     long getMemoryFootprint();
+
+    /**
+     * Thia method checks, if dataset is compressed, and applies decompression to it
+     */
+    void decompress();
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/MultiDataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/MultiDataSet.java
@@ -172,4 +172,9 @@ public interface MultiDataSet extends Serializable {
 
     long getMemoryFootprint();
 
+    /**
+     * Thia method checks, if dataset is compressed, and applies decompression to it
+     */
+    void decompress();
+
 }


### PR DESCRIPTION
![richard-hendricks](https://cloud.githubusercontent.com/assets/1445295/25011402/12ac129a-2022-11e7-8777-6b4565cb6946.jpg)


## What changes were proposed in this pull request?

The default signature for DataSet.save() now has compression enabled by default. 

Addresses https://github.com/deeplearning4j/nd4j/issues/1224.

## How was this patch tested?

Ran unit tests in addition to tested in a real-world project. Float16 was used for compression since it appears to be the best compression/lossless algorithm.

Weissman score is off the charts!