### PR TITLE
fix retrieving byte buffers from direct buffers

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/serde/binary/BinarySerde.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/serde/binary/BinarySerde.java
@@ -109,6 +109,7 @@ public class BinarySerde {
 
     }
 
+
     /**
      * Convert an ndarray to an unsafe buffer
      * for use by aeron

--- a/nd4j-serde/nd4j-aeron/src/main/java/org/nd4j/aeron/ipc/AeronNDArraySerde.java
+++ b/nd4j-serde/nd4j-aeron/src/main/java/org/nd4j/aeron/ipc/AeronNDArraySerde.java
@@ -28,6 +28,16 @@ import java.nio.ByteOrder;
 public class AeronNDArraySerde extends BinarySerde {
 
 
+    /**
+     * Get the direct byte buffer from the given direct buffer
+     * @param directBuffer
+     * @return
+     */
+    public static ByteBuffer getDirectByteBuffer(DirectBuffer directBuffer) {
+        return directBuffer.byteBuffer() == null ?
+                ByteBuffer.allocateDirect(directBuffer.capacity()).put(directBuffer.byteArray())
+                : directBuffer.byteBuffer();
+    }
 
     /**
      * Convert an ndarray to an unsafe buffer
@@ -55,7 +65,7 @@ public class AeronNDArraySerde extends BinarySerde {
      * @return the ndarray derived from this buffer
      */
     public static Pair<INDArray, ByteBuffer> toArrayAndByteBuffer(DirectBuffer buffer, int offset) {
-        return toArrayAndByteBuffer(buffer.byteBuffer(),offset);
+        return toArrayAndByteBuffer(getDirectByteBuffer(buffer),offset);
     }
 
 

--- a/samediff/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
+++ b/samediff/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
@@ -418,7 +418,8 @@ public class SameDiffTests {
                 SDVariable y = sameDiff.var("y",inputs.get("y"));
                 SDVariable outputTimesY = outputs.mul(y);
                 SDVariable oneMinusOutput = outputs.rsub(sameDiff.scalar("one",1.0));
-                SDVariable probs = outputTimesY.add(oneMinusOutput.mul(y.rsub(sameDiff.scalar("onetwo",1.0))));
+                SDVariable oneMinusPredictions = y.rsub(sameDiff.scalar("onetwo",1.0));
+                SDVariable probs = outputTimesY.add(oneMinusOutput.mul(oneMinusPredictions));
                 SDVariable logProbs = sameDiff.log(probs);
                 SDVariable sum = sameDiff.sum(logProbs,Integer.MAX_VALUE);
                 SDVariable negSum = sameDiff.neg(sum);
@@ -438,7 +439,7 @@ public class SameDiffTests {
         },inputs);
 
 
-        SameDiff logisticGraph = sameDiffOuter.getSameDiffFunctionInstances().get("lossGrad");
+        SameDiff logisticGraph = sameDiffOuter.getSameDiffFunctionInstances().get("loss");
         INDArray[] outputs = logisticGraph.eval(inputs);
         System.out.println(outputs);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Byte buffer retrieval from aeron wasn't robust enough.
This takes care of that edge case.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
