### PR TITLE
Add MultiDataSetIterator.getPreProcessor() method to API

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/MultiDataSetIterator.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/MultiDataSetIterator.java
@@ -23,6 +23,15 @@ public interface MultiDataSetIterator extends Iterator<MultiDataSet>, Serializab
      */
     void setPreProcessor(MultiDataSetPreProcessor preProcessor);
 
+
+    /**
+     * Get the {@link MultiDataSetPreProcessor}, if one has previously been set.
+     * Returns null if no preprocessor has been set
+     *
+     * @return Preprocessor
+     */
+    MultiDataSetPreProcessor getPreProcessor();
+
     /**
      * Is resetting supported by this DataSetIterator? Many DataSetIterators do support resetting,
      * but some don't

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/TestMultiDataSetIterator.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/TestMultiDataSetIterator.java
@@ -50,6 +50,11 @@ public class TestMultiDataSetIterator implements MultiDataSetIterator {
     }
 
     @Override
+    public MultiDataSetPreProcessor getPreProcessor() {
+        return this.preProcessor;
+    }
+
+    @Override
     public boolean resetSupported() {
         return true;
     }


### PR DESCRIPTION
Simple API change (adds getPreProcessor() method) to align with DataSetIterator (which has both set and get methods).
