### PR TITLE
Eigen.java

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
@@ -48,7 +48,7 @@ public class Eigen {
      * Compute generalized eigenvalues of the problem A x = L x.
      * Matrix A is modified in the process, holding eigenvectors at the end.
      *
-     * @param A symmetric Matrix A. After completion, A will contain the eigenvectors as rows
+     * @param A symmetric Matrix A. After completion, A will contain the eigenvectors as columns
      * @return a vector of eigenvalues L.
      */
     public static INDArray symmetricGeneralizedEigenvalues(INDArray A) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
@@ -109,7 +109,7 @@ public class Eigen {
         assert A.rows() == A.columns();
         assert B.rows() == B.columns();
         INDArray W = Nd4j.create(A.rows());
-	A = InverseMatrix.inverse(B, false).mmul(A);
+	A = InvertMatrix.invert(B, false).mmul(A);
         Nd4j.getBlasWrapper().syev( 'V', 'L', A, W);
         return W;
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
@@ -45,9 +45,10 @@ public class Eigen {
 
 
     /**
-     * Compute generalized eigenvalues of the problem A x = L B x.
+     * Compute generalized eigenvalues of the problem A x = L x.
+     * Matrix A is modified in the process, holding eigenvectors at the end.
      *
-     * @param A symmetric Matrix A. Only the upper triangle will be considered.
+     * @param A symmetric Matrix A. After completion, A will contain the eigenvectors as rows
      * @return a vector of eigenvalues L.
      */
     public static INDArray symmetricGeneralizedEigenvalues(INDArray A) {
@@ -98,16 +99,18 @@ public class Eigen {
 
     /**
      * Compute generalized eigenvalues of the problem A x = L B x.
+     * The data will be unchanged, no eigenvectors returned.
      *
-     * @param A symmetric Matrix A. Only the upper triangle will be considered.
-     * @param B symmetric Matrix B. Only the upper triangle will be considered.
+     * @param A symmetric Matrix A.
+     * @param B symmetric Matrix B.
      * @return a vector of eigenvalues L.
      */
     public static INDArray symmetricGeneralizedEigenvalues(INDArray A, INDArray B) {
         assert A.rows() == A.columns();
         assert B.rows() == B.columns();
         INDArray W = Nd4j.create(A.rows());
-        Nd4j.getBlasWrapper().syev( 'V', 'L', A.dup(), W);
+	A = InverseMatrix.inverse(B, false).mmul(A);
+        Nd4j.getBlasWrapper().syev( 'V', 'L', A, W);
         return W;
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
@@ -44,13 +44,26 @@ public class Eigen {
         return Nd4j.createComplex(WR, WI);
     }
 
+    /**
+     * Compute generalized eigenvalues of the problem A x = L x.
+     * Matrix A is modified in the process, holding eigenvectors after execution.
+     *
+     * @param A symmetric Matrix A. After execution, A will contain the eigenvectors as columns
+     * @return a vector of eigenvalues L.
+     */
+    public static INDArray symmetricGeneralizedEigenvalues(INDArray A) {
+        INDArray eigenvalues = Nd4j.create(A.rows());
+        Nd4j.getBlasWrapper().syev( 'V', 'L', A, eigenvalues );
+        return eigenvalues;
+    }
+
 
     /**
      * Compute generalized eigenvalues of the problem A x = L x.
-     * Matrix A is modified in the process, holding eigenvectors at the end, unless calculateVectors is set false.
+     * Matrix A is modified in the process, holding eigenvectors as columns after execution.
      *
-     * @param A symmetric Matrix A.
-     * @param calculateVectors whether to calculate the eigenvectors (true) or not (false)
+     * @param A symmetric Matrix A. After execution, A will contain the eigenvectors as columns
+     * @param calculateVectors if false, it will not modify A and calculate eigenvectors
      * @return a vector of eigenvalues L.
      */
     public static INDArray symmetricGeneralizedEigenvalues(INDArray A, boolean calculateVectors) {
@@ -101,11 +114,29 @@ public class Eigen {
 
     /**
      * Compute generalized eigenvalues of the problem A x = L B x.
-     * The data will be unchanged, no eigenvectors returned, unless calculateVectors = true
+     * The data will be unchanged, no eigenvectors returned.
      *
      * @param A symmetric Matrix A.
      * @param B symmetric Matrix B.
-     * @param calculateVectors whether to calculate the eigenvectors
+     * @return a vector of eigenvalues L.
+     */
+    public static INDArray symmetricGeneralizedEigenvalues(INDArray A, INDArray B) {
+        assert A.rows() == A.columns();
+        assert B.rows() == B.columns();
+        INDArray W = Nd4j.create(A.rows());
+
+        A = InvertMatrix.invert(B, false).mmuli(A);
+        Nd4j.getBlasWrapper().syev( 'V', 'L', A, W);
+        return W;
+    }
+
+    /**
+     * Compute generalized eigenvalues of the problem A x = L B x.
+     * The data will be unchanged, no eigenvectors returned unless calculateVectors is true.
+     * If calculateVectors == true, A will contain a matrix with the eigenvectors as columns.
+     *
+     * @param A symmetric Matrix A.
+     * @param B symmetric Matrix B.
      * @return a vector of eigenvalues L.
      */
     public static INDArray symmetricGeneralizedEigenvalues(INDArray A, INDArray B, boolean calculateVectors) {
@@ -113,7 +144,8 @@ public class Eigen {
         assert B.rows() == B.columns();
         INDArray W = Nd4j.create(A.rows());
 	if (calculateVectors) A.assign(InvertMatrix.invert(B, false).mmuli(A));
-	    else A = InvertMatrix.invert(B, false).mmuli(A);
+        else A = InvertMatrix.invert(B, false).mmuli(A);
+
         Nd4j.getBlasWrapper().syev( 'V', 'L', A, W);
         return W;
     }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/TestEigen.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/TestEigen.java
@@ -1,4 +1,3 @@
-
 package org.nd4j.linalg.eigen;
 
 import org.junit.Test;
@@ -9,7 +8,8 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.eigen.Eigen ;
-
+import org.nd4j.linalg.inverse.InvertMatrix;
+import org.nd4j.linalg.util.ArrayUtil;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -21,6 +21,23 @@ public class TestEigen extends BaseNd4jTest {
 
     public TestEigen(Nd4jBackend backend) {
         super(backend);
+    }
+
+    // test of functions added by Luke Czapla
+    // Compares solution of A x = L x  to solution to A x = L B x when it is simple
+    @Test
+    public void test2Syev() {
+    	double[][] matrix = new double[][] {{0.0427, -0.04, 0, 0, 0, 0}, {-0.04, 0.0427, 0, 0, 0, 0}, {0, 0.00, 0.0597, 0, 0, 0}, {0, 0, 0, 50, 0, 0}, {0, 0, 0, 0, 50, 0}, {0, 0, 0, 0, 0, 50}};
+	INDArray m = Nd4j.create(ArrayUtil.flattenDoubleArray(matrix), new int[] {6,6});
+	INDArray res = Eigen.symmetricGeneralizedEigenvalues(m, true);
+	
+	INDArray n = Nd4j.create(ArrayUtil.flattenDoubleArray(matrix), new int[] {6,6});
+	INDArray res2 = Eigen.symmetricGeneralizedEigenvalues(n, Nd4j.eye(6).mul(2.0), true);
+
+	for (int i = 0; i < 6; i++) {
+		assertEquals(res.getDouble(i), 2*res2.getDouble(i), 0.000001);
+	}
+	
     }
 
     @Test
@@ -52,4 +69,3 @@ public class TestEigen extends BaseNd4jTest {
         return 'f';
     }
 }
-


### PR DESCRIPTION
## What changes were proposed in this pull request?

In regards to issue #1926:

I tried to implement the suggestions on JavaDoc documenting the current symmetricGeneralizedEigenvectors(A) behavior.  That it is transforming matrix A into its eigenvectors in the process of returning the eigenvalues.  And solving the problem A x = L x.

and I added some code to symmetricGeneralizedEigenvectors(A, B) that should in theory solve the problem "A x = L B x" as it was intended.  I saw in some old branches that the code was entirely different.

*Updated: I made two versions of both methods, since the original symmetricGeneralizedEigenvalues(A) overwrote the matrix A with the eigenvectors as columns, I have one with an extra parameter boolean calculateVectors, if it's false, it doesn't do this.   Similarly with the two arg version symmetricGeneralizedEigenvalues(A, B), it was not saving the eigenvectors.  So I made a new version that has a third parameter calculateVectors, which if it's true, then it will assign to A in-place and collect eigenvectors as columns of A.   The idea behind the calculation is that if you are trying to solve "A x = L B x" and L is a scalar, then it's "A x = B L x" and the solution to B_inverse A x = L x (making substitution of A' = B_inverse A) should be the correct solution.  It's not efficient but it works with syev() call that is implemented *

## How was this patch tested?

https://gist.github.com/lukeczapla/f8e14e93dfa816a5ad88a2a466ff40c0

I did unit tests of the symmetricGeneralizedEigenvalues(A) vs. a version of eigenvector/eigenvalue calculator found in Numerical Recipes (Jacobi method).  The same eigenvector/value pairs are output but in sorted order by increasing eigenvalue from this syev() method.  I have tested all new versions with 6x6 symmetric matrix data and checked that the solutions of A x = L B x are coming out correctly, for the version with the two parameters A and B.
