### PR TITLE
Issue #3468 : Move loss function size assertions into loss functions …

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossBinaryXENT.java
@@ -53,6 +53,12 @@ public class LossBinaryXENT implements ILossFunction {
     }
 
     private INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray scoreArr;
         if (activationFn instanceof ActivationSoftmax) {
             //Use LogSoftMax op to avoid numerical issues when calculating score
@@ -106,6 +112,12 @@ public class LossBinaryXENT implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
 
         INDArray numerator = output.sub(labels);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossCosineProximity.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossCosineProximity.java
@@ -17,6 +17,12 @@ import java.util.Arrays;
 public class LossCosineProximity implements ILossFunction {
 
     public INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         /*
          mean of -(y.dot(yhat)/||y||*||yhat||)
          */
@@ -65,6 +71,12 @@ public class LossCosineProximity implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray yhat = activationFn.getActivation(preOutput.dup(), true);
         INDArray yL2norm = labels.norm2(1);
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossHinge.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossHinge.java
@@ -16,6 +16,12 @@ import org.nd4j.linalg.lossfunctions.LossUtil;
 public class LossHinge implements ILossFunction {
 
     public INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         /* y_hat is -1 or 1
         hinge loss is max(0,1-y_hat*y)
          */
@@ -50,6 +56,12 @@ public class LossHinge implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         /*
         gradient is 0 if yhaty is >= 1
         else gradient is gradient of the loss function = (1-yhaty) wrt preOutput = -y*derivative_of_yhat wrt preout

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossKLD.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossKLD.java
@@ -19,6 +19,12 @@ import org.nd4j.linalg.ops.transforms.Transforms;
 public class LossKLD implements ILossFunction {
 
     private INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
 
         // Clip output and labels to be between Nd4j.EPS_THREsHOLD and 1, i.e. a valid non-zero probability
@@ -56,6 +62,12 @@ public class LossKLD implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         //INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL1.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL1.java
@@ -49,6 +49,12 @@ public class LossL1 implements ILossFunction {
     }
 
     public INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray scoreArr;
         //INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
@@ -91,6 +97,12 @@ public class LossL1 implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
 
         INDArray outSubLabels = output.sub(labels);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL2.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossL2.java
@@ -52,6 +52,12 @@ public class LossL2 implements ILossFunction {
     }
 
     protected INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
         INDArray scoreArr = output.rsubi(labels);
         scoreArr = scoreArr.muli(scoreArr);
@@ -93,6 +99,12 @@ public class LossL2 implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         //INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAPE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMAPE.java
@@ -48,6 +48,12 @@ public class LossMAPE implements ILossFunction {
 
 
     public INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray scoreArr;
         //INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
@@ -91,6 +97,12 @@ public class LossMAPE implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
 
         INDArray actSubPredicted = labels.sub(output);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
@@ -54,6 +54,12 @@ public class LossMCXENT implements ILossFunction {
     }
 
     private INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray scoreArr;
         //if ("softmax".equals(activationFn)) {
         if (activationFn instanceof ActivationSoftmax) {
@@ -104,6 +110,12 @@ public class LossMCXENT implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray grad;
         //INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
         INDArray output = activationFn.getActivation(preOutput.dup(), true);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSLE.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMSLE.java
@@ -47,6 +47,12 @@ public class LossMSLE implements ILossFunction {
     }
 
     public INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray scoreArr;
         //INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
@@ -89,6 +95,12 @@ public class LossMSLE implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         //INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFn, preOutput.dup()));
         INDArray output = activationFn.getActivation(preOutput.dup(), true);
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossPoisson.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossPoisson.java
@@ -15,6 +15,12 @@ import org.nd4j.linalg.ops.transforms.Transforms;
 public class LossPoisson implements ILossFunction {
 
     public INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         /*
          mean of (yhat - y * log(yhat))
          */
@@ -52,6 +58,12 @@ public class LossPoisson implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray yHat = activationFn.getActivation(preOutput.dup(), true);
         INDArray yDivyhat = labels.div(yHat);
         INDArray dLda = yDivyhat.rsubi(1);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossSquaredHinge.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossSquaredHinge.java
@@ -16,6 +16,12 @@ import org.nd4j.linalg.lossfunctions.LossUtil;
 public class LossSquaredHinge implements ILossFunction {
 
     public INDArray scoreArray(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         /* y_hat is -1 or 1
         hinge loss is max(0,1-y_hat*y)
          */
@@ -50,6 +56,12 @@ public class LossSquaredHinge implements ILossFunction {
 
     @Override
     public INDArray computeGradient(INDArray labels, INDArray preOutput, IActivation activationFn, INDArray mask) {
+        if (labels.size(1) != preOutput.size(1)) {
+            throw new IllegalArgumentException("Labels array numColumns (size(1) = " + labels.size(1)
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOutput.size(1)
+                            + ") ");
+            
+        }
         INDArray scoreArr = scoreArray(labels, preOutput, activationFn, mask);
 
         INDArray bitMaskRowCol = scoreArr.dup();

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/lossfunctions/TestLossFunctionsSizeChecks.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/lossfunctions/TestLossFunctionsSizeChecks.java
@@ -1,0 +1,84 @@
+package org.nd4j.linalg.lossfunctions;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
+
+/**
+ * This is intended to ensure that if the incorrect size of data is given
+ * to the loss functions, that the report this fact through an appropriate
+ * exception.  This functionality used to be performed at the 'deeplearning4j'
+ * level, but it was discovered that many loss functions perform mappings
+ * involving 'label' sizes different than 'output' sizes.  Such an example
+ * would be the Bishop Mixture Density Network.  Hence the testing for
+ * loss function size was moved to being the responsibility of the loss function
+ * to enforce.
+ * 
+ * @author Jonathan S. Arney.
+ */
+public class TestLossFunctionsSizeChecks {
+    @Test
+    public void testL2() {
+        LossFunction[] lossFunctionList = {
+            LossFunction.MSE, 
+            LossFunction.L1,
+            LossFunction.EXPLL,
+            LossFunction.XENT,
+            LossFunction.MCXENT,
+            LossFunction.SQUARED_LOSS,
+            LossFunction.RECONSTRUCTION_CROSSENTROPY,
+            LossFunction.NEGATIVELOGLIKELIHOOD,
+            LossFunction.COSINE_PROXIMITY,
+            LossFunction.HINGE,
+            LossFunction.SQUARED_HINGE,
+            LossFunction.KL_DIVERGENCE,
+            LossFunction.MEAN_ABSOLUTE_ERROR,
+            LossFunction.L2,
+            LossFunction.MEAN_ABSOLUTE_PERCENTAGE_ERROR,
+            LossFunction.MEAN_SQUARED_LOGARITHMIC_ERROR,
+            LossFunction.POISSON
+        };
+        
+        testLossFunctions(lossFunctionList);
+    }
+    
+    public void testLossFunctions(LossFunction[] lossFunctions) {
+        for (LossFunction loss : lossFunctions) {
+            testLossFunctionScoreSizeMismatchCase(loss.getILossFunction());
+        }
+    }
+    
+    /**
+     * This method checks that the given loss function will give an assertion
+     * if the labels and output vectors are of different sizes.
+     * @param loss Loss function to verify.
+     */
+    public void testLossFunctionScoreSizeMismatchCase(ILossFunction loss) {
+        
+        try {
+            INDArray labels = Nd4j.create(100, 32);
+            INDArray preOutput = Nd4j.create(100, 44);
+            double score = loss.computeScore(labels, preOutput, Activation.IDENTITY.getActivationFunction(), null, true);
+            Assert.assertFalse("Loss function " + loss.toString() + "did not check for size mismatch.  This should fail to compute an activation function because the sizes of the vectors are not equal", true);
+        }
+        catch (IllegalArgumentException ex) {
+            String exceptionMessage = ex.getMessage();
+            Assert.assertTrue("Loss function exception " + loss.toString() + " did not indicate size mismatch when vectors of incorrect size were used.", exceptionMessage.contains("does not match"));
+        }
+        
+        try {
+            INDArray labels = Nd4j.create(100, 32);
+            INDArray preOutput = Nd4j.create(100, 44);
+            INDArray gradient = loss.computeGradient(labels, preOutput, Activation.IDENTITY.getActivationFunction(), null);
+            Assert.assertFalse("Loss function " + loss.toString() + "did not check for size mismatch.  This should fail to compute an activation function because the sizes of the vectors are not equal", true);
+        }
+        catch (IllegalArgumentException ex) {
+            String exceptionMessage = ex.getMessage();
+            Assert.assertTrue("Loss function exception " + loss.toString() + " did not indicate size mismatch when vectors of incorrect size were used.", exceptionMessage.contains("does not match"));
+        }
+        
+    }
+}


### PR DESCRIPTION
Issue #3468 : Move loss function size assertions into loss functions instead of enforcing it universally.  This allows custom loss-functions such as the Bishop Mixture Density Network loss function to have different label size than network output size.

## What changes were proposed in this pull request?

This patch resolves this issue: deeplearning4j/deeplearning4j#3468

## How was this patch tested?

A unit-test was added which verifies the assertion behavior added.
