### PR TITLE
wrong assertion

### DIFF
--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/ShapeTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/ShapeTests.java
@@ -146,11 +146,6 @@ public class ShapeTests extends BaseNd4jTest {
 
     @Test
     public void testNewAxis() {
-        INDArray arr = Nd4j.linspace(1, 4, 4).reshape(2, 2);
-        INDArray newAxisAssertion = Nd4j.create(new double[] {1, 3}).reshape(1, 2, 1);
-        INDArray newAxisGet = arr.get(NDArrayIndex.point(0), NDArrayIndex.newAxis());
-        assertEquals(newAxisAssertion, newAxisGet);
-
         INDArray tensor = Nd4j.linspace(1, 12, 12).reshape(3, 2, 2);
         INDArray assertion = Nd4j.create(new double[][] {{1, 7}, {4, 10}}).reshape(1, 2, 2);
         INDArray tensorGet = tensor.get(NDArrayIndex.point(0), NDArrayIndex.newAxis());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Wrong assertion on test there.
See:
In [1]: import numpy as np

In [2]: a = np.reshape(np.linspace(1,4,4),(2,2))

In [3]: a[1,np.newaxis]
Out[3]: array([[ 3.,  4.]])

In [4]: a[1,np.newaxis].shape
Out[4]: (1, 2)

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
