### PR TITLE
Only rebuild needed modules between different scala version builds

### DIFF
--- a/buildmultiplescalaversions.sh
+++ b/buildmultiplescalaversions.sh
@@ -1,7 +1,17 @@
 #! /bin/bash
+BASEDIR=$(dirname $(readlink -f "$0"))
+
+function whatchanged() {
+    cd $BASEDIR
+    for i in $(git status -s --porcelain -- $(find ./ -mindepth 2 -name pom.xml)|awk '{print $2}'); do
+	echo $(dirname $i)
+	cd $BASEDIR
+    done
+}
+
 set -eu
 ./change-scala-versions.sh 2.11 # should be idempotent, this is the default
 mvn "$@"
 ./change-scala-versions.sh 2.10
-mvn "$@"
+mvn -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
 ./change-scala-versions.sh 2.11 #back to default


### PR DESCRIPTION
Reduces build time of `./buildmultiplescalaversions.sh clean install -DskipTests=true`
   from 184s to 107s
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/2873