### PR TITLE
Replaces com.google.code.findbugs:annotations with a clean room reimplementaiton licensed under Apache 2.0.

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/DeviceLocal.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/DeviceLocal.java
@@ -2,7 +2,8 @@ package org.nd4j.linalg.util;
 
 import org.nd4j.linalg.factory.Nd4j;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/memory/MemoryWorkspaceManager.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/memory/MemoryWorkspaceManager.java
@@ -3,7 +3,8 @@ package org.nd4j.linalg.api.memory;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 
 /**
  * This interface describes backend-specific implementations of MemoryWorkspaceManager, basically Factory + Thread-based provider

--- a/nd4j-common/pom.xml
+++ b/nd4j-common/pom.xml
@@ -52,6 +52,18 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.10</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+              </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- used to alleviate licensing issues with findbugs -->
+        <dependency>
+          <groupId>com.github.stephenc.findbugs</groupId>
+          <artifactId>findbugs-annotations</artifactId>
+          <version>1.3.9-1</version>
         </dependency>
 
         <dependency>

--- a/nd4j-instrumentation/pom.xml
+++ b/nd4j-instrumentation/pom.xml
@@ -73,6 +73,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>com.google.code.findbugs</groupId>
+                  <artifactId>jsr305</artifactId>
+                </exclusion>
 
             </exclusions>
         </dependency>

--- a/nd4j-parameter-server-parent/nd4j-parameter-server-status/pom.xml
+++ b/nd4j-parameter-server-parent/nd4j-parameter-server-status/pom.xml
@@ -37,6 +37,12 @@
             <groupId>com.typesafe.play</groupId>
             <artifactId>play-java_2.11</artifactId>
             <version>${playframework.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/nd4j-serde/nd4j-jackson-reflectionloader/pom.xml
+++ b/nd4j-serde/nd4j-jackson-reflectionloader/pom.xml
@@ -20,11 +20,18 @@
             <version>${lombok.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.10</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+              </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.nd4j</groupId>
             <artifactId>jackson</artifactId>

--- a/nd4j-serde/nd4j-kryo/pom.xml
+++ b/nd4j-serde/nd4j-kryo/pom.xml
@@ -31,6 +31,12 @@
             <artifactId>spark-core_2.11</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Also known as an exercise in futility, since findbugs is notoriously BSD, now
see https://github.com/findbugsproject/findbugs/issues/128
But this should cut down discussion time with lawyers.