### PR TITLE
Variable input fixes

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
@@ -432,7 +432,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
 
 
         if (cycleAllocations.get() > maxCycle.get()) {
-            log.info("Workspace [{}], current cycle: {}; max cycle: {}", id, cycleAllocations.get(), maxCycle.get());
+            log.debug("Workspace [{}], current cycle: {}; max cycle: {}", id, cycleAllocations.get(), maxCycle.get());
             maxCycle.set(cycleAllocations.get());
         }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
@@ -116,7 +116,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
                 throw new ND4JIllegalStateException("For cyclic workspace overallocation should be positive integral value.");
 
             stepsNumber = (int) (workspaceConfiguration.getOverallocationLimit() + 1);
-            log.info("Steps: {}", stepsNumber);
+            log.debug("Steps: {}", stepsNumber);
         }
 
         //if (workspaceConfiguration.getPolicyLearning() == LearningPolicy.OVER_TIME && workspaceConfiguration.getCyclesBeforeInitialization() < 1)
@@ -453,7 +453,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
                 //log.info("Initializing on cycle {}", cyclesCount.get());
                 initializeWorkspace();
             } else if (currentSize.get() > 0 && cycleAllocations.get() > 0 && workspaceConfiguration.getPolicySpill() == SpillPolicy.REALLOCATE && workspaceConfiguration.getPolicyReset() != ResetPolicy.ENDOFBUFFER_REACHED) {
-                log.info("Reinit on cycle {}; step: {}", cyclesCount.get(), stepsCount.get());
+                log.debug("Reinit on cycle {}; step: {}", cyclesCount.get(), stepsCount.get());
                 initializeWorkspace();
             }
         }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
@@ -116,7 +116,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
                 throw new ND4JIllegalStateException("For cyclic workspace overallocation should be positive integral value.");
 
             stepsNumber = (int) (workspaceConfiguration.getOverallocationLimit() + 1);
-            log.debug("Steps: {}", stepsNumber);
+            log.info("Steps: {}", stepsNumber);
         }
 
         //if (workspaceConfiguration.getPolicyLearning() == LearningPolicy.OVER_TIME && workspaceConfiguration.getCyclesBeforeInitialization() < 1)
@@ -234,7 +234,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
             deviceOffset.set(hostOffset.get());
 
             if (isDebug.get())
-                log.info("Workspace [{}]: Allocating array of {} bytes, capacity of {} elements, prevOffset:", id, requiredMemory, numElements);
+                log.info("Workspace [{}]: Allocating array of {} bytes, capacity of {} elements, prevOffset: {}", id, requiredMemory, numElements, prevOffset);
 
             PagedPointer ptr = workspace.getHostPointer().withOffset(prevOffset, numElements);
 
@@ -244,8 +244,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
             return ptr;
         } else {
             if (workspaceConfiguration.getPolicyReset() == ResetPolicy.ENDOFBUFFER_REACHED && currentSize.get() > 0 && !trimmer) {
-                hostOffset.set(0);
-                deviceOffset.set(0);
+                reset();
                 resetPlanned.set(true);
                 //stepsCount.incrementAndGet();
                 return alloc(requiredMemory, kind, type, initialize);
@@ -358,8 +357,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
 
         workspace.setHostPointer(null);
         currentSize.set(0);
-        hostOffset.set(0);
-        deviceOffset.set(0);
+        reset();
 
         externalCount.set(0);
 
@@ -388,6 +386,10 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
         return this;
     }
 
+    public long getCyclesCount() {
+        return cyclesCount.get();
+    }
+
     @Override
     public void close() {
         if (isBorrowed.get()) {
@@ -414,7 +416,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
 
 
         cyclesCount.incrementAndGet();
-        if (cyclesCount.get() % stepsNumber == 0) {
+        if (cyclesCount.get() > 1 & (cyclesCount.get() - 1) % stepsNumber == 0) {
             stepsCount.incrementAndGet();
         }
         /*
@@ -430,7 +432,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
 
 
         if (cycleAllocations.get() > maxCycle.get()) {
-            log.debug("Workspace [{}], current cycle: {}; max cycle: {}", id, cycleAllocations.get(), maxCycle.get());
+            log.info("Workspace [{}], current cycle: {}; max cycle: {}", id, cycleAllocations.get(), maxCycle.get());
             maxCycle.set(cycleAllocations.get());
         }
 
@@ -451,7 +453,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
                 //log.info("Initializing on cycle {}", cyclesCount.get());
                 initializeWorkspace();
             } else if (currentSize.get() > 0 && cycleAllocations.get() > 0 && workspaceConfiguration.getPolicySpill() == SpillPolicy.REALLOCATE && workspaceConfiguration.getPolicyReset() != ResetPolicy.ENDOFBUFFER_REACHED) {
-                //log.info("Reinit on cycle {}", cyclesCount.get());
+                log.info("Reinit on cycle {}; step: {}", cyclesCount.get(), stepsCount.get());
                 initializeWorkspace();
             }
         }
@@ -462,24 +464,37 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
             clearPinnedAllocations(false);
 
         if (trimmedMode.get() && trimmedStep.get() + 2 < stepsCount.get()) {
-            initialBlockSize.set(cycleAllocations.get());
+            initialBlockSize.set(maxCycle.get());
             initializeWorkspace();
             trimmedMode.set(false);
             trimmedStep.set(0);
 
-            hostOffset.set(0);
-            deviceOffset.set(0);
+            //log.info("Exiting trimmed mode");
+            reset();
         }
 
         lastCycleAllocations.set(cycleAllocations.get());
 
         disabledCounter.set(0);
-        cycleAllocations.set(0);
+
 
         if (workspaceConfiguration.getPolicyReset() == ResetPolicy.BLOCK_LEFT) {
-            hostOffset.set(0);
-            deviceOffset.set(0);
+            reset();
+        } else if (workspaceConfiguration.getPolicyReset() == ResetPolicy.ENDOFBUFFER_REACHED && currentSize.get() > 0) {
+
+            // for variable input we want to ensure alignment to max block, to avoid accidental buffer overruns
+            long diff = initialBlockSize.get() - cycleAllocations.get();
+
+            //log.info("Align to [{}]; diff: [{}]; block size: [{}]; currentOffset: [{}]; workspaceSize: [{}]; trimmedMode: {}", initialBlockSize.get(), diff, cycleAllocations.get(), deviceOffset.get(), currentSize.get(), trimmedMode.get());
+
+            // we don't care about offsets if that's trimmed mode, offsets will be reset anyway upon reallocation
+            if (diff > 0 && !trimmedMode.get() && deviceOffset.get() > 0) {
+                deviceOffset.getAndAdd(diff);
+                hostOffset.getAndAdd(diff);
+            }
         }
+
+        cycleAllocations.set(0);
     }
 
     protected abstract void clearPinnedAllocations(boolean extended);
@@ -504,8 +519,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
         isOpen.set(true);
 
         if (workspaceConfiguration.getPolicyReset() == ResetPolicy.BLOCK_LEFT) {
-            hostOffset.set(0);
-            deviceOffset.set(0);
+            reset();
         }
 
         if (externalCount.get() > 0 && (workspaceConfiguration.getPolicyReset() == ResetPolicy.BLOCK_LEFT || resetPlanned.get())) {
@@ -521,6 +535,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
     }
 
     public void reset() {
+        //log.info("Resetting at device: {}; host: {};", deviceOffset.get(), hostOffset.get());
         hostOffset.set(0);
         deviceOffset.set(0);
     }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/workspace/CudaWorkspace.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/workspace/CudaWorkspace.java
@@ -129,7 +129,6 @@ public class CudaWorkspace extends Nd4jWorkspace {
         if (trimmer && workspaceConfiguration.getPolicySpill() == SpillPolicy.REALLOCATE && !trimmedMode.get()) {
             trimmedMode.set(true);
             trimmedStep.set(stepsCount.get());
-            log.info("Entering trimmed mode");
         }
 
         if (kind == MemoryKind.DEVICE) {

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/workspace/CudaWorkspace.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/workspace/CudaWorkspace.java
@@ -78,13 +78,11 @@ public class CudaWorkspace extends Nd4jWorkspace {
     @Override
     public synchronized void destroyWorkspace(boolean extended) {
         currentSize.set(0);
-        hostOffset.set(0);
-        deviceOffset.set(0);
+        reset();
 
         if (extended)
             clearExternalAllocations();
 
-        stepsCount.set(Long.MAX_VALUE - 100);
         clearPinnedAllocations(extended);
 
         if (workspace.getHostPointer() != null)
@@ -131,6 +129,7 @@ public class CudaWorkspace extends Nd4jWorkspace {
         if (trimmer && workspaceConfiguration.getPolicySpill() == SpillPolicy.REALLOCATE && !trimmedMode.get()) {
             trimmedMode.set(true);
             trimmedStep.set(stepsCount.get());
+            log.info("Entering trimmed mode");
         }
 
         if (kind == MemoryKind.DEVICE) {
@@ -138,10 +137,10 @@ public class CudaWorkspace extends Nd4jWorkspace {
                 cycleAllocations.addAndGet(requiredMemory);
                 long prevOffset = deviceOffset.getAndAdd(requiredMemory);
 
-                if (isDebug.get())
-                    log.info("Workspace [{}] device_{}: alloc array of {} bytes, capacity of {} elements; offset: {}; size: {};", id, Nd4j.getAffinityManager().getDeviceForCurrentThread(), requiredMemory, numElements, deviceOffset.get(), currentSize.get());
-
                 PagedPointer ptr = workspace.getDevicePointer().withOffset(prevOffset, numElements);
+
+                if (isDebug.get())
+                    log.info("Workspace [{}] device_{}: alloc array of {} bytes, capacity of {} elements; prevOffset: {}; newOffset: {}; size: {}; address: {}", id, Nd4j.getAffinityManager().getDeviceForCurrentThread(), requiredMemory, numElements, prevOffset, deviceOffset.get(), currentSize.get(), ptr.address());
 
                 if (initialize) {
                     //CudaContext context = AtomicAllocator.getInstance().getMemoryHandler().getCudaContext();
@@ -159,8 +158,8 @@ public class CudaWorkspace extends Nd4jWorkspace {
             } else {
                 // spill
                 if (workspaceConfiguration.getPolicyReset() == ResetPolicy.ENDOFBUFFER_REACHED && currentSize.get() > 0 && !trimmer) {
-                    hostOffset.set(0);
-                    deviceOffset.set(0);
+                    //log.info("End of space reached. Current offset: {}; requiredMemory: {}", deviceOffset.get(), requiredMemory);
+                    reset();
                     resetPlanned.set(true);
                     return alloc(requiredMemory, kind, type, initialize);
                 }
@@ -276,7 +275,7 @@ public class CudaWorkspace extends Nd4jWorkspace {
             if (isDebug.get())
                 log.info("Allocation step: {}; Current step: {}", stepNumber, stepCurrent);
 
-            if (stepNumber + 2 < stepCurrent|| extended) {
+            if (stepNumber + 2 < stepCurrent || extended) {
                 pinnedAllocations.remove();
 
                 if (pair.getDevicePointer() != null) {

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspace.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspace.java
@@ -99,7 +99,6 @@ public class CpuWorkspace extends Nd4jWorkspace {
         if (extended)
             clearExternalAllocations();
 
-        stepsCount.set(Long.MAX_VALUE - 100);
         clearPinnedAllocations(extended);
 
         if (workspace.getHostPointer() != null)

--- a/nd4j-backends/nd4j-tests/pom.xml
+++ b/nd4j-backends/nd4j-tests/pom.xml
@@ -86,7 +86,7 @@
 
         <dependency>
             <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-cuda-8.0</artifactId>
+            <artifactId>nd4j-native</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/SpecialWorkspaceTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/SpecialWorkspaceTests.java
@@ -94,10 +94,10 @@ public class SpecialWorkspaceTests extends BaseNd4jTest {
                 assertEquals("Failed on iteration " + i, (i + 1) * 1000 * Nd4j.sizeOfDataType(), workspace.getDeviceOffset());
             }
 
-            if (e >= 2) {
+            if (e >= 1) {
                 assertEquals("Failed on iteration " + e,0, workspace.getNumberOfPinnedAllocations());
             } else {
-                assertEquals(1, workspace.getNumberOfPinnedAllocations());
+                assertEquals("Failed on iteration " + e,1, workspace.getNumberOfPinnedAllocations());
             }
         }
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/SpecialWorkspaceTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/SpecialWorkspaceTests.java
@@ -94,7 +94,7 @@ public class SpecialWorkspaceTests extends BaseNd4jTest {
                 assertEquals("Failed on iteration " + i, (i + 1) * 1000 * Nd4j.sizeOfDataType(), workspace.getDeviceOffset());
             }
 
-            if (e >= 1) {
+            if (e >= 2) {
                 assertEquals("Failed on iteration " + e,0, workspace.getNumberOfPinnedAllocations());
             } else {
                 assertEquals("Failed on iteration " + e,1, workspace.getNumberOfPinnedAllocations());

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/WorkspaceProviderTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/WorkspaceProviderTests.java
@@ -120,6 +120,16 @@ public class WorkspaceProviderTests extends BaseNd4jTest {
             .policyReset(ResetPolicy.ENDOFBUFFER_REACHED)
             .build();
 
+
+    private static final WorkspaceConfiguration adsiConfiguration = WorkspaceConfiguration.builder()
+            .overallocationLimit(3.0)
+            .policySpill(SpillPolicy.REALLOCATE)
+            .policyLearning(LearningPolicy.FIRST_LOOP)
+            .policyMirroring(MirroringPolicy.FULL)
+            .policyAllocation(AllocationPolicy.OVERALLOCATE)
+            .policyReset(ResetPolicy.ENDOFBUFFER_REACHED)
+            .build();
+
     DataBuffer.Type initialType;
 
     public WorkspaceProviderTests(Nd4jBackend backend) {
@@ -434,6 +444,86 @@ public class WorkspaceProviderTests extends BaseNd4jTest {
     }
 
     @Test
+    public void testVariableInput1() throws Exception {
+        Nd4jWorkspace workspace = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(adsiConfiguration, "ADSI");
+
+        INDArray array1 = null;
+        INDArray array2 = null;
+
+        try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
+            // we allocate first element smaller then subsequent;
+            array1 = Nd4j.create(8, 128, 100);
+        }
+
+        assertEquals(8 * 128 * 100 * 4 * 4, workspace.getCurrentSize());
+        assertEquals(0, workspace.getHostOffset());
+        assertEquals(0, workspace.getDeviceOffset());
+
+        assertEquals(1, workspace.getCyclesCount());
+        assertEquals(0, workspace.getStepNumber());
+
+
+        try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
+            // allocating same shape
+            array1 = Nd4j.create(8, 128, 100);
+        }
+
+        assertEquals(8 * 128 * 100 * 4, workspace.getHostOffset());
+        assertEquals(8 * 128 * 100 * 4, workspace.getDeviceOffset());
+
+        assertEquals(2, workspace.getCyclesCount());
+        assertEquals(0, workspace.getStepNumber());
+
+
+        try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
+            // allocating bigger shape
+            array1 = Nd4j.create(8, 128, 200).assign(1.0);
+        }
+
+        // offsets should be intact, allocation happened as pinned
+        assertEquals(8 * 128 * 100 * 4, workspace.getHostOffset());
+        assertEquals(8 * 128 * 100 * 4, workspace.getDeviceOffset());
+
+        assertEquals(1, workspace.getNumberOfPinnedAllocations());
+
+        assertEquals(3, workspace.getCyclesCount());
+        assertEquals(0, workspace.getStepNumber());
+
+
+        try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
+            // allocating same shape
+            array1 = Nd4j.create(8, 128, 100);
+        }
+
+        assertEquals(2, workspace.getNumberOfPinnedAllocations());
+        assertEquals(1, workspace.getStepNumber());
+        assertEquals(4, workspace.getCyclesCount());
+
+        try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
+            // allocating same shape
+            array1 = Nd4j.create(8, 128, 100);
+        }
+
+        assertEquals(3, workspace.getNumberOfPinnedAllocations());
+        assertEquals(1, workspace.getStepNumber());
+        assertEquals(5, workspace.getCyclesCount());
+
+        for (int i = 0; i < 13; i++) {
+            try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
+                // allocating same shape
+                array1 = Nd4j.create(8, 128, 100);
+            }
+        }
+
+        // Now we know that workspace was reallocated and offset was shifted to the end of workspace
+        assertEquals(5, workspace.getStepNumber());
+        assertEquals(8 * 128 * 200 * 4 * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        assertEquals(8 * 128 * 200 * 4 * Nd4j.sizeOfDataType(), workspace.getHostOffset());
+        assertEquals(8 * 128 * 200 * 4 * Nd4j.sizeOfDataType(), workspace.getDeviceOffset());
+
+    }
+
+    @Test
     public void testReallocate3() throws Exception {
         MemoryWorkspace workspace = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(reallocateUnspecifiedConfiguration, "WS_1");
 
@@ -487,6 +577,7 @@ public class WorkspaceProviderTests extends BaseNd4jTest {
 
             Nd4jWorkspace workspace = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(circularConfiguration, "WSX");
             assertEquals(10 * 1024 * 1024L, workspace.getCurrentSize());
+            log.info("Step number: {}", workspace.getStepNumber());
             if (i == 0)
                 assertEquals(0, workspace.getHostOffset());
             else if (i == 1)

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/WorkspaceProviderTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/WorkspaceProviderTests.java
@@ -496,7 +496,7 @@ public class WorkspaceProviderTests extends BaseNd4jTest {
         }
 
         assertEquals(2, workspace.getNumberOfPinnedAllocations());
-        assertEquals(1, workspace.getStepNumber());
+        assertEquals(0, workspace.getStepNumber());
         assertEquals(4, workspace.getCyclesCount());
 
         try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
@@ -508,7 +508,7 @@ public class WorkspaceProviderTests extends BaseNd4jTest {
         assertEquals(1, workspace.getStepNumber());
         assertEquals(5, workspace.getCyclesCount());
 
-        for (int i = 0; i < 13; i++) {
+        for (int i = 0; i < 12; i++) {
             try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
                 // allocating same shape
                 array1 = Nd4j.create(8, 128, 100);
@@ -516,7 +516,7 @@ public class WorkspaceProviderTests extends BaseNd4jTest {
         }
 
         // Now we know that workspace was reallocated and offset was shifted to the end of workspace
-        assertEquals(5, workspace.getStepNumber());
+        assertEquals(4, workspace.getStepNumber());
         assertEquals(8 * 128 * 200 * 4 * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
         assertEquals(8 * 128 * 200 * 4 * Nd4j.sizeOfDataType(), workspace.getHostOffset());
         assertEquals(8 * 128 * 200 * 4 * Nd4j.sizeOfDataType(), workspace.getDeviceOffset());

--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/memory/conf/WorkspaceConfiguration.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/memory/conf/WorkspaceConfiguration.java
@@ -51,6 +51,11 @@ public class WorkspaceConfiguration implements Serializable {
      */
     protected double overallocationLimit;
 
+    /**
+     * This value is used only for circular workspaces
+     */
+    protected int stepsNumber;
+
     public static class WorkspaceConfigurationBuilder {
         private AllocationPolicy policyAllocation = AllocationPolicy.OVERALLOCATE;
         private SpillPolicy policySpill = SpillPolicy.EXTERNAL;
@@ -65,5 +70,6 @@ public class WorkspaceConfiguration implements Serializable {
         protected int cyclesBeforeInitialization = 0;
 
         private double overallocationLimit = 0.3;
+        private int stepsNumber = 2;
     }
 }


### PR DESCRIPTION
This PR addresses fixes for variable input at circular workspaces (used within AsyncDataSet iterators). Affects variable time series and other similar scenarios, where input size might differ significantly in both directions relatively to first batch.