### PR TITLE
ensure singular specified index dimensions are collapses

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/NDArrayIndex.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/NDArrayIndex.java
@@ -311,7 +311,7 @@ public class NDArrayIndex implements INDArrayIndex {
                         ret[i] = new SpecifiedIndex(new long[0]);
                     } else if (intendedIndexes[i] instanceof IntervalIndex) {
                         IntervalIndex intervalIndex = (IntervalIndex) intendedIndexes[i];
-                        ret[i] = new SpecifiedIndex(ArrayUtil.range(0, intervalIndex.end(), intervalIndex.stride()));
+                        ret[i] = new SpecifiedIndex(ArrayUtil.range(intervalIndex.begin, intervalIndex.end(), intervalIndex.stride()));
                     }
                 }
             }
@@ -424,6 +424,8 @@ public class NDArrayIndex implements INDArrayIndex {
         //fill the rest with all
         while (retList.size() < length)
             retList.add(NDArrayIndex.all());
+
+
 
         return retList.toArray(new INDArrayIndex[retList.size()]);
     }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/indexing/IndexingTestsC.java
@@ -26,6 +26,23 @@ public class IndexingTestsC extends BaseNd4jTest {
 
 
     @Test
+    public void testIntervalLowerBound() {
+        INDArray wholeArr = Nd4j.linspace(1,24,24).reshape(4,2,3);
+        INDArray subarray = wholeArr.get(
+                NDArrayIndex.interval(1, 3),
+                new SpecifiedIndex(new int[]{0}),
+                new SpecifiedIndex(new int[]{0, 2}));
+        INDArray assertion = Nd4j.create(new double[][]{
+                {7,9},
+                {13,15}
+        });
+
+        assertEquals(assertion,subarray);
+
+    }
+
+
+    @Test
     public void testGetPointRowVector() {
         INDArray arr = Nd4j.linspace(1, 1000, 1000);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Collapses specified indices  when singular dimension.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
