### PR TITLE
Variable input fixes/improvements

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspace.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspace.java
@@ -40,7 +40,8 @@ public class CpuWorkspace extends Nd4jWorkspace {
             isInit.set(true);
 
 
-            log.debug("Allocating [{}] workspace of {} bytes...", id, currentSize.get());
+            if (isDebug.get())
+                log.info("Allocating [{}] workspace of {} bytes...", id, currentSize.get());
 
             workspace.setHostPointer(new PagedPointer(memoryManager.allocate(currentSize.get() + SAFETY_OFFSET, MemoryKind.HOST, true)));
         }
@@ -92,6 +93,8 @@ public class CpuWorkspace extends Nd4jWorkspace {
 
     @Override
     public synchronized void destroyWorkspace(boolean extended) {
+        log.info("Destroying workspace...");
+
         currentSize.set(0);
         hostOffset.set(0);
         deviceOffset.set(0);

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/SpecialWorkspaceTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/SpecialWorkspaceTests.java
@@ -61,18 +61,20 @@ public class SpecialWorkspaceTests extends BaseNd4jTest {
 
         assertEquals(0, workspace.getStepNumber());
 
-        assertEquals(1000 * Nd4j.sizeOfDataType(), workspace.getSpilledSize());
-        assertEquals(1000 * Nd4j.sizeOfDataType(), workspace.getInitialBlockSize());
-        assertEquals((1000 + (1000*3)) * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        long requiredMemory = 1000 * Nd4j.sizeOfDataType();
+        long shiftedSize = ((long)(requiredMemory * 1.3)) + (8 -(((long)(requiredMemory * 1.3)) % 8));
+        assertEquals(requiredMemory, workspace.getSpilledSize());
+        assertEquals(shiftedSize, workspace.getInitialBlockSize());
+        assertEquals(workspace.getInitialBlockSize() * 4, workspace.getCurrentSize());
 
         try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace("WS1")) {
-            Nd4j.create(1100);
+            Nd4j.create(2000);
         }
 
         assertEquals(0, workspace.getStepNumber());
 
         assertEquals(1000 * Nd4j.sizeOfDataType(), workspace.getSpilledSize());
-        assertEquals(1100 * Nd4j.sizeOfDataType(), workspace.getPinnedSize());
+        assertEquals(2000 * Nd4j.sizeOfDataType(), workspace.getPinnedSize());
 
         assertEquals(0, workspace.getDeviceOffset());
 
@@ -91,7 +93,7 @@ public class SpecialWorkspaceTests extends BaseNd4jTest {
                     Nd4j.create(500);
                 }
 
-                assertEquals("Failed on iteration " + i, (i + 1) * 1000 * Nd4j.sizeOfDataType(), workspace.getDeviceOffset());
+                assertEquals("Failed on iteration " + i, (i + 1) * workspace.getInitialBlockSize(), workspace.getDeviceOffset());
             }
 
             if (e >= 2) {
@@ -171,9 +173,11 @@ public class SpecialWorkspaceTests extends BaseNd4jTest {
 
         assertEquals(0, workspace.getStepNumber());
 
-        assertEquals(1000 * Nd4j.sizeOfDataType(), workspace.getSpilledSize());
-        assertEquals(1000 * Nd4j.sizeOfDataType(), workspace.getInitialBlockSize());
-        assertEquals((1000 + (1000*3)) * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        long requiredMemory = 1000 * Nd4j.sizeOfDataType();
+        long shiftedSize = ((long)(requiredMemory * 1.3)) + (8 -(((long)(requiredMemory * 1.3)) % 8));
+        assertEquals(requiredMemory, workspace.getSpilledSize());
+        assertEquals(shiftedSize, workspace.getInitialBlockSize());
+        assertEquals(workspace.getInitialBlockSize() * 4, workspace.getCurrentSize());
 
 
         for (int i = 0; i < 100; i++) {
@@ -185,7 +189,7 @@ public class SpecialWorkspaceTests extends BaseNd4jTest {
         }
 
 
-        assertEquals((1500 + (1500*3)) * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        assertEquals(workspace.getInitialBlockSize() * 4, workspace.getCurrentSize());
 
         assertEquals(0, workspace.getNumberOfPinnedAllocations());
         assertEquals(0, workspace.getNumberOfExternalAllocations());


### PR DESCRIPTION
This PR adds following:
- overallocation added for circular buffer, to prevent frequent reallocations with variable input
- block alignment is 64bit-aligned
- tests updated to handle overallocated circular buffers