### PR TITLE
Minor cnpy fixes

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -1456,6 +1456,15 @@ public abstract class NativeOps extends Pointer {
      */
     public abstract Pointer shapeBufferForNumpy(Pointer npyArray);
 
+    /**
+     * Thie method releases numpy pointer
+     *
+     * PLEASE NOTE: This method should be ONLY used if pointer/numpy array was originated from file
+     *
+     * @param npyArray
+     */
+    public abstract void releaseNumpy(Pointer npyArray);
+
 
     /**
      * Create a numpy array pointer

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -62,6 +62,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
 import java.util.*;
 
 /**
@@ -1424,11 +1427,22 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
     public INDArray createFromNpyPointer(Pointer pointer) {
         Pointer dataPointer = nativeOps.dataPointForNumpy(pointer);
         int dataBufferElementSize = nativeOps.elementSizeForNpyArray(pointer);
+
         DataBuffer data = null;
         Pointer shapeBufferPointer = nativeOps.shapeBufferForNumpy(pointer);
         int length = nativeOps.lengthForShapeBufferPointer(shapeBufferPointer);
+        shapeBufferPointer.capacity(4 * length);
+        shapeBufferPointer.limit(4 * length);
+        shapeBufferPointer.position(0);
+
         IntPointer intPointer = new IntPointer(shapeBufferPointer);
+
         DataBuffer shapeBuffer = Nd4j.createBuffer(shapeBufferPointer, DataBuffer.Type.INT,length,new IntRawIndexer(intPointer));
+
+        dataPointer.position(0);
+        dataPointer.limit(dataBufferElementSize * Shape.length(shapeBuffer));
+        dataPointer.capacity(dataBufferElementSize * Shape.length(shapeBuffer));
+
         if(dataBufferElementSize == (Float.SIZE / 8)) {
             data = Nd4j.createBuffer(dataPointer,
                     DataBuffer.Type.FLOAT,
@@ -1455,7 +1469,20 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
      */
     @Override
     public INDArray createFromNpyFile(File file) {
-        Pointer pointer = nativeOps.numpyFromFile(new BytePointer(file.getAbsolutePath().getBytes()));
+        /*Pointer pointer = nativeOps.numpyFromFile(new BytePointer(file.getAbsolutePath().getBytes()));
+        log.info("Pointer here: {}", pointer.address());
+        return createFromNpyPointer(pointer);
+
+        */
+
+        byte[] pathBytes = file.getAbsolutePath().getBytes(Charset.forName("UTF-8" ));
+        String otherBytes = new String(pathBytes);
+        System.out.println(otherBytes);
+        ByteBuffer directBuffer = ByteBuffer.allocateDirect(pathBytes.length).order(ByteOrder.nativeOrder());
+        directBuffer.put(pathBytes);
+        directBuffer.rewind();
+        directBuffer.position(0);
+        Pointer pointer = nativeOps.numpyFromFile(new BytePointer(directBuffer));
         return createFromNpyPointer(pointer);
     }
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -102,9 +102,32 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         NativeOpsHolder.getInstance().getDeviceNativeOps().memcpyAsync(allocationPoint.getHostPointer(), pointer, length * getElementSize(), CudaConstants.cudaMemcpyHostToHost, context.getSpecialStream());
         NativeOpsHolder.getInstance().getDeviceNativeOps().memcpyAsync(allocationPoint.getDevicePointer(), allocationPoint.getHostPointer(), length * getElementSize(), CudaConstants.cudaMemcpyHostToHost, context.getSpecialStream());
 
+        context.getSpecialStream().synchronize();
+
         this.pointer = new CudaPointer(allocationPoint.getHostPointer(), length * getElementSize(), 0);
 
-        context.getSpecialStream().synchronize();
+        switch (dataType()) {
+            case INT: {
+                setIndexer(IntIndexer.create(((CudaPointer) this.pointer).asIntPointer()));
+            }
+            break;
+            case FLOAT: {
+                setIndexer(FloatIndexer.create(((CudaPointer) this.pointer).asFloatPointer()));
+            }
+            break;
+            case DOUBLE: {
+                setIndexer(DoubleIndexer.create(((CudaPointer) this.pointer).asDoublePointer()));
+            }
+            break;
+            case HALF: {
+                setIndexer(ShortIndexer.create(((CudaPointer) this.pointer).asShortPointer()));
+            }
+            break;
+            case LONG: {
+                setIndexer(LongIndexer.create(((CudaPointer) this.pointer).asLongPointer()));
+            }
+            break;
+        }
 
         this.trackingPoint = allocationPoint.getObjectId();
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativeblas/Nd4jCuda.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativeblas/Nd4jCuda.java
@@ -4848,6 +4848,15 @@ public static class NativeOps extends org.nd4j.nativeblas.NativeOps {
     public native @Cast("Nd4jPointer") Pointer numpyFromFile(@StdString String path);
 
     /**
+     * This method releases pointer.
+     *
+     * PLEASE NOTE: This method shouldn't be ever called for anything but numpy arrays created from FILE
+     *
+     * @param npyArray
+     */
+    public native void releaseNumpy(@Cast("Nd4jPointer") Pointer npyArray);
+
+    /**
      * Return the length of a shape buffer
      * based on the pointer
      * @param buffer  the buffer pointer to check

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
@@ -1175,6 +1175,7 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
         DataBuffer data = null;
         Pointer shapeBufferPointer = nativeOps.shapeBufferForNumpy(pointer);
         int length = nativeOps.lengthForShapeBufferPointer(shapeBufferPointer);
+        log.info("Length: {}", length);
         shapeBufferPointer.capacity(4 * length);
         shapeBufferPointer.limit(4 * length);
         shapeBufferPointer.position(0);
@@ -1192,6 +1193,7 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
         dataPointer.limit(dataBufferElementSize * Shape.length(shapeBuffer));
         dataPointer.capacity(dataBufferElementSize * Shape.length(shapeBuffer));
 
+        log.info("Shape length: {}", Shape.length(shapeBuffer));
 
         if(dataBufferElementSize == (Float.SIZE / 8)) {
             data = Nd4j.createBuffer(dataPointer,

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpu.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpu.java
@@ -4848,6 +4848,15 @@ public static class NativeOps extends org.nd4j.nativeblas.NativeOps {
     public native @Cast("Nd4jPointer") Pointer numpyFromFile(@StdString String path);
 
     /**
+     * This method releases pointer.
+     *
+     * PLEASE NOTE: This method shouldn't be ever called for anything but numpy arrays created from FILE
+     *
+     * @param npyArray
+     */
+    public native void releaseNumpy(@Cast("Nd4jPointer") Pointer npyArray);
+
+    /**
      * Return the length of a shape buffer
      * based on the pointer
      * @param buffer  the buffer pointer to check

--- a/nd4j-backends/nd4j-tests/pom.xml
+++ b/nd4j-backends/nd4j-tests/pom.xml
@@ -86,7 +86,7 @@
 
         <dependency>
             <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
+            <artifactId>nd4j-cuda-8.0</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/TestNDArrayCreation.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/TestNDArrayCreation.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 /**
  * Created by Alex on 30/04/2016.
  */
-@Ignore
 public class TestNDArrayCreation extends BaseNd4jTest {
 
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/TestNDArrayCreation.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/TestNDArrayCreation.java
@@ -1,5 +1,6 @@
 package org.nd4j.linalg.api;
 
+import lombok.extern.slf4j.Slf4j;
 import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.javacpp.Pointer;
 import org.junit.Ignore;
@@ -20,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Created by Alex on 30/04/2016.
  */
+@Slf4j
 public class TestNDArrayCreation extends BaseNd4jTest {
 
 


### PR DESCRIPTION
Minor cnpy fixes

- CUDA works
- Memory gets released if numpy array was originated from file.
- we are ***NOT*** releasing original pointer, if NDArray was created from numpy pointer. Numpy should handle that, so we won't get into double spending crash.