### PR TITLE
fix stack overflow in nd4j buffer

### DIFF
--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -459,7 +459,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
 
     @Override
     public Pointer pointer() {
-        return underlyingDataBuffer() != null ? underlyingDataBuffer().pointer() : pointer;
+        return underlyingDataBuffer() != null  && underlyingDataBuffer() != this ? underlyingDataBuffer().pointer() : pointer;
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes a stack overflow when referencing a data buffer pointer.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
