### PR TITLE
Version Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,4 @@ lib/
 nd4j-shade/jackson/dependency-reduced-pom.xml
 !nd4j-backends/nd4j-api-parent/nd4j-api/src/main/resources/bin
 nd4j-backends/nd4j-backend-impls/nd4j-native/src/test/resources/writeNumpy.csv
+*-git.properties

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -138,5 +138,10 @@
             <artifactId>neoitertools</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>${reflections.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -85,6 +85,7 @@ import org.nd4j.linalg.memory.MemoryManager;
 import org.nd4j.linalg.memory.provider.BasicWorkspaceManager;
 import org.nd4j.linalg.string.NDArrayStrings;
 import org.nd4j.linalg.util.ArrayUtil;
+import org.nd4j.versioncheck.VersionCheck;
 
 import java.io.*;
 import java.lang.ref.ReferenceQueue;
@@ -6094,6 +6095,8 @@ public class Nd4j {
      * @param backend the backend to initialize with
      */
     public void initWithBackend(Nd4jBackend backend) {
+        VersionCheck.checkVersions();
+
         try {
             if (System.getProperties().getProperty("backends") != null
                     && !System.getProperties().getProperty("backends").contains(backend.getClass().getName())) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/GitRepositoryState.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/GitRepositoryState.java
@@ -1,0 +1,89 @@
+package org.nd4j.versioncheck;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Created by Alex on 04/08/2017.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class GitRepositoryState {
+
+    private static final int SUFFIX_LENGTH = "-git.properties".length();
+
+    private String groupId;
+    private String artifactId;
+
+    private String tags;                    // =${git.tags} // comma separated tag names
+    private String branch;                  // =${git.branch}
+    private String dirty;                   // =${git.dirty}
+    private String remoteOriginUrl;         // =${git.remote.origin.url}
+
+    private String commitId;                // =${git.commit.id.full} OR ${git.commit.id}
+    private String commitIdAbbrev;          // =${git.commit.id.abbrev}
+    private String describe;                // =${git.commit.id.describe}
+    private String describeShort;           // =${git.commit.id.describe-short}
+    private String commitUserName;          // =${git.commit.user.name}
+    private String commitUserEmail;         // =${git.commit.user.email}
+    private String commitMessageFull;       // =${git.commit.message.full}
+    private String commitMessageShort;      // =${git.commit.message.short}
+    private String commitTime;              // =${git.commit.time}
+    private String closestTagName;          // =${git.closest.tag.name}
+    private String closestTagCommitCount;   // =${git.closest.tag.commit.count}
+
+    private String buildUserName;           // =${git.build.user.name}
+    private String buildUserEmail;          // =${git.build.user.email}
+    private String buildTime;               // =${git.build.time}
+    private String buildHost;               // =${git.build.host}
+    private String buildVersion;             // =${git.build.version}
+
+    public GitRepositoryState(String propertiesFilePath) throws IOException {
+        //First: parse the properties file path, which is in format <groupid>-<artifactId>-git.properties
+        int idxOf = propertiesFilePath.indexOf('/');
+        idxOf = Math.max(idxOf, propertiesFilePath.indexOf('\\'));
+        String filename;
+        if(idxOf <= 0){
+            filename = propertiesFilePath;
+        } else {
+            filename = propertiesFilePath.substring(idxOf+1);
+        }
+
+        idxOf = filename.indexOf('-');
+        groupId = filename.substring(0, idxOf);
+        artifactId = filename.substring(idxOf+1, filename.length() - SUFFIX_LENGTH);
+
+
+        //Extract values from properties file:
+        Properties properties = new Properties();
+        properties.load(VersionCheck.class.getClassLoader().getResourceAsStream(propertiesFilePath));
+
+        this.tags = String.valueOf(properties.get("git.tags"));
+        this.branch = String.valueOf(properties.get("git.branch"));
+        this.dirty = String.valueOf(properties.get("git.dirty"));
+        this.remoteOriginUrl = String.valueOf(properties.get("git.remote.origin.url"));
+
+        this.commitId = String.valueOf(properties.get("git.commit.id.full")); // OR properties.get("git.commit.id") depending on your configuration
+        this.commitIdAbbrev = String.valueOf(properties.get("git.commit.id.abbrev"));
+        this.describe = String.valueOf(properties.get("git.commit.id.describe"));
+        this.describeShort = String.valueOf(properties.get("git.commit.id.describe-short"));
+        this.commitUserName = String.valueOf(properties.get("git.commit.user.name"));
+        this.commitUserEmail = String.valueOf(properties.get("git.commit.user.email"));
+        this.commitMessageFull = String.valueOf(properties.get("git.commit.message.full"));
+        this.commitMessageShort = String.valueOf(properties.get("git.commit.message.short"));
+        this.commitTime = String.valueOf(properties.get("git.commit.time"));
+        this.closestTagName = String.valueOf(properties.get("git.closest.tag.name"));
+        this.closestTagCommitCount = String.valueOf(properties.get("git.closest.tag.commit.count"));
+
+        this.buildUserName = String.valueOf(properties.get("git.build.user.name"));
+        this.buildUserEmail = String.valueOf(properties.get("git.build.user.email"));
+        this.buildTime = String.valueOf(properties.get("git.build.time"));
+        this.buildHost = String.valueOf(properties.get("git.build.host"));
+        this.buildVersion = String.valueOf(properties.get("git.build.version"));
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/GitRepositoryState.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/GitRepositoryState.java
@@ -1,6 +1,7 @@
 package org.nd4j.versioncheck;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +14,7 @@ import java.util.Properties;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
+@Builder
 public class GitRepositoryState {
 
     private static final int SUFFIX_LENGTH = "-git.properties".length();
@@ -43,10 +45,16 @@ public class GitRepositoryState {
     private String buildHost;               // =${git.build.host}
     private String buildVersion;             // =${git.build.version}
 
+    public GitRepositoryState(String groupId, String artifactId, String buildVersion){
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.buildVersion = buildVersion;
+    }
+
     public GitRepositoryState(String propertiesFilePath) throws IOException {
         //First: parse the properties file path, which is in format <groupid>-<artifactId>-git.properties
-        int idxOf = propertiesFilePath.indexOf('/');
-        idxOf = Math.max(idxOf, propertiesFilePath.indexOf('\\'));
+        int idxOf = propertiesFilePath.lastIndexOf('/');
+        idxOf = Math.max(idxOf, propertiesFilePath.lastIndexOf('\\'));
         String filename;
         if(idxOf <= 0){
             filename = propertiesFilePath;

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
@@ -208,14 +208,20 @@ public class VersionCheck {
         if(!dl4jFound){
             //See if pre-0.9.1 DL4J is present on classpath;
             if(classExists(DL4J_CLASS)){
-                repState.add(new VersionInfo(DL4J_GROUPID, DL4J_ARTIFACT, UNKNOWN_VERSION));
+                List<VersionInfo> temp = new ArrayList<>();
+                temp.add(new VersionInfo(DL4J_GROUPID, DL4J_ARTIFACT, UNKNOWN_VERSION));
+                temp.addAll(repState);
+                repState = temp;
             }
         }
 
         if(!datavecFound){
             //See if pre-0.9.1 DataVec is present on classpath
             if(classExists(DATAVEC_CLASS)){
-                repState.add(new VersionInfo(DATAVEC_GROUPID, DATAVEC_ARTIFACT, UNKNOWN_VERSION));
+                List<VersionInfo> temp = new ArrayList<>();
+                temp.add(new VersionInfo(DATAVEC_GROUPID, DATAVEC_ARTIFACT, UNKNOWN_VERSION));
+                temp.addAll(repState);
+                repState = temp;
             }
         }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
@@ -74,7 +74,7 @@ public class VersionCheck {
         for(VersionInfo gpr : repos){
             String g = gpr.getGroupId();
             if(g != null && GROUPIDS_TO_CHECK.contains(g)){
-                foundVersions.add(g);
+                foundVersions.add(gpr.getBuildVersion());
             }
         }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
@@ -1,0 +1,101 @@
+package org.nd4j.versioncheck;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
+import org.nd4j.linalg.io.ClassPathResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.*;
+
+/**
+ * Created by Alex on 04/08/2017.
+ */
+@Slf4j
+public class VersionCheck {
+
+    public enum Detail {
+        GAV,
+        GAVC,
+        FULL
+    }
+
+    private VersionCheck(){
+
+    }
+
+    public static List<String> listGitPropertiesFiles() throws IOException {
+
+        List<String> files = IOUtils.readLines(VersionCheck.class.getClassLoader()
+                .getResourceAsStream("ai/skymind/"), Charsets.UTF_8);
+
+        if(files == null || files.size() == 0){
+            return Collections.emptyList();
+        }
+
+        List<String> out = new ArrayList<>();
+        for(String s : files){
+            if(!s.endsWith("-git.properties")){
+                continue;
+            }
+            out.add("ai/skymind/" + s);
+        }
+
+        //Sort by file path - should be equivalent to sorting by groupId then artifactId
+        Collections.sort(out);
+
+        return out;
+    }
+
+    public static List<GitRepositoryState> listGitRepositoryInfo() throws IOException {
+        List<GitRepositoryState> repState = new ArrayList<>();
+        for(String s : listGitPropertiesFiles()){
+            repState.add(new GitRepositoryState(s));
+        }
+
+        return repState;
+    }
+
+    public static void logVersionInfo() throws IOException {
+        logVersionInfo(Detail.GAV);
+    }
+
+    public static void logVersionInfo(Detail detail) throws IOException{
+
+        List<GitRepositoryState> info = listGitRepositoryInfo();
+
+        for(GitRepositoryState grp : info){
+            switch (detail){
+                case GAV:
+                    log.info("{} : {} : {}", grp.getGroupId(), grp.getArtifactId(), grp.getBuildVersion());
+                    break;
+                case GAVC:
+                    log.info("{} : {} : {} - {}", grp.getGroupId(), grp.getArtifactId(), grp.getBuildVersion(),
+                            grp.getCommitIdAbbrev());
+                    break;
+                case FULL:
+                    log.info("{} : {} : {} - {}, buildTime={}, buildHost={} branch={}, commitMsg={}", grp.getGroupId(), grp.getArtifactId(),
+                            grp.getBuildVersion(), grp.getCommitId(), grp.getBuildTime(), grp.getBuildHost(),
+                            grp.getBranch(), grp.getCommitMessageShort());
+                    break;
+            }
+        }
+    }
+
+    public static GitRepositoryState getGitRepositoryState(String propertiesFilePath) throws IOException {
+        return new GitRepositoryState(propertiesFilePath);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        logVersionInfo(Detail.GAV);
+
+
+    }
+
+//    private static List<String>
+
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
@@ -1,23 +1,11 @@
 package org.nd4j.versioncheck;
 
-import com.google.common.collect.Multimap;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.Charsets;
-import org.apache.commons.io.IOUtils;
-import org.nd4j.linalg.io.ClassPathResource;
 import org.reflections.Reflections;
-import org.reflections.scanners.AbstractScanner;
-import org.reflections.util.ConfigurationBuilder;
-import org.reflections.util.FilterBuilder;
 import org.reflections.scanners.ResourcesScanner;
-import org.reflections.vfs.Vfs;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
 import java.util.*;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -25,6 +13,26 @@ import java.util.regex.Pattern;
  */
 @Slf4j
 public class VersionCheck {
+
+    public static final String VERSION_CHECK_PROPERTY = "org.nd4j.versioncheck";
+
+    private static final String UNKNOWN_VERSION = "(Unknown, pre-0.9.1)";
+
+    private static final String DL4J_GROUPID = "org.deeplearning4j";
+    private static final String DL4J_ARTIFACT = "deeplearning4j-nn";
+    private static final String DL4J_CLASS = "org.deeplearning4j.nn.conf.MultiLayerConfiguration";
+
+    private static final String DATAVEC_GROUPID = "org.datavec";
+    private static final String DATAVEC_ARTIFACT = "datavec-api";
+    private static final String DATAVEC_CLASS = "org.datavec.api.versioncheck.DataVecApiVersionInfo";
+
+    private static final String ND4J_GROUPID = "org.nd4j";
+
+    private static final String ND4J_JBLAS_CLASS = "org.nd4j.linalg.jblas.JblasBackend";
+    private static final String CANOVA_CLASS = "org.canova.api.io.data.DoubleWritable";
+
+    private static final Set<String> GROUPIDS_TO_CHECK = new HashSet<>(Arrays.asList(
+            ND4J_GROUPID, DL4J_GROUPID, DATAVEC_GROUPID));    //NOTE: DL4J_GROUPID also covers Arbiter and RL4J
 
     public enum Detail {
         GAV,
@@ -35,34 +43,134 @@ public class VersionCheck {
     private VersionCheck(){
 
     }
-    
 
-    public static List<String> listGitPropertiesFiles() throws IOException {
+    public static void checkVersions(){
+        boolean doCheck = Boolean.parseBoolean(System.getProperty(VERSION_CHECK_PROPERTY, "true"));
+
+        if(!doCheck){
+            return;
+        }
+
+        List<GitRepositoryState> repos = listGitRepositoryInfo();
+        Set<String> foundVersions = new HashSet<>();
+        for(GitRepositoryState gpr : repos){
+            String g = gpr.getGroupId();
+            if(g != null && GROUPIDS_TO_CHECK.contains(g)){
+                foundVersions.add(g);
+            }
+        }
+
+        if(foundVersions.size() > 1){
+            log.warn("*** ND4J VERSION CHECK FAILED - INCOMPATIBLE VERSIONS FOUND ***");
+            log.warn("Incompatible versions (different version number) of DL4J, ND4J, RL4J, DataVec, Arbiter are unlikely to function correctly");
+            log.info("Versions of artifacts found on classpath:");
+            logVersionInfo();
+        } else if(foundVersions.size() == 1 && foundVersions.contains(UNKNOWN_VERSION)){
+            log.warn("*** ND4J VERSION CHECK FAILED - COULD NOT INFER VERSIONS ***");
+            log.warn("Incompatible versions (different version number) of DL4J, ND4J, RL4J, DataVec, Arbiter are unlikely to function correctly");
+            log.info("Versions of artifacts found on classpath:");
+            logVersionInfo();
+        }
+
+
+        if(classExists(ND4J_JBLAS_CLASS)){
+            //nd4j-jblas is ancient and incompatible
+            log.error("Found incompatible/obsolete backend and version (nd4j-jblas) on classpath. ND4J is unlikely to"
+                    + " function correctly with nd4j-jblas on the classpath. JVM will now exit.");
+            System.exit(1);
+        }
+
+        if(classExists(CANOVA_CLASS)){
+            //Canova is ancient and likely to pull in incompatible dependencies
+            log.error("Found incompatible/obsolete library Canova on classpath. ND4J is unlikely to"
+                    + " function correctly with this library on the classpath. JVM will now exit.");
+            System.exit(1);
+        }
+    }
+
+
+    public static List<String> listGitPropertiesFiles() {
         Reflections reflections = new Reflections(new ResourcesScanner());
 
         Set<String> resources = reflections.getResources(Pattern.compile(".*-git.properties"));
 
-        return new ArrayList<>(resources);
+        List<String> out = new ArrayList<>(resources);
+        Collections.sort(out);      //Equivalent to sorting by groupID and artifactID
+
+        return out;
     }
 
-    public static List<GitRepositoryState> listGitRepositoryInfo() throws IOException {
+    public static List<GitRepositoryState> listGitRepositoryInfo() {
+
+        boolean dl4jFound = false;
+        boolean datavecFound = false;
+
         List<GitRepositoryState> repState = new ArrayList<>();
         for(String s : listGitPropertiesFiles()){
-            repState.add(new GitRepositoryState(s));
+            GitRepositoryState grs;
+
+            try{
+                grs = new GitRepositoryState(s);
+            } catch (Exception e){
+                log.warn("Error reading property files for {}", s);
+                continue;
+            }
+            repState.add(grs);
+
+            if(!dl4jFound && DL4J_GROUPID.equalsIgnoreCase(grs.getGroupId()) && DL4J_ARTIFACT.equalsIgnoreCase(grs.getArtifactId())){
+                dl4jFound = true;
+            }
+
+            if(!datavecFound && DATAVEC_GROUPID.equalsIgnoreCase(grs.getGroupId()) && DATAVEC_ARTIFACT.equalsIgnoreCase(grs.getArtifactId())){
+                datavecFound = true;
+            }
         }
+
+        if(!dl4jFound){
+            //See if pre-0.9.1 DL4J is present on classpath;
+            if(classExists(DL4J_CLASS)){
+                repState.add(new GitRepositoryState(DL4J_GROUPID, DL4J_ARTIFACT, UNKNOWN_VERSION));
+            }
+        }
+
+        if(!datavecFound){
+            //See if pre-0.9.1 DataVec is present on classpath
+            if(classExists(DATAVEC_CLASS)){
+                repState.add(new GitRepositoryState(DATAVEC_GROUPID, DATAVEC_ARTIFACT, UNKNOWN_VERSION));
+            }
+        }
+
+        if(classExists(ND4J_JBLAS_CLASS)){
+            //nd4j-jblas is ancient and incompatible
+            log.error("Found incompatible/obsolete backend and version (nd4j-jblas) on classpath. ND4J is unlikely to"
+                    + " function correctly with nd4j-jblas on the classpath.");
+        }
+
+        if(classExists(CANOVA_CLASS)){
+            //Canova is anchient and likely to pull in incompatible
+            log.error("Found incompatible/obsolete library Canova on classpath. ND4J is unlikely to"
+                    + " function correctly with this library on the classpath.");
+        }
+
 
         return repState;
     }
 
-    public static void logVersionInfo() throws IOException {
-        logVersionInfo(Detail.GAV);
+    private static boolean classExists(String className){
+        try{
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e ){
+            //OK - not found
+        }
+        return false;
     }
 
-    public static String versionInfoString() throws IOException {
+    public static String versionInfoString() {
         return versionInfoString(Detail.GAV);
     }
 
-    public static String versionInfoString(Detail detail) throws IOException {
+    public static String versionInfoString(Detail detail) {
         StringBuilder sb = new StringBuilder();
         for(GitRepositoryState grp : listGitRepositoryInfo()){
             sb.append(grp.getGroupId()).append(" : ").append(grp.getArtifactId()).append(" : ").append(grp.getBuildVersion());
@@ -80,7 +188,11 @@ public class VersionCheck {
         return sb.toString();
     }
 
-    public static void logVersionInfo(Detail detail) throws IOException{
+    public static void logVersionInfo(){
+        logVersionInfo(Detail.GAV);
+    }
+
+    public static void logVersionInfo(Detail detail){
 
         List<GitRepositoryState> info = listGitRepositoryInfo();
 
@@ -100,14 +212,6 @@ public class VersionCheck {
                     break;
             }
         }
-    }
-
-    public static GitRepositoryState getGitRepositoryState(String propertiesFilePath) throws IOException {
-        return new GitRepositoryState(propertiesFilePath);
-    }
-
-    public static void main(String[] args) throws Exception {
-        logVersionInfo(Detail.GAV);
     }
 
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
@@ -32,7 +32,7 @@ public class VersionCheck {
 
     private static final String DATAVEC_GROUPID = "org.datavec";
     private static final String DATAVEC_ARTIFACT = "datavec-api";
-    private static final String DATAVEC_CLASS = "org.datavec.api.versioncheck.DataVecApiVersionInfo";
+    private static final String DATAVEC_CLASS = "org.datavec.api.writable.DoubleWritable";
 
     private static final String ND4J_GROUPID = "org.nd4j";
 
@@ -69,6 +69,20 @@ public class VersionCheck {
             return;
         }
 
+        if(classExists(ND4J_JBLAS_CLASS)){
+            //nd4j-jblas is ancient and incompatible
+            log.error("Found incompatible/obsolete backend and version (nd4j-jblas) on classpath. ND4J is unlikely to"
+                    + " function correctly with nd4j-jblas on the classpath. JVM will now exit.");
+            System.exit(1);
+        }
+
+        if(classExists(CANOVA_CLASS)){
+            //Canova is ancient and likely to pull in incompatible dependencies
+            log.error("Found incompatible/obsolete library Canova on classpath. ND4J is unlikely to"
+                    + " function correctly with this library on the classpath. JVM will now exit.");
+            System.exit(1);
+        }
+
         List<VersionInfo> repos = getVersionInfos();
         Set<String> foundVersions = new HashSet<>();
         for(VersionInfo gpr : repos){
@@ -88,21 +102,6 @@ public class VersionCheck {
             log.warn("Incompatible versions (different version number) of DL4J, ND4J, RL4J, DataVec, Arbiter are unlikely to function correctly");
             log.info("Versions of artifacts found on classpath:");
             logVersionInfo();
-        }
-
-
-        if(classExists(ND4J_JBLAS_CLASS)){
-            //nd4j-jblas is ancient and incompatible
-            log.error("Found incompatible/obsolete backend and version (nd4j-jblas) on classpath. ND4J is unlikely to"
-                    + " function correctly with nd4j-jblas on the classpath. JVM will now exit.");
-            System.exit(1);
-        }
-
-        if(classExists(CANOVA_CLASS)){
-            //Canova is ancient and likely to pull in incompatible dependencies
-            log.error("Found incompatible/obsolete library Canova on classpath. ND4J is unlikely to"
-                    + " function correctly with this library on the classpath. JVM will now exit.");
-            System.exit(1);
         }
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
@@ -89,6 +89,14 @@ public class VersionCheck {
         }
 
         List<VersionInfo> repos = getVersionInfos();
+
+        if(getVersionInfos().size() == 0){
+            //No -properties.git files were found on the classpath. This may be due to a misconfigured uber-jar
+            // or maybe running in IntelliJ with "dynamic.classpath" set to true (in workspace.xml). Either way,
+            // we can't check versions and don't want to log an error, which will more often than not be wrong
+            return;
+        }
+
         Set<String> foundVersions = new HashSet<>();
         for(VersionInfo vi : repos){
             String g = vi.getGroupId();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionInfo.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionInfo.java
@@ -15,7 +15,7 @@ import java.util.Properties;
 @NoArgsConstructor
 @Data
 @Builder
-public class GitRepositoryState {
+public class VersionInfo {
 
     private static final int SUFFIX_LENGTH = "-git.properties".length();
 
@@ -45,13 +45,13 @@ public class GitRepositoryState {
     private String buildHost;               // =${git.build.host}
     private String buildVersion;             // =${git.build.version}
 
-    public GitRepositoryState(String groupId, String artifactId, String buildVersion){
+    public VersionInfo(String groupId, String artifactId, String buildVersion){
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.buildVersion = buildVersion;
     }
 
-    public GitRepositoryState(String propertiesFilePath) throws IOException {
+    public VersionInfo(String propertiesFilePath) throws IOException {
         //First: parse the properties file path, which is in format <groupid>-<artifactId>-git.properties
         int idxOf = propertiesFilePath.lastIndexOf('/');
         idxOf = Math.max(idxOf, propertiesFilePath.lastIndexOf('\\'));

--- a/nd4j-common/pom.xml
+++ b/nd4j-common/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.10</version>
+            <version>${reflections.version}</version>
             <exclusions>
               <exclusion>
                 <groupId>com.google.code.findbugs</groupId>

--- a/nd4j-parameter-server-parent/pom.xml
+++ b/nd4j-parameter-server-parent/pom.xml
@@ -26,7 +26,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>${maven-build-helper-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,7 @@
         <playframework.version>2.4.6</playframework.version>
         <lombok.version>1.16.16</lombok.version>
         <jackson.version>2.5.1</jackson.version>
+        <reflections.version>0.9.11</reflections.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.10</slf4j.version>
@@ -505,7 +506,6 @@
                         <include>**/*.dll</include>
                         <include>**/*.dylib</include>
                         <include>lib/*</include>
-
                     </includes>
                 </configuration>
             </plugin>
@@ -687,7 +687,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>18.0</version>
+                <version>20.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -468,25 +468,28 @@
 
         <plugins>
             <plugin>
-              <groupId>pl.project13.maven</groupId>
-              <artifactId>git-commit-id-plugin</artifactId>
-              <version>2.2.2</version>
-              <executions>
-                <execution>
-                  <goals>
-                    <goal>revision</goal>
-                  </goals>
-                  <phase>package</phase>
-                </execution>
-              </executions>
-              <configuration>
-                <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-                <gitDescribe>
-                  <skip>true</skip>
-                </gitDescribe>
-              </configuration>
-</plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <!--<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties-->
+                    <!--</generateGitPropertiesFilename>-->
+                    <generateGitPropertiesFilename>${project.basedir}/src/main/resources/ai/skymind/${project.groupId}-${project.artifactId}-git.properties
+                    </generateGitPropertiesFilename>
+                    <gitDescribe>
+                        <skip>true</skip>
+                    </gitDescribe>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -476,6 +476,7 @@
     <build>
 
         <plugins>
+            <!-- Configuration for git-commit-id plugin - used with ND4J version check functionality -->
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
@@ -497,6 +498,32 @@
                     </gitDescribe>
                 </configuration>
             </plugin>
+
+            <!-- Add generated git.properties files resource directory, for output of git-commit-id plugin -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${maven-build-helper-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/target/generated-sources/src/main/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven-jar-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -422,11 +422,6 @@
         <camel.version>2.18.2</camel.version>
         <unirest.version>1.4.9</unirest.version>
         <mapdb.version>3.0.2</mapdb.version>
-        <maven-scala-plugin.version>2.15.2</maven-scala-plugin.version>
-        <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
-        <sbt-compiler-maven-plugin.version>1.0.0-beta8</sbt-compiler-maven-plugin.version>
-        <maven-build-helper-plugin.version>1.12</maven-build-helper-plugin.version>
-        <maven-play2-plugin.version>1.0.0-beta5</maven-play2-plugin.version>
         <jcommander.version>1.27</jcommander.version>
         <guava.version>20.0</guava.version>
         <playframework.version>2.4.6</playframework.version>
@@ -444,6 +439,11 @@
         <javacpp.platform.root />            <!--              -Dplatform.root=/path/to/android-ndk/                         -->
         <javacpp.platform.compiler />    <!--              -Dplatform.compiler=/path/to/arm-linux-androideabi-g++        -->
         <spark.version>1.6.3</spark.version>
+        <maven-scala-plugin.version>2.15.2</maven-scala-plugin.version>
+        <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
+        <sbt-compiler-maven-plugin.version>1.0.0-beta8</sbt-compiler-maven-plugin.version>
+        <maven-build-helper-plugin.version>3.0.0</maven-build-helper-plugin.version>
+        <maven-play2-plugin.version>1.0.0-beta5</maven-play2-plugin.version>
         <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-surefire.version>2.19.1</maven-surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
         <playframework.version>2.4.6</playframework.version>
         <lombok.version>1.16.16</lombok.version>
         <jackson.version>2.5.1</jackson.version>
-        <reflections.version>0.9.11</reflections.version>
+        <reflections.version>0.9.10</reflections.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.10</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,7 @@
                 </executions>
                 <configuration>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                    <generateGitPropertiesFilename>${project.basedir}/src/main/resources/ai/skymind/${project.groupId}-${project.artifactId}-git.properties
+                    <generateGitPropertiesFilename>${project.basedir}/target/generated-sources/src/main/resources/ai/skymind/${project.groupId}-${project.artifactId}-git.properties
                     </generateGitPropertiesFilename>
                     <gitDescribe>
                         <skip>true</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,7 @@
         <maven-build-helper-plugin.version>1.12</maven-build-helper-plugin.version>
         <maven-play2-plugin.version>1.0.0-beta5</maven-play2-plugin.version>
         <jcommander.version>1.27</jcommander.version>
+        <guava.version>20.0</guava.version>
         <playframework.version>2.4.6</playframework.version>
         <lombok.version>1.16.16</lombok.version>
         <jackson.version>2.5.1</jackson.version>
@@ -446,6 +447,13 @@
         <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-surefire.version>2.19.1</maven-surefire.version>
+        <maven-lifecycle-mapping.version>1.0.0</maven-lifecycle-mapping.version>
+        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
+        <maven-git-commit-id-plugin.version>2.2.2</maven-git-commit-id-plugin.version>
+        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     </properties>
 
     <developers>
@@ -471,7 +479,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.2</version>
+                <version>${maven-git-commit-id-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -482,8 +490,6 @@
                 </executions>
                 <configuration>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                    <!--<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties-->
-                    <!--</generateGitPropertiesFilename>-->
                     <generateGitPropertiesFilename>${project.basedir}/src/main/resources/ai/skymind/${project.groupId}-${project.artifactId}-git.properties
                     </generateGitPropertiesFilename>
                     <gitDescribe>
@@ -493,7 +499,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>${maven-jar-plugin.version}</version>
                 <configuration>
                     <includes>
                         <include>**/*.so</include>
@@ -585,7 +591,7 @@
                   <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
+                    <version>${maven-lifecycle-mapping.version}</version>
                     <configuration>
                       <lifecycleMappingMetadata>
                         <pluginExecutions>
@@ -606,7 +612,7 @@
 
                  <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
                         <additionalparam>-Xdoclint:none</additionalparam>
                     </configuration>
@@ -622,7 +628,7 @@
 
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>${maven-source-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -634,7 +640,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <!-- To deploy to an open staging repository: -Darguments=-DstagingRepositoryId=orgnd4j-xxxx -->
@@ -661,7 +667,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
                         <source>1.7</source>
                         <target>1.7</target>
@@ -687,7 +693,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>20.0</version>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/samediff/pom.xml
+++ b/samediff/pom.xml
@@ -68,8 +68,7 @@
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <artifactId>guava</artifactId>  <!-- Version set by nd4j parent pom dependency management section -->
         </dependency>
         <!--Only for tests-->
         <dependency>


### PR DESCRIPTION
This PR: adds version check functionality, based on git-commit-id plugin.
Checks for:
- Mixed DL4J/ND4J/DataVec etc versions
- Mixed Scala versions, our deps only (i.e., dl4j spark 2.10, datavec spark 2.11)
- Mixed spark versions (i.e., datavec spark 1, dl4j spark 2)

As far as I can tell: this is complete + good to go. Can be merged after final review.

EDIT: One issue discovered here with IntelliJ (I've been unable to find a workaround after many hours) - it doesn't  work with Intellij running with "dynamic.classpath" in workspace.xml set to true.
It seems the reflections library simply fails to find any -git.properties files, even though they definitely are on the classpath (and can be found using a hard-coded path using say ClassPathResource).
The exact same code/pom runs perfectly with intellij not using dynamic classpath, or when running via an uber-jar.
Workaround for now: if no git.properties files are found, we abort the version check.

----
Unfortunately it does not seem possible to automate testing of this functionality - I could not find a way to manually control the classpath for individual tests for Maven Surefire.

Output of VersionCheck.logVersionInfo();
https://gist.github.com/AlexDBlack/1c59e94be4c79c597b01206995502aae

Output of VersionCheck.logVersionInfo(VersionCheck.Detail.FULL);
https://gist.github.com/AlexDBlack/730075b856f74ea8002b2e78a75c7e2f

Output when forcing datavec-api 0.9.0 via dependency management:
https://gist.github.com/AlexDBlack/46ebc7a574946a33d9872e7faf73760c

Output when nd4j-jblas or Canova are on the classpath (JVM exits immediately)
https://gist.github.com/AlexDBlack/abfb9b042fdbdbf70a871bb9f1b54ddf

Output with datavec spark 2.10 and 2.11:
https://gist.github.com/AlexDBlack/1b410f575db8d242669db6c4c1a42835

