### PR TITLE
add new binary module (splitting out the aeron functionality

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/serde/binary/BinarySerde.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/serde/binary/BinarySerde.java
@@ -1,0 +1,233 @@
+package org.nd4j.serde.binary;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.bytedeco.javacpp.BytePointer;
+import org.nd4j.linalg.api.buffer.DataBuffer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.compression.CompressedDataBuffer;
+import org.nd4j.linalg.compression.CompressionDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Created by agibsonccc on 7/1/17.
+ */
+public class BinarySerde {
+
+
+    /**
+     * Create an ndarray
+     * from the unsafe buffer
+     * @param buffer the buffer to create the array from
+     * @return the ndarray derived from this buffer
+     */
+    public static INDArray toArray(ByteBuffer buffer, int offset) {
+        return toArrayAndByteBuffer(buffer, offset).getLeft();
+    }
+
+    /**
+     * Create an ndarray
+     * from the unsafe buffer
+     * @param buffer the buffer to create the array from
+     * @return the ndarray derived from this buffer
+     */
+    public static INDArray toArray(ByteBuffer buffer) {
+        return toArray(buffer, 0);
+    }
+
+
+
+
+    /**
+     * Create an ndarray and existing bytebuffer
+     * @param buffer
+     * @param offset
+     * @return
+     */
+    public static Pair<INDArray, ByteBuffer> toArrayAndByteBuffer(ByteBuffer buffer, int offset) {
+        ByteBuffer byteBuffer =
+                buffer == null
+                        ? ByteBuffer.allocateDirect(buffer.array().length).put(buffer.array())
+                        .order(ByteOrder.nativeOrder())
+                        : buffer.order(ByteOrder.nativeOrder());
+        //bump the byte buffer to the proper position
+        byteBuffer.position(offset);
+        int rank = byteBuffer.getInt();
+        if (rank < 0)
+            throw new IllegalStateException("Found negative integer. Corrupt serialization?");
+        //get the shape buffer length to create the shape information buffer
+        int shapeBufferLength = Shape.shapeInfoLength(rank);
+        //create the ndarray shape information
+        DataBuffer shapeBuff = Nd4j.createBufferDetached(new int[shapeBufferLength]);
+
+        //compute the databuffer type from the index
+        DataBuffer.Type type = DataBuffer.Type.values()[byteBuffer.getInt()];
+        for (int i = 0; i < shapeBufferLength; i++) {
+            shapeBuff.put(i, byteBuffer.getInt());
+        }
+
+        //after the rank,data type, shape buffer (of length shape buffer length) * sizeof(int)
+        if (type != DataBuffer.Type.COMPRESSED) {
+            ByteBuffer slice = byteBuffer.slice();
+            //wrap the data buffer for the last bit
+            DataBuffer buff = Nd4j.createBuffer(slice, type, Shape.length(shapeBuff));
+            //advance past the data
+            int position = byteBuffer.position() + (buff.getElementSize() * (int) buff.length());
+            byteBuffer.position(position);
+            //create the final array
+            //TODO: see how to avoid dup here
+            INDArray arr = Nd4j.createArrayFromShapeBuffer(buff.dup(), shapeBuff.dup());
+            return Pair.of(arr, byteBuffer);
+        } else {
+            CompressionDescriptor compressionDescriptor = CompressionDescriptor.fromByteBuffer(byteBuffer);
+            ByteBuffer slice = byteBuffer.slice();
+            //ensure that we only deal with the slice of the buffer that is actually the data
+            BytePointer byteBufferPointer = new BytePointer(slice);
+            //create a compressed array based on the rest of the data left in the buffer
+            CompressedDataBuffer compressedDataBuffer =
+                    new CompressedDataBuffer(byteBufferPointer, compressionDescriptor);
+            //TODO: see how to avoid dup()
+            INDArray arr = Nd4j.createArrayFromShapeBuffer(compressedDataBuffer.dup(), shapeBuff.dup());
+            //advance past the data
+            int compressLength = (int) compressionDescriptor.getCompressedLength();
+            byteBuffer.position(byteBuffer.position() + compressLength);
+            return Pair.of(arr, byteBuffer);
+        }
+
+    }
+
+    /**
+     * Convert an ndarray to an unsafe buffer
+     * for use by aeron
+     * @param arr the array to convert
+     * @return the unsafebuffer representation of this array
+     */
+    public static ByteBuffer toByteBuffer(INDArray arr) {
+        //subset and get rid of 1 off non 1 element wise stride cases
+        if (arr.isView())
+            arr = arr.dup();
+        if (!arr.isCompressed()) {
+            ByteBuffer b3 = ByteBuffer.allocateDirect(byteBufferSizeFor(arr)).order(ByteOrder.nativeOrder());
+            doByteBufferPutUnCompressed(arr, b3, true);
+            return b3;
+        }
+        //compressed array
+        else {
+            ByteBuffer b3 = ByteBuffer.allocateDirect(byteBufferSizeFor(arr)).order(ByteOrder.nativeOrder());
+            doByteBufferPutCompressed(arr, b3, true);
+            return b3;
+        }
+
+    }
+
+    /**
+     * Returns the byte buffer size for the given
+     * ndarray. This is an auxillary method
+     * for determining the size of the buffer
+     * size to allocate for sending an ndarray via
+     * the aeron media driver.
+     *
+     * The math break down for uncompressed is:
+     * 2 ints for rank of the array and an ordinal representing the data type of the data buffer
+     * The rest is in order:
+     * shape information
+     * data buffer
+     *
+     * The math break down for compressed is:
+     * 2 ints for rank and an ordinal representing the data type for the data buffer
+     *
+     * The rest is in order:
+     * shape information
+     * codec information
+     * data buffer
+     *
+     * @param arr the array to compute the size for
+     * @return the size of the byte buffer that was allocated
+     */
+    public static int byteBufferSizeFor(INDArray arr) {
+        if (!arr.isCompressed()) {
+            ByteBuffer buffer = arr.data().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
+            ByteBuffer shapeBuffer = arr.shapeInfoDataBuffer().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
+            //2 four byte ints at the beginning
+            int twoInts = 8;
+            return twoInts + buffer.limit() + shapeBuffer.limit();
+        } else {
+            CompressedDataBuffer compressedDataBuffer = (CompressedDataBuffer) arr.data();
+            CompressionDescriptor descriptor = compressedDataBuffer.getCompressionDescriptor();
+            ByteBuffer codecByteBuffer = descriptor.toByteBuffer();
+            ByteBuffer buffer = arr.data().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
+            ByteBuffer shapeBuffer = arr.shapeInfoDataBuffer().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
+            int twoInts = 2 * 4;
+            return twoInts + buffer.limit() + shapeBuffer.limit() + codecByteBuffer.limit();
+        }
+    }
+
+
+
+
+    /**
+     * Setup the given byte buffer
+     * for serialization (note that this is for uncompressed INDArrays)
+     * 4 bytes int for rank
+     * 4 bytes for data type
+     * shape buffer
+     * data buffer
+     *
+     * @param arr the array to setup
+     * @param allocated the byte buffer to setup
+     * @param rewind whether to rewind the byte buffer or nt
+     */
+    public static void doByteBufferPutUnCompressed(INDArray arr, ByteBuffer allocated, boolean rewind) {
+        ByteBuffer buffer = arr.data().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
+        ByteBuffer shapeBuffer = arr.shapeInfoDataBuffer().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
+        //2 four byte ints at the beginning
+        allocated.putInt(arr.rank());
+        //put data type next so its self describing
+        allocated.putInt(arr.data().dataType().ordinal());
+        allocated.put(shapeBuffer);
+        allocated.put(buffer);
+        if (rewind)
+            allocated.rewind();
+    }
+
+    /**
+     * Setup the given byte buffer
+     * for serialization (note that this is for compressed INDArrays)
+     * 4 bytes for rank
+     * 4 bytes for data type
+     * shape information
+     * codec information
+     * data type
+     *
+     * @param arr the array to setup
+     * @param allocated the byte buffer to setup
+     * @param rewind whether to rewind the byte buffer or not
+     */
+    public static void doByteBufferPutCompressed(INDArray arr, ByteBuffer allocated, boolean rewind) {
+        CompressedDataBuffer compressedDataBuffer = (CompressedDataBuffer) arr.data();
+        CompressionDescriptor descriptor = compressedDataBuffer.getCompressionDescriptor();
+        ByteBuffer codecByteBuffer = descriptor.toByteBuffer();
+        ByteBuffer buffer = arr.data().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
+        ByteBuffer shapeBuffer = arr.shapeInfoDataBuffer().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
+        allocated.putInt(arr.rank());
+        //put data type next so its self describing
+        allocated.putInt(arr.data().dataType().ordinal());
+        //put shape next
+        allocated.put(shapeBuffer);
+        //put codec information next
+        allocated.put(codecByteBuffer);
+        //finally put the data
+        allocated.put(buffer);
+        if (rewind)
+            allocated.rewind();
+    }
+
+
+
+
+
+
+}

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/serde/binary/BinarySerdeTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/serde/binary/BinarySerdeTest.java
@@ -1,0 +1,86 @@
+package org.nd4j.serde.binary;
+
+import org.apache.commons.lang3.time.StopWatch;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by agibsonccc on 9/23/16.
+ */
+public class BinarySerdeTest {
+
+    @Test
+    public void testToAndFrom() {
+        INDArray arr = Nd4j.scalar(1.0);
+        ByteBuffer buffer = BinarySerde.toByteBuffer(arr);
+        INDArray back = BinarySerde.toArray(buffer);
+        assertEquals(arr, back);
+    }
+
+    @Test
+    public void testToAndFromCompressed() {
+        INDArray arr = Nd4j.scalar(1.0);
+        INDArray compress = Nd4j.getCompressor().compress(arr, "GZIP");
+        assertTrue(compress.isCompressed());
+        ByteBuffer buffer = BinarySerde.toByteBuffer(compress);
+        INDArray back = BinarySerde.toArray(buffer);
+        INDArray decompressed = Nd4j.getCompressor().decompress(compress);
+        assertEquals(arr, decompressed);
+        assertEquals(arr, back);
+    }
+
+
+    @Test
+    public void testToAndFromCompressedLarge() {
+        INDArray arr = Nd4j.zeros((int) 1e7);
+        INDArray compress = Nd4j.getCompressor().compress(arr, "GZIP");
+        assertTrue(compress.isCompressed());
+        ByteBuffer buffer = BinarySerde.toByteBuffer(compress);
+        INDArray back = BinarySerde.toArray(buffer);
+        INDArray decompressed = Nd4j.getCompressor().decompress(compress);
+        assertEquals(arr, decompressed);
+        assertEquals(arr, back);
+    }
+
+
+    @Test
+    public void timeOldVsNew() throws Exception {
+        int numTrials = 1000;
+        long oldTotal = 0;
+        long newTotal = 0;
+        INDArray arr = Nd4j.create(100000);
+        Nd4j.getCompressor().compressi(arr, "GZIP");
+        for (int i = 0; i < numTrials; i++) {
+            StopWatch oldStopWatch = new StopWatch();
+            BufferedOutputStream bos = new BufferedOutputStream(new ByteArrayOutputStream(arr.length()));
+            DataOutputStream dos = new DataOutputStream(bos);
+            oldStopWatch.start();
+            Nd4j.write(arr, dos);
+            oldStopWatch.stop();
+            // System.out.println("Old " + oldStopWatch.getNanoTime());
+            oldTotal += oldStopWatch.getNanoTime();
+            StopWatch newStopWatch = new StopWatch();
+            newStopWatch.start();
+            BinarySerde.toByteBuffer(arr);
+            newStopWatch.stop();
+            //  System.out.println("New " + newStopWatch.getNanoTime());
+            newTotal += newStopWatch.getNanoTime();
+
+        }
+
+        oldTotal /= numTrials;
+        newTotal /= numTrials;
+        System.out.println("Old avg " + oldTotal + " New avg " + newTotal);
+
+    }
+
+}

--- a/nd4j-serde/nd4j-aeron/src/main/java/org/nd4j/aeron/ipc/AeronNDArraySerde.java
+++ b/nd4j-serde/nd4j-aeron/src/main/java/org/nd4j/aeron/ipc/AeronNDArraySerde.java
@@ -10,6 +10,7 @@ import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.compression.CompressedDataBuffer;
 import org.nd4j.linalg.compression.CompressionDescriptor;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.serde.binary.BinarySerde;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -24,50 +25,9 @@ import java.nio.ByteOrder;
  *
  * @author Adam Gibson
  */
-public class AeronNDArraySerde {
+public class AeronNDArraySerde extends BinarySerde {
 
 
-    /**
-     * Returns the byte buffer size for the given
-     * ndarray. This is an auxillary method
-     * for determining the size of the buffer
-     * size to allocate for sending an ndarray via
-     * the aeron media driver.
-     *
-     * The math break down for uncompressed is:
-     * 2 ints for rank of the array and an ordinal representing the data type of the data buffer
-     * The rest is in order:
-     * shape information
-     * data buffer
-     *
-     * The math break down for compressed is:
-     * 2 ints for rank and an ordinal representing the data type for the data buffer
-     *
-     * The rest is in order:
-     * shape information
-     * codec information
-     * data buffer
-     *
-     * @param arr the array to compute the size for
-     * @return the size of the byte buffer that was allocated
-     */
-    public static int byteBufferSizeFor(INDArray arr) {
-        if (!arr.isCompressed()) {
-            ByteBuffer buffer = arr.data().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
-            ByteBuffer shapeBuffer = arr.shapeInfoDataBuffer().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
-            //2 four byte ints at the beginning
-            int twoInts = 8;
-            return twoInts + buffer.limit() + shapeBuffer.limit();
-        } else {
-            CompressedDataBuffer compressedDataBuffer = (CompressedDataBuffer) arr.data();
-            CompressionDescriptor descriptor = compressedDataBuffer.getCompressionDescriptor();
-            ByteBuffer codecByteBuffer = descriptor.toByteBuffer();
-            ByteBuffer buffer = arr.data().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
-            ByteBuffer shapeBuffer = arr.shapeInfoDataBuffer().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
-            int twoInts = 2 * 4;
-            return twoInts + buffer.limit() + shapeBuffer.limit() + codecByteBuffer.limit();
-        }
-    }
 
     /**
      * Convert an ndarray to an unsafe buffer
@@ -76,80 +36,12 @@ public class AeronNDArraySerde {
      * @return the unsafebuffer representation of this array
      */
     public static UnsafeBuffer toBuffer(INDArray arr) {
-        //subset and get rid of 1 off non 1 element wise stride cases
-        if (arr.isView())
-            arr = arr.dup();
-        if (!arr.isCompressed()) {
-            ByteBuffer b3 = ByteBuffer.allocateDirect(byteBufferSizeFor(arr)).order(ByteOrder.nativeOrder());
-            doByteBufferPutUnCompressed(arr, b3, true);
-            return new UnsafeBuffer(b3);
-        }
-        //compressed array
-        else {
-            ByteBuffer b3 = ByteBuffer.allocateDirect(byteBufferSizeFor(arr)).order(ByteOrder.nativeOrder());
-            doByteBufferPutCompressed(arr, b3, true);
-            return new UnsafeBuffer(b3);
-        }
+        return new UnsafeBuffer(toByteBuffer(arr));
 
     }
 
 
-    /**
-     * Setup the given byte buffer
-     * for serialization (note that this is for uncompressed INDArrays)
-     * 4 bytes int for rank
-     * 4 bytes for data type
-     * shape buffer
-     * data buffer
-     *
-     * @param arr the array to setup
-     * @param allocated the byte buffer to setup
-     * @param rewind whether to rewind the byte buffer or nt
-     */
-    public static void doByteBufferPutUnCompressed(INDArray arr, ByteBuffer allocated, boolean rewind) {
-        ByteBuffer buffer = arr.data().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
-        ByteBuffer shapeBuffer = arr.shapeInfoDataBuffer().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
-        //2 four byte ints at the beginning
-        allocated.putInt(arr.rank());
-        //put data type next so its self describing
-        allocated.putInt(arr.data().dataType().ordinal());
-        allocated.put(shapeBuffer);
-        allocated.put(buffer);
-        if (rewind)
-            allocated.rewind();
-    }
 
-    /**
-     * Setup the given byte buffer
-     * for serialization (note that this is for compressed INDArrays)
-     * 4 bytes for rank
-     * 4 bytes for data type
-     * shape information
-     * codec information
-     * data type
-     *
-     * @param arr the array to setup
-     * @param allocated the byte buffer to setup
-     * @param rewind whether to rewind the byte buffer or not
-     */
-    public static void doByteBufferPutCompressed(INDArray arr, ByteBuffer allocated, boolean rewind) {
-        CompressedDataBuffer compressedDataBuffer = (CompressedDataBuffer) arr.data();
-        CompressionDescriptor descriptor = compressedDataBuffer.getCompressionDescriptor();
-        ByteBuffer codecByteBuffer = descriptor.toByteBuffer();
-        ByteBuffer buffer = arr.data().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
-        ByteBuffer shapeBuffer = arr.shapeInfoDataBuffer().pointer().asByteBuffer().order(ByteOrder.nativeOrder());
-        allocated.putInt(arr.rank());
-        //put data type next so its self describing
-        allocated.putInt(arr.data().dataType().ordinal());
-        //put shape next
-        allocated.put(shapeBuffer);
-        //put codec information next
-        allocated.put(codecByteBuffer);
-        //finally put the data
-        allocated.put(buffer);
-        if (rewind)
-            allocated.rewind();
-    }
 
 
     /**
@@ -163,55 +55,7 @@ public class AeronNDArraySerde {
      * @return the ndarray derived from this buffer
      */
     public static Pair<INDArray, ByteBuffer> toArrayAndByteBuffer(DirectBuffer buffer, int offset) {
-        ByteBuffer byteBuffer =
-                        buffer.byteBuffer() == null
-                                        ? ByteBuffer.allocateDirect(buffer.byteArray().length).put(buffer.byteArray())
-                                                        .order(ByteOrder.nativeOrder())
-                                        : buffer.byteBuffer().order(ByteOrder.nativeOrder());
-        //bump the byte buffer to the proper position
-        byteBuffer.position(offset);
-        int rank = byteBuffer.getInt();
-        if (rank < 0)
-            throw new IllegalStateException("Found negative integer. Corrupt serialization?");
-        //get the shape buffer length to create the shape information buffer
-        int shapeBufferLength = Shape.shapeInfoLength(rank);
-        //create the ndarray shape information
-        DataBuffer shapeBuff = Nd4j.createBufferDetached(new int[shapeBufferLength]);
-
-        //compute the databuffer type from the index
-        DataBuffer.Type type = DataBuffer.Type.values()[byteBuffer.getInt()];
-        for (int i = 0; i < shapeBufferLength; i++) {
-            shapeBuff.put(i, byteBuffer.getInt());
-        }
-
-        //after the rank,data type, shape buffer (of length shape buffer length) * sizeof(int)
-        if (type != DataBuffer.Type.COMPRESSED) {
-            ByteBuffer slice = byteBuffer.slice();
-            //wrap the data buffer for the last bit
-            DataBuffer buff = Nd4j.createBuffer(slice, type, Shape.length(shapeBuff));
-            //advance past the data
-            int position = byteBuffer.position() + (buff.getElementSize() * (int) buff.length());
-            byteBuffer.position(position);
-            //create the final array
-            //TODO: see how to avoid dup here
-            INDArray arr = Nd4j.createArrayFromShapeBuffer(buff.dup(), shapeBuff.dup());
-            return Pair.of(arr, byteBuffer);
-        } else {
-            CompressionDescriptor compressionDescriptor = CompressionDescriptor.fromByteBuffer(byteBuffer);
-            ByteBuffer slice = byteBuffer.slice();
-            //ensure that we only deal with the slice of the buffer that is actually the data
-            BytePointer byteBufferPointer = new BytePointer(slice);
-            //create a compressed array based on the rest of the data left in the buffer
-            CompressedDataBuffer compressedDataBuffer =
-                            new CompressedDataBuffer(byteBufferPointer, compressionDescriptor);
-            //TODO: see how to avoid dup()
-            INDArray arr = Nd4j.createArrayFromShapeBuffer(compressedDataBuffer.dup(), shapeBuff.dup());
-            //advance past the data
-            int compressLength = (int) compressionDescriptor.getCompressedLength();
-            byteBuffer.position(byteBuffer.position() + compressLength);
-            return Pair.of(arr, byteBuffer);
-        }
-
+        return toArrayAndByteBuffer(buffer.byteBuffer(),offset);
     }
 
 

--- a/nd4j-serde/pom.xml
+++ b/nd4j-serde/pom.xml
@@ -18,7 +18,6 @@
         <module>nd4j-camel-routes</module>
         <module>nd4j-gson</module>
         <module>nd4j-jackson-reflectionloader</module>
-        <module>nd4j-binary</module>
     </modules>
 
 </project>

--- a/nd4j-serde/pom.xml
+++ b/nd4j-serde/pom.xml
@@ -18,6 +18,7 @@
         <module>nd4j-camel-routes</module>
         <module>nd4j-gson</module>
         <module>nd4j-jackson-reflectionloader</module>
+        <module>nd4j-binary</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changes aeron serialization to be part of nd4j-api (with backwards compatibility!)
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
