### PR TITLE
Configure surefire for nd4j-jackson-reflectionloader to avoid failure in maven tests

### DIFF
--- a/nd4j-serde/nd4j-jackson-reflectionloader/pom.xml
+++ b/nd4j-serde/nd4j-jackson-reflectionloader/pom.xml
@@ -43,4 +43,29 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+
+
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire.version}</version>
+                    <configuration>
+                        <!--
+                         By default: Surefire will set the classpath based on the manifest. Because tests are not included
+                         in the JAR, any tests that rely on class path scanning for resources in the tests directory will not
+                         function correctly without this configuration.
+                         For example, reflection tests for classes defined in the test directory will fail due to the
+                         class not being found on the classpath.
+                         http://maven.apache.org/surefire/maven-surefire-plugin/examples/class-loading.html
+                         -->
+                        <useSystemClassLoader>true</useSystemClassLoader>
+                        <useManifestOnlyJar>false</useManifestOnlyJar>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,7 @@
         <spark.version>1.6.3</spark.version>
         <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-surefire.version>2.19.1</maven-surefire.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
Fixes tests in nd4j-jackson-reflectionloader incorrectly failing due to maven surefire config. These were already passing in IntelliJ