### PR TITLE
JVM-side shapeInfo

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/blas/impl/BaseLapack.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/blas/impl/BaseLapack.java
@@ -22,11 +22,11 @@ public abstract class BaseLapack implements Lapack {
         int n = A.columns();
 
         INDArray INFO = Nd4j.createArrayFromShapeBuffer(Nd4j.getDataBufferFactory().createInt(1),
-                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 1}));
+                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 1}).getFirst());
 
         int mn = Math.min(m, n);
         INDArray IPIV = Nd4j.createArrayFromShapeBuffer(Nd4j.getDataBufferFactory().createInt(mn),
-                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, mn}));
+                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, mn}).getFirst());
 
         if (A.data().dataType() == DataBuffer.Type.DOUBLE)
             dgetrf(m, n, A, IPIV, INFO);
@@ -71,7 +71,7 @@ public abstract class BaseLapack implements Lapack {
         int n = A.columns();
 
         INDArray INFO = Nd4j.createArrayFromShapeBuffer(Nd4j.getDataBufferFactory().createInt(1),
-                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 1}));
+                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 1}).getFirst());
 
         if (A.data().dataType() == DataBuffer.Type.DOUBLE)
             dpotrf( uplo, n, A, INFO);
@@ -114,7 +114,7 @@ public abstract class BaseLapack implements Lapack {
         int n = A.columns();
 
         INDArray INFO = Nd4j.createArrayFromShapeBuffer(Nd4j.getDataBufferFactory().createInt(1),
-                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 1}));
+                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 1}).getFirst());
 
         if( R.rows() != A.columns() || R.columns() != A.columns() ) {
             throw new Error( "geqrf: R must be N x N (n = columns in A)") ;
@@ -197,7 +197,7 @@ public abstract class BaseLapack implements Lapack {
         byte jobvt = (byte) (VT == null ? 'N' : 'A');
 
         INDArray INFO = Nd4j.createArrayFromShapeBuffer(Nd4j.getDataBufferFactory().createInt(1),
-                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 1}));
+                        Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 1}).getFirst());
 
         if (A.data().dataType() == DataBuffer.Type.DOUBLE)
             dgesvd(jobu, jobvt, m, n, A, S, U, VT, INFO);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseShapeInfoProvider.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseShapeInfoProvider.java
@@ -1,5 +1,6 @@
 package org.nd4j.linalg.api.ndarray;
 
+import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
@@ -15,7 +16,7 @@ public abstract class BaseShapeInfoProvider implements ShapeInfoProvider {
      * @return
      */
     @Override
-    public DataBuffer createShapeInformation(int[] shape) {
+    public Pair<DataBuffer, int[]> createShapeInformation(int[] shape) {
         char order = Nd4j.order();
 
         return createShapeInformation(shape, order);
@@ -29,7 +30,7 @@ public abstract class BaseShapeInfoProvider implements ShapeInfoProvider {
      * @return
      */
     @Override
-    public DataBuffer createShapeInformation(int[] shape, char order) {
+    public Pair<DataBuffer, int[]> createShapeInformation(int[] shape, char order) {
         int[] stride = Nd4j.getStrides(shape, order);
 
         // this won't be view, so ews is 1
@@ -39,9 +40,9 @@ public abstract class BaseShapeInfoProvider implements ShapeInfoProvider {
     }
 
     @Override
-    public DataBuffer createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride, char order) {
+    public Pair<DataBuffer, int[]> createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride, char order) {
         DataBuffer buffer = Shape.createShapeInformation(shape, stride, offset, elementWiseStride, order);
         buffer.setConstant(true);
-        return buffer;
+        return Pair.create(buffer, buffer.asInt());
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/ShapeInfoProvider.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/ShapeInfoProvider.java
@@ -1,5 +1,6 @@
 package org.nd4j.linalg.api.ndarray;
 
+import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 
 /**
@@ -11,21 +12,21 @@ public interface ShapeInfoProvider {
      * @param shape
      * @return
      */
-    DataBuffer createShapeInformation(int[] shape);
+    Pair<DataBuffer, int[]> createShapeInformation(int[] shape);
 
     /**
      * This method creates shapeInformation buffer, based on shape & order being passed in
      * @param shape
      * @return
      */
-    DataBuffer createShapeInformation(int[] shape, char order);
+    Pair<DataBuffer, int[]> createShapeInformation(int[] shape, char order);
 
     /**
      * This method creates shapeInformation buffer, based on detailed shape information being passed in
      * @param shape
      * @return
      */
-    DataBuffer createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride, char order);
+    Pair<DataBuffer, int[]> createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride, char order);
 
     /**
      * This method forces cache purge, if cache is available for specific implementation

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.math3.util.Pair;
 import org.bytedeco.javacpp.DoublePointer;
 import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.javacpp.IntPointer;
@@ -2417,6 +2418,24 @@ public class Nd4j {
 
         return result;
     }
+
+    /**
+     *
+     * @param data
+     * @param shapeInfo
+     * @return
+     */
+    public static INDArray createArrayFromShapeBuffer(DataBuffer data, Pair<DataBuffer, int[]> shapeInfo) {
+        int rank = Shape.rank(shapeInfo.getFirst());
+        int offset = Shape.offset(shapeInfo.getFirst());
+        INDArray result = Nd4j.create(data, toIntArray(rank, Shape.shapeOf(shapeInfo.getFirst())),
+                toIntArray(rank, Shape.stride(shapeInfo.getFirst())), offset, Shape.order(shapeInfo.getFirst()));
+        if (data instanceof CompressedDataBuffer)
+            result.markAsCompressed(true);
+
+        return result;
+    }
+
 
 
     /**

--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/compression/impl/AbstractCompressor.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/compression/impl/AbstractCompressor.java
@@ -137,7 +137,7 @@ public abstract class AbstractCompressor implements NDArrayCompressor {
     public INDArray compress(float[] data, int[] shape, char order) {
         FloatPointer pointer = new FloatPointer(data);
 
-        DataBuffer shapeInfo = Nd4j.getShapeInfoProvider().createShapeInformation(shape, order);
+        DataBuffer shapeInfo = Nd4j.getShapeInfoProvider().createShapeInformation(shape, order).getFirst();
         DataBuffer buffer = compressPointer(DataBuffer.TypeEx.FLOAT, pointer, data.length, 4);
 
         return Nd4j.createArrayFromShapeBuffer(buffer, shapeInfo);
@@ -155,7 +155,7 @@ public abstract class AbstractCompressor implements NDArrayCompressor {
     public INDArray compress(double[] data, int[] shape, char order) {
         DoublePointer pointer = new DoublePointer(data);
 
-        DataBuffer shapeInfo = Nd4j.getShapeInfoProvider().createShapeInformation(shape, order);
+        DataBuffer shapeInfo = Nd4j.getShapeInfoProvider().createShapeInformation(shape, order).getFirst();
         DataBuffer buffer = compressPointer(DataBuffer.TypeEx.DOUBLE, pointer, data.length, 8);
 
         return Nd4j.createArrayFromShapeBuffer(buffer, shapeInfo);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/concurrency/CudaAffinityManager.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/concurrency/CudaAffinityManager.java
@@ -256,7 +256,7 @@ public class CudaAffinityManager extends BasicAffinityManager {
 
         DataBuffer newDataBuffer = replicateToDevice(deviceId, array.data());
         DataBuffer newShapeBuffer = Nd4j.getShapeInfoProvider().createShapeInformation(shape, stride, 0,
-                        elementWiseStride, ordering);
+                        elementWiseStride, ordering).getFirst();
         INDArray result = Nd4j.createArrayFromShapeBuffer(newDataBuffer, newShapeBuffer);
 
         attachThreadToDevice(Thread.currentThread().getId(), currentDeviceId);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/constant/ProtectedCudaShapeInfoProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/constant/ProtectedCudaShapeInfoProvider.java
@@ -1,6 +1,7 @@
 package org.nd4j.jita.constant;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.math3.util.Pair;
 import org.nd4j.jita.allocator.impl.AtomicAllocator;
 import org.nd4j.jita.conf.Configuration;
 import org.nd4j.jita.conf.CudaEnvironment;
@@ -47,7 +48,7 @@ public class ProtectedCudaShapeInfoProvider extends BaseShapeInfoProvider {
     }
 
     @Override
-    public DataBuffer createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride, char order) {
+    public Pair<DataBuffer, int[]> createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride, char order) {
         // We enforce offset to 0 in shapeBuffer, since we need it for cache efficiency + we don't actually use offset value @ native side
         offset = 0;
 
@@ -56,15 +57,15 @@ public class ProtectedCudaShapeInfoProvider extends BaseShapeInfoProvider {
         ShapeDescriptor descriptor = new ShapeDescriptor(shape, stride, offset, elementWiseStride, order);
 
         if (!protector.containsDataBuffer(deviceId, descriptor)) {
-            DataBuffer buffer = null;
+            Pair<DataBuffer, int[]> buffer = null;
             synchronized (this) {
                 if (!protector.containsDataBuffer(deviceId, descriptor)) {
                     //log.info("Cache miss: {}", descriptor);
                     buffer = super.createShapeInformation(shape, stride, offset, elementWiseStride, order);
-                    buffer.setConstant(true);
+                    buffer.getFirst().setConstant(true);
 
                     if (CudaEnvironment.getInstance().getConfiguration().getMemoryModel() == Configuration.MemoryModel.IMMEDIATE) {
-                        Nd4j.getConstantHandler().moveToConstantSpace(buffer);
+                        Nd4j.getConstantHandler().moveToConstantSpace(buffer.getFirst());
                     }
 
                     //deviceCache.get(deviceId).put(descriptor, buffer);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/CachedShapeInfoProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/CachedShapeInfoProvider.java
@@ -1,5 +1,6 @@
 package org.nd4j.linalg.jcublas;
 
+import org.apache.commons.math3.util.Pair;
 import org.nd4j.jita.constant.ProtectedCudaShapeInfoProvider;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.BaseShapeInfoProvider;
@@ -20,8 +21,8 @@ public class CachedShapeInfoProvider extends BaseShapeInfoProvider {
     }
 
     @Override
-    public DataBuffer createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride,
-                    char order) {
+    public Pair<DataBuffer, int[]> createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride,
+                                                          char order) {
         return provider.createShapeInformation(shape, stride, offset, elementWiseStride, order);
     }
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java
@@ -221,7 +221,7 @@ public class JcublasLapack extends BaseLapack {
             r = R.dup('f');
 
         INDArray tau = Nd4j.createArrayFromShapeBuffer(Nd4j.getDataBufferFactory().createFloat(N),
-                Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, N}));
+                Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, N}).getFirst());
 
         if (Nd4j.getExecutioner() instanceof GridExecutioner)
             ((GridExecutioner) Nd4j.getExecutioner()).flushQueue();

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
@@ -1,6 +1,7 @@
 package org.nd4j.linalg.cpu.nativecpu;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.BaseShapeInfoProvider;
 import org.nd4j.linalg.api.shape.ShapeDescriptor;
@@ -14,12 +15,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @Slf4j
 public class DirectShapeInfoProvider extends BaseShapeInfoProvider {
-    private Map<ShapeDescriptor, DataBuffer> shapeCache = new ConcurrentHashMap<>();
+    private Map<ShapeDescriptor, Pair<DataBuffer, int[]>> shapeCache = new ConcurrentHashMap<>();
     private AtomicInteger counter = new AtomicInteger(0);
     private static final int MAX_ENTRIES = 100;
 
     @Override
-    public DataBuffer createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride, char order) {
+    public Pair<DataBuffer, int[]> createShapeInformation(int[] shape, int[] stride, int offset, int elementWiseStride, char order) {
 
         // We enforce offset to 0 in shapeBuffer, since we need it for cache efficiency + we don't actually use offset value @ native side
         offset = 0;
@@ -30,7 +31,7 @@ public class DirectShapeInfoProvider extends BaseShapeInfoProvider {
                 synchronized (this) {
                     if (!shapeCache.containsKey(descriptor)) {
                         counter.incrementAndGet();
-                        DataBuffer buffer =
+                        Pair<DataBuffer, int[]> buffer =
                                         super.createShapeInformation(shape, stride, offset, elementWiseStride, order);
                         shapeCache.put(descriptor, buffer);
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuLapack.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuLapack.java
@@ -214,7 +214,7 @@ public class CpuLapack extends BaseLapack {
 	if( status == 0 ) {
 		int lwork = (int)fp.get() ;
 		INDArray work = Nd4j.createArrayFromShapeBuffer(Nd4j.getDataBufferFactory().createFloat(lwork),
-		                Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, lwork}));
+		                Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, lwork}).getFirst());
 
 		status = LAPACKE_ssyev( getColumnOrder(A), (byte)jobz, (byte)uplo, N, 
 		            (FloatPointer)A.data().addressPointer(), getLda(A),
@@ -236,7 +236,7 @@ public class CpuLapack extends BaseLapack {
 	if( status == 0 ) {
 		int lwork = (int)dp.get() ;
 		INDArray work = Nd4j.createArrayFromShapeBuffer(Nd4j.getDataBufferFactory().createDouble(lwork),
-		                Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, lwork}));
+		                Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, lwork}).getFirst());
 
 		status = LAPACKE_dsyev( getColumnOrder(A), (byte)jobz, (byte)uplo, N, 
 		            (DoublePointer)A.data().addressPointer(), getLda(A),

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/compression/CpuFlexibleThreshold.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/compression/CpuFlexibleThreshold.java
@@ -50,7 +50,7 @@ public class CpuFlexibleThreshold extends CpuThreshold {
 
     @Override
     public DataBuffer compress(DataBuffer buffer) {
-        INDArray temp = Nd4j.createArrayFromShapeBuffer(buffer, Nd4j.getShapeInfoProvider().createShapeInformation(new int[]{1, (int) buffer.length()}));
+        INDArray temp = Nd4j.createArrayFromShapeBuffer(buffer, Nd4j.getShapeInfoProvider().createShapeInformation(new int[]{1, (int) buffer.length()}).getFirst());
         double max = temp.amaxNumber().doubleValue();
 
         int cntAbs = temp.scan(Conditions.absGreaterThanOrEqual(max - (max * threshold))).intValue();

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/compression/CpuThreshold.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/compression/CpuThreshold.java
@@ -91,7 +91,7 @@ public class CpuThreshold extends AbstractCompressor {
 
     @Override
     public DataBuffer compress(DataBuffer buffer) {
-        INDArray temp = Nd4j.createArrayFromShapeBuffer(buffer, Nd4j.getShapeInfoProvider().createShapeInformation(new int[]{1, (int) buffer.length()}));
+        INDArray temp = Nd4j.createArrayFromShapeBuffer(buffer, Nd4j.getShapeInfoProvider().createShapeInformation(new int[]{1, (int) buffer.length()}).getFirst());
         MatchCondition condition = new MatchCondition(temp, Conditions.absGreaterThanOrEqual(threshold));
         int cntAbs = Nd4j.getExecutioner().exec(condition, Integer.MAX_VALUE).getInt(0);
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
@@ -217,9 +217,9 @@ public class LoneTest extends BaseNd4jTest {
     public void testGetRow1() throws Exception {
         INDArray array = Nd4j.create(10000, 10000);
 
-        Thread.sleep(10000);
+        //Thread.sleep(10000);
 
-        int numTries = 100000000;
+        int numTries = 1000;
         List<Long> times = new ArrayList<>();
         long time = 0;
         for (int i = 0; i < numTries; i++) {

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
@@ -1,6 +1,7 @@
 package org.nd4j.linalg;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -14,6 +15,7 @@ import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -211,5 +213,30 @@ public class LoneTest extends BaseNd4jTest {
     }
 
 
+    @Test
+    public void testGetRow1() throws Exception {
+        INDArray array = Nd4j.create(10000, 10000);
 
+        Thread.sleep(10000);
+
+        int numTries = 100000000;
+        List<Long> times = new ArrayList<>();
+        long time = 0;
+        for (int i = 0; i < numTries; i++) {
+
+            int idx = RandomUtils.nextInt(0, 10000);
+            long time1 = System.nanoTime();
+            array.getRow(idx);
+            long time2 = System.nanoTime() - time1;
+
+            times.add(time2);
+            time += time2;
+        }
+
+        time /= numTries;
+
+        Collections.sort(times);
+
+        log.info("p50: {}; avg: {};", times.get(times.size() / 2), time);
+    }
 }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
@@ -100,7 +100,7 @@ public class Nd4jTestsC extends BaseNd4jTest {
     @Before
     public void before() throws Exception {
         super.before();
-        Nd4j.setDataType(DataBuffer.Type.FLOAT);
+        Nd4j.setDataType(DataBuffer.Type.DOUBLE);
         Nd4j.getRandom().setSeed(123);
 
     }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
@@ -4574,6 +4574,66 @@ public class Nd4jTestsC extends BaseNd4jTest {
 
 
     @Test
+    public void testAllDistances4_Large_Columns() throws Exception {
+        INDArray initialX = Nd4j.create(2000, 5);
+        INDArray initialY = Nd4j.create(2000, 7);
+        for (int i = 0; i < initialX.columns(); i++) {
+            initialX.getColumn(i).assign(i+1);
+        }
+
+        for (int i = 0; i < initialY.columns(); i++) {
+            initialY.getColumn(i).assign(i+101);
+        }
+
+        INDArray result = Transforms.allManhattanDistances(initialX, initialY, 0);
+
+        assertEquals(5 * 7, result.length());
+
+        for (int x = 0; x < initialX.columns(); x++) {
+
+            INDArray colX = initialX.getColumn(x).dup();
+
+            for (int y = 0; y < initialY.columns(); y++) {
+
+                double res = result.getDouble(x, y);
+                double exp = Transforms.manhattanDistance(colX, initialY.getColumn(y).dup());
+
+                assertEquals("Failed for [" + x + ", " + y +"]", exp, res, 0.001);
+            }
+        }
+    }
+
+    @Test
+    public void testAllDistances5_Large_Columns() throws Exception {
+        INDArray initialX = Nd4j.create(2000, 5);
+        INDArray initialY = Nd4j.create(2000, 7);
+        for (int i = 0; i < initialX.columns(); i++) {
+            initialX.getColumn(i).assign(i+1);
+        }
+
+        for (int i = 0; i < initialY.columns(); i++) {
+            initialY.getColumn(i).assign(i+101);
+        }
+
+        INDArray result = Transforms.allCosineDistances(initialX, initialY, 0);
+
+        assertEquals(5 * 7, result.length());
+
+        for (int x = 0; x < initialX.columns(); x++) {
+
+            INDArray colX = initialX.getColumn(x).dup();
+
+            for (int y = 0; y < initialY.columns(); y++) {
+
+                double res = result.getDouble(x, y);
+                double exp = Transforms.cosineDistance(colX, initialY.getColumn(y).dup());
+
+                assertEquals("Failed for [" + x + ", " + y +"]", exp, res, 0.001);
+            }
+        }
+    }
+
+    @Test
     public void testAllDistances3_Small_Columns() throws Exception {
         INDArray initialX = Nd4j.create(200, 5);
         INDArray initialY = Nd4j.create(200, 7);
@@ -4585,7 +4645,7 @@ public class Nd4jTestsC extends BaseNd4jTest {
             initialY.getColumn(i).assign(i+101);
         }
 
-        INDArray result = Transforms.allEuclideanDistances(initialX, initialY, 0);
+        INDArray result = Transforms.allManhattanDistances(initialX, initialY, 0);
 
         assertEquals(5 * 7, result.length());
 
@@ -4595,12 +4655,15 @@ public class Nd4jTestsC extends BaseNd4jTest {
             for (int y = 0; y < initialY.columns(); y++) {
 
                 double res = result.getDouble(x, y);
-                double exp = Transforms.euclideanDistance(colX, initialY.getColumn(y).dup());
+                double exp = Transforms.manhattanDistance(colX, initialY.getColumn(y).dup());
 
                 assertEquals("Failed for [" + x + ", " + y +"]", exp, res, 0.001);
             }
         }
     }
+
+
+
 
 
     @Test

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/TestNDArrayCreation.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/TestNDArrayCreation.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 /**
  * Created by Alex on 30/04/2016.
  */
-@Ignore
 public class TestNDArrayCreation extends BaseNd4jTest {
 
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/TestNDArrayCreation.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/TestNDArrayCreation.java
@@ -2,6 +2,7 @@ package org.nd4j.linalg.api;
 
 import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.javacpp.Pointer;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.buffer.DataBuffer;
@@ -19,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Created by Alex on 30/04/2016.
  */
+@Ignore
 public class TestNDArrayCreation extends BaseNd4jTest {
 
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/buffer/IntDataBufferTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/buffer/IntDataBufferTests.java
@@ -34,7 +34,7 @@ public class IntDataBufferTests extends BaseNd4jTest {
 
 
         DataBuffer dataBuffer = Nd4j.createBuffer(new int[] {1, 2, 3, 4, 5});
-        DataBuffer shapeBuffer = Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 5});
+        DataBuffer shapeBuffer = Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 5}).getFirst();
         INDArray intArray = Nd4j.createArrayFromShapeBuffer(dataBuffer, shapeBuffer);
 
         File tempFile = File.createTempFile("test", "test");
@@ -60,7 +60,7 @@ public class IntDataBufferTests extends BaseNd4jTest {
     @Test(expected = ND4JIllegalStateException.class)
     public void testOpDiscarded() throws Exception {
         DataBuffer dataBuffer = Nd4j.createBuffer(new int[] {1, 2, 3, 4, 5});
-        DataBuffer shapeBuffer = Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 5});
+        DataBuffer shapeBuffer = Nd4j.getShapeInfoProvider().createShapeInformation(new int[] {1, 5}).getFirst();
         INDArray intArray = Nd4j.createArrayFromShapeBuffer(dataBuffer, shapeBuffer);
 
         intArray.add(10f);


### PR DESCRIPTION
This PR addresses issue raised by @agibsonccc and xxx earlier: getRow() and similar calls might be consuming more time then expected.

To address this issue we're making all Shape-related internal calls to use JVM int[] array that holds copy of ShapeInfoDataBuffer, to reduce number of off-heap accesses and instanceof calls used during such invocations.

int[] arrays are cached the same way ShapeInfo DataBuffers, and in the same place. Basically: createShapeInfo() method returns Pair of DataBuffer, int[] and the same array is reused together with DataBuffer