### PR TITLE
Random projections

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/distances/CosineDistance.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/distances/CosineDistance.java
@@ -187,10 +187,10 @@ public class CosineDistance extends BaseAccumulation {
 
     @Override
     public Op opForDimension(int index, int... dimension) {
-        INDArray xForDimesnion = x.tensorAlongDimension(index, dimension);
+        INDArray xForDimension = x.tensorAlongDimension(index, dimension);
         CosineDistance ret;
         if (y() != null)
-            ret = new CosineDistance(xForDimesnion, y.tensorAlongDimension(index, dimension), xForDimesnion.length());
+            ret = new CosineDistance(xForDimension, y.tensorAlongDimension(index, dimension), xForDimension.length());
         else
             ret = new CosineDistance(x.tensorAlongDimension(index, dimension));
         ret.setApplyFinalTransform(applyFinalTransform());

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
@@ -53,8 +53,8 @@ public class RandomProjection {
         Boolean basicCheck = n == null || n.length == 0 || eps == null || eps.length == 0;
         if (basicCheck)
             throw new IllegalArgumentException("Johnson-Lindenstrauss dimension estimation requires > 0 components and at least a relative error");
-        for (int i =0; i < eps.length; i++){
-            if (eps[i] <= 0 || eps[i] >= 1) {
+        for (double epsilon: eps){
+            if (epsilon <= 0 || epsilon >= 1) {
                 throw new IllegalArgumentException("A relative error should be in ]0, 1[");
             }
         }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
@@ -9,6 +9,7 @@ import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 
 /**
@@ -48,7 +49,7 @@ public class RandomProjection {
      *            Will compute array-wise if an array is given.
      * @return
      */
-    public static ArrayList<Integer> johnsonLindenstraussMinDim(int[] n, double... eps){
+    public static List<Integer> johnsonLindenstraussMinDim(int[] n, double... eps){
         Boolean basicCheck = n == null || n.length == 0 || eps == null || eps.length == 0;
         if (basicCheck)
             throw new IllegalArgumentException("Johnson-Lindenstrauss dimension estimation requires > 0 components and at least a relative error");
@@ -57,7 +58,7 @@ public class RandomProjection {
                 throw new IllegalArgumentException("A relative error should be in ]0, 1[");
             }
         }
-        ArrayList<Integer> res = new ArrayList(n.length * eps.length);
+        List<Integer> res = new ArrayList(n.length * eps.length);
         for (double epsilon : eps){
             double denom = (Math.pow(epsilon, 2) / 2 - Math.pow(epsilon, 3) / 3);
             for (int components: n){
@@ -67,7 +68,7 @@ public class RandomProjection {
         return res;
     }
 
-    public static ArrayList<Integer> johnsonLindenStraussMinDim(int n, double... eps){
+    public static List<Integer> johnsonLindenStraussMinDim(int n, double... eps){
         return johnsonLindenstraussMinDim(new int[]{n}, eps);
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
@@ -99,6 +99,14 @@ public class RandomProjection {
         return res;
     }
 
+    private int[] projectionMatrixShape;
+    private INDArray _projectionMatrix;
+    private INDArray getProjectionMatrix(int[] shape, Random rng){
+        if (! Arrays.equals(projectionMatrixShape, shape) || _projectionMatrix == null)
+            _projectionMatrix = gaussianRandomMatrix(shape, rng);
+        return _projectionMatrix;
+    }
+
     /**
      *
      * Compute the target shape of the projection matrix
@@ -146,7 +154,7 @@ public class RandomProjection {
      */
     public INDArray project(INDArray data){
         int[] tShape = targetShape(data.shape(), eps, components, autoMode);
-        return data.mmul(gaussianRandomMatrix(tShape, this.rng));
+        return data.mmul(getProjectionMatrix(tShape, this.rng));
     }
 
     /**
@@ -158,7 +166,7 @@ public class RandomProjection {
      */
     public INDArray project(INDArray data, INDArray result){
         int[] tShape = targetShape(data.shape(), eps, components, autoMode);
-        return data.mmuli(gaussianRandomMatrix(tShape, this.rng), result);
+        return data.mmuli(getProjectionMatrix(tShape, this.rng), result);
     }
 
     /**
@@ -168,7 +176,7 @@ public class RandomProjection {
      */
     public INDArray projecti(INDArray data){
         int[] tShape = targetShape(data.shape(), eps, components, autoMode);
-        return data.mmuli(gaussianRandomMatrix(tShape, this.rng));
+        return data.mmuli(getProjectionMatrix(tShape, this.rng));
     }
 
     /**
@@ -180,7 +188,7 @@ public class RandomProjection {
      */
     public INDArray projecti(INDArray data, INDArray result){
         int[] tShape = targetShape(data.shape(), eps, components, autoMode);
-        return data.mmuli(gaussianRandomMatrix(tShape, this.rng), result);
+        return data.mmuli(getProjectionMatrix(tShape, this.rng), result);
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
@@ -158,8 +158,7 @@ public class RandomProjection {
      */
     public INDArray project(INDArray data, INDArray result){
         int[] tShape = targetShape(data.shape(), eps, components, autoMode);
-        INDArray z1 = Nd4j.zeros(data.shape()[0], tShape[1]);
-        return data.mmul(gaussianRandomMatrix(tShape, this.rng), z1);
+        return data.mmuli(gaussianRandomMatrix(tShape, this.rng), result);
     }
 
     /**
@@ -181,8 +180,7 @@ public class RandomProjection {
      */
     public INDArray projecti(INDArray data, INDArray result){
         int[] tShape = targetShape(data.shape(), eps, components, autoMode);
-        INDArray z1 = Nd4j.zeros(data.shape()[0], tShape[1]);
-        return data.mmuli(gaussianRandomMatrix(tShape, this.rng), z1);
+        return data.mmuli(gaussianRandomMatrix(tShape, this.rng), result);
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
@@ -22,16 +22,24 @@ public class RandomProjection {
     private double eps;
     private boolean autoMode;
 
-    public RandomProjection(double eps){
-        this.rng = Nd4j.getRandom();
+    public RandomProjection(double eps, Random rng){
+        this.rng = rng;
         this.eps = eps;
         this.autoMode = true;
     }
 
-    public RandomProjection(int components){
-        this.rng = Nd4j.getRandom();
+    public RandomProjection(double eps){
+        this(eps, Nd4j.getRandom());
+    }
+
+    public RandomProjection(int components, Random rng){
+        this.rng = rng;
         this.components = components;
         this.autoMode = false;
+    }
+
+    public RandomProjection(int components){
+        this(components, Nd4j.getRandom());
     }
 
     /**

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/RandomProjection.java
@@ -112,7 +112,7 @@ public class RandomProjection {
         int components = targetDimension;
         if (auto) components = johnsonLindenStraussMinDim(shape[0], eps).get(0);
         // JL or user spec edge cases
-        if (components <= 0 || components > shape[1]){
+        if (auto && (components <= 0 || components > shape[1])){
             throw new ND4JIllegalStateException(String.format("Estimation led to a target dimension of %d, which is invalid", components));
         }
         return new int[]{ shape[1], components};

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -5017,8 +5017,8 @@ public class Nd4j {
     }
 
     public static void checkShapeValues(int[] shape) {
-        for (int e = 0; e < shape.length; e++) {
-            if (shape[e] < 1)
+        for (int e: shape) {
+            if (e < 1)
                 throw new ND4JIllegalStateException("Invalid shape: Requested INDArray shape " + Arrays.toString(shape)
                         + " contains dimension size values < 1 (all dimensions must be 1 or more)");
         }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -5016,7 +5016,7 @@ public class Nd4j {
         return ret;
     }
 
-    protected static void checkShapeValues(int[] shape) {
+    public static void checkShapeValues(int[] shape) {
         for (int e = 0; e < shape.length; e++) {
             if (shape[e] < 1)
                 throw new ND4JIllegalStateException("Invalid shape: Requested INDArray shape " + Arrays.toString(shape)

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dimensionalityreduction/TestRandomProjection.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dimensionalityreduction/TestRandomProjection.java
@@ -1,0 +1,138 @@
+package org.nd4j.linalg.dimensionalityreduction;
+
+import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.accum.distances.EuclideanDistance;
+import org.nd4j.linalg.api.rng.Random;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
+import org.nd4j.linalg.indexing.BooleanIndexing;
+import org.nd4j.linalg.indexing.conditions.Conditions;
+import org.nd4j.linalg.ops.transforms.Transforms;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.nd4j.linalg.dimensionalityreduction.RandomProjection.johnsonLindenStraussMinDim;
+import static org.nd4j.linalg.dimensionalityreduction.RandomProjection.targetShape;
+
+/**
+ * Created by huitseeker on 7/28/17.
+ */
+@RunWith(Parameterized.class)
+public class TestRandomProjection extends BaseNd4jTest {
+
+    INDArray z1 = Nd4j.createUninitialized(new int[]{(int)1e6, 1000});
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+
+    public TestRandomProjection(Nd4jBackend backend) {
+        super(backend);
+    }
+
+    @Test
+    public void testJohnsonLindenStraussDim() {
+        assertEquals(663, (int)johnsonLindenStraussMinDim((int) 1e6, 0.5).get(0));
+        assertTrue(johnsonLindenStraussMinDim((int) 1e6, 0.5).equals(new ArrayList<Integer>(Arrays.asList(663))));
+
+        ArrayList<Integer> res1 = new ArrayList<Integer>(Arrays.asList(663, 11841, 1112658));
+        assertEquals(johnsonLindenStraussMinDim((int) 1e6, 0.5, 0.1, 0.01), res1);
+
+        ArrayList<Integer> res2 = new ArrayList<>(Arrays.asList(7894,  9868, 11841));
+        assertEquals(RandomProjection.johnsonLindenstraussMinDim(new int[]{(int) 1e4, (int) 1e5, (int) 1e6}, 0.1), res2);
+
+    }
+
+    @Test
+    public void testTargetShape() {
+        assertArrayEquals(targetShape(z1, 0.5), new int[]{1000, 663});
+        assertArrayEquals(targetShape(Nd4j.createUninitialized(new int[]{(int)1e2, 225}), 0.5), new int[]{225, 221});
+        // non-changing estimate
+        assertArrayEquals(targetShape(z1, 700), new int[]{1000, 700});
+    }
+
+    @Test
+    public void testTargetEpsilonChecks() {
+        exception.expect(IllegalArgumentException.class);
+        // wrong rel. error
+        targetShape(z1, 0.0);
+    }
+
+    @Test
+    public void testTargetShapeTooHigh() {
+        exception.expect(ND4JIllegalStateException.class);
+        // original dimension too small
+        targetShape(Nd4j.createUninitialized(new int[]{(int)1e2, 1}), 0.5);
+        // target dimension too high
+        targetShape(z1, 1001);
+        // suggested dimension too high
+        targetShape(z1, 0.1);
+        // original samples too small
+        targetShape(Nd4j.createUninitialized(new int[]{1, 1000}), 0.5);
+    }
+
+
+    private void makeRandomSparseData(int[] shape, double density) {
+        INDArray z1 = Nd4j.rand(shape);
+        // because this is rand with mean = 0, stdev = 1, abslessThan ~= density
+        BooleanIndexing.replaceWhere(z1, 0.0, Conditions.absLessThan(density));
+    }
+
+
+
+    @Test
+    public void testBasicEmbedding() {
+        INDArray z1 = Nd4j.randn(10000, 500);
+        RandomProjection rp = new RandomProjection(0.5);
+        INDArray res = Nd4j.zeros(10000, 442);
+        INDArray z2 = rp.projecti(z1, res);
+        assertArrayEquals(z2.shape(), new int[]{10000, 442});
+    }
+
+    @Test
+    public void testEmbedding(){
+        INDArray z1 = Nd4j.randn(2000, 400);
+        INDArray z2 = z1.dup();
+        INDArray result = Transforms.allEuclideanDistances(z1, z2, 1);
+
+        RandomProjection rp = new RandomProjection(0.5);
+        INDArray zp = rp.project(z1);
+        INDArray zp2 = zp.dup();
+        INDArray projRes = Transforms.allEuclideanDistances(zp, zp2, 1);
+
+        // check that the automatically tuned values for the density respect the
+        // contract for eps: pairwise distances are preserved according to the
+        // Johnson-Lindenstrauss lemma
+        INDArray ratios = projRes.div(result);
+
+        for (int i = 0; i < ratios.length(); i++){
+            double val = ratios.getDouble(i);
+            // this avoids the NaNs we get along the diagonal
+            if (val == val) {
+                assertTrue(ratios.getDouble(i) < 1.5);
+            }
+        }
+
+    }
+
+
+    @Override
+    public char ordering() {
+        return 'f';
+    }
+
+}

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dimensionalityreduction/TestRandomProjection.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dimensionalityreduction/TestRandomProjection.java
@@ -93,6 +93,17 @@ public class TestRandomProjection extends BaseNd4jTest {
     }
 
 
+    private void testRandomProjectionDeterministicForSameShape(){
+        INDArray z1 = Nd4j.randn(1000, 500);
+        RandomProjection rp = new RandomProjection(50);
+        INDArray res1 = Nd4j.zeros(10000, 442);
+        rp.projecti(z1, res1);
+
+        INDArray res2 = Nd4j.zeros(10000, 442);
+        rp.projecti(z1, res2);
+
+        assertEquals(res1, res2);
+    }
 
     @Test
     public void testBasicEmbedding() {


### PR DESCRIPTION
- introduces Gaussianity tests on rng (based on Anderson-Darling)
- introduces random projection using a Gaussian matrix, w/scikit-style
  auto-mode that only requires max relative error in distances to
  compute the dimension of the projection (based on Johnson-Lindenstrauss).

See unit tests, esp. TestRandomProjection/testEmbedding.

From the discard pile of high-performance ANN experiments.

Edit: Unit Tests forked in https://github.com/deeplearning4j/nd4j/pull/2036