### PR TITLE
Introduce SKIP_BUILD mode to perform-release.sh script

### DIFF
--- a/perform-release.sh
+++ b/perform-release.sh
@@ -9,9 +9,7 @@ fi
 RELEASE_VERSION=$1
 SNAPSHOT_VERSION=$2
 STAGING_REPOSITORY=${3:-}
-if [[ -z ${SKIP_BUILD:-} ]]; then
-    SKIP_BUILD=0
-fi
+SKIP_BUILD=${SKIP_BUILD:-0}
 
 echo "Releasing version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"
 echo "========================================================================================"

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -28,8 +28,8 @@ if [[ -z $(git tag -l "libnd4j-$RELEASE_VERSION") ]]; then
         bash buildnativeoperations.sh -c cuda -v 7.5
         bash buildnativeoperations.sh -c cuda -v 8.0
     fi
-    git tag -a -m "libnd4j-$RELEASE_VERSION" "libnd4j-$RELEASE_VERSION"
-    git tag -a -f -m "libnd4j-$RELEASE_VERSION" "latest_release"
+    git tag -s -a -m "libnd4j-$RELEASE_VERSION" "libnd4j-$RELEASE_VERSION"
+    git tag -s -a -f -m "libnd4j-$RELEASE_VERSION" "latest_release"
 fi
 cd ../nd4j
 
@@ -79,11 +79,11 @@ if [[ "${SKIP_BUILD}" == "0" ]]; then
     source change-cuda-versions.sh 8.0
 fi
 
-git commit -a -m "Update to version $RELEASE_VERSION"
-git tag -a -m "nd4j-$RELEASE_VERSION" "nd4j-$RELEASE_VERSION"
-git tag -a -f -m "nd4j-$RELEASE_VERSION" "latest_release"
+git commit -s -a -m "Update to version $RELEASE_VERSION"
+git tag -s -a -m "nd4j-$RELEASE_VERSION" "nd4j-$RELEASE_VERSION"
+git tag -s -a -f -m "nd4j-$RELEASE_VERSION" "latest_release"
 
 mvn versions:set -DallowSnapshots=true -DgenerateBackupPoms=false -DnewVersion=$SNAPSHOT_VERSION
-git commit -a -m "Update to version $SNAPSHOT_VERSION"
+git commit -s -a -m "Update to version $SNAPSHOT_VERSION"
 
 echo "Successfully performed release of version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -9,6 +9,9 @@ fi
 RELEASE_VERSION=$1
 SNAPSHOT_VERSION=$2
 STAGING_REPOSITORY=${3:-}
+if [[ -z ${SKIP_BUILD:-} ]]; then
+    SKIP_BUILD=0
+fi
 
 echo "Releasing version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"
 echo "========================================================================================"
@@ -22,58 +25,65 @@ cd ../libnd4j
 export TRICK_NVCC=YES
 export LIBND4J_HOME="$(pwd)"
 if [[ -z $(git tag -l "libnd4j-$RELEASE_VERSION") ]]; then
-    bash buildnativeoperations.sh -c cpu
-    bash buildnativeoperations.sh -c cuda -v 7.5
-    bash buildnativeoperations.sh -c cuda -v 8.0
+    if [[ "${SKIP_BUILD}" == "0" ]]; then
+        bash buildnativeoperations.sh -c cpu
+        bash buildnativeoperations.sh -c cuda -v 7.5
+        bash buildnativeoperations.sh -c cuda -v 8.0
+    fi
     git tag -a -m "libnd4j-$RELEASE_VERSION" "libnd4j-$RELEASE_VERSION"
+    git tag -a -f -m "libnd4j-$RELEASE_VERSION" "latest_release"
 fi
 cd ../nd4j
 
 mvn versions:set -DallowSnapshots=true -DgenerateBackupPoms=false -DnewVersion=$RELEASE_VERSION
 
-if [[ -z ${STAGING_REPOSITORY:-} ]]; then
-    # create new staging repository with everything in it
-    source change-scala-versions.sh 2.10
-    source change-cuda-versions.sh 7.5
-    mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -DstagingRepositoryId=$STAGING_REPOSITORY
+if [[ "${SKIP_BUILD}" == "0" ]]; then
+    if [[ -z ${STAGING_REPOSITORY:-} ]]; then
+        # create new staging repository with everything in it
+        source change-scala-versions.sh 2.10
+        source change-cuda-versions.sh 7.5
+        mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -DstagingRepositoryId=$STAGING_REPOSITORY
 
-    if [[ ! $(grep stagingRepository.id target/nexus-staging/staging/*.properties) =~ ^stagingRepository.id=(.*) ]]; then
-        exit 1
+        if [[ ! $(grep stagingRepository.id target/nexus-staging/staging/*.properties) =~ ^stagingRepository.id=(.*) ]]; then
+            exit 1
+        fi
+        STAGING_REPOSITORY=${BASH_REMATCH[1]}
+
+        source change-scala-versions.sh 2.11
+        source change-cuda-versions.sh 8.0
+        mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -DstagingRepositoryId=$STAGING_REPOSITORY
+
+        # build for Android with the NDK
+        export ANDROID_NDK=~/Android/android-ndk/
+
+        cd ../libnd4j
+        bash buildnativeoperations.sh -c cpu -platform android-arm
+        cd ../nd4j
+        mvn clean deploy -Djavacpp.platform=android-arm -am -pl nd4j-backends/nd4j-backend-impls/nd4j-native -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -Dmaven.javadoc.skip -DstagingRepositoryId=$STAGING_REPOSITORY
+
+        cd ../libnd4j
+        bash buildnativeoperations.sh -c cpu -platform android-x86
+        cd ../nd4j
+        mvn clean deploy -Djavacpp.platform=android-x86 -am -pl nd4j-backends/nd4j-backend-impls/nd4j-native -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -Dmaven.javadoc.skip -DstagingRepositoryId=$STAGING_REPOSITORY
+
+    else
+        # build only partially (on other platforms) and deploy to given repository
+        source change-scala-versions.sh 2.10
+        source change-cuda-versions.sh 7.5
+        mvn clean deploy -am -pl nd4j-backends/nd4j-backend-impls/nd4j-native,nd4j-backends/nd4j-backend-impls/nd4j-cuda -Dgpg.useagent=false -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -Dmaven.javadoc.skip -DstagingRepositoryId=$STAGING_REPOSITORY
+
+        source change-scala-versions.sh 2.11
+        source change-cuda-versions.sh 8.0
+        mvn clean deploy -am -pl nd4j-backends/nd4j-backend-impls/nd4j-native,nd4j-backends/nd4j-backend-impls/nd4j-cuda -Dgpg.useagent=false -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -Dmaven.javadoc.skip -DstagingRepositoryId=$STAGING_REPOSITORY
     fi
-    STAGING_REPOSITORY=${BASH_REMATCH[1]}
 
     source change-scala-versions.sh 2.11
     source change-cuda-versions.sh 8.0
-    mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -DstagingRepositoryId=$STAGING_REPOSITORY
-
-    # build for Android with the NDK
-    export ANDROID_NDK=~/Android/android-ndk/
-
-    cd ../libnd4j
-    bash buildnativeoperations.sh -c cpu -platform android-arm
-    cd ../nd4j
-    mvn clean deploy -Djavacpp.platform=android-arm -am -pl nd4j-backends/nd4j-backend-impls/nd4j-native -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -Dmaven.javadoc.skip -DstagingRepositoryId=$STAGING_REPOSITORY
-
-    cd ../libnd4j
-    bash buildnativeoperations.sh -c cpu -platform android-x86
-    cd ../nd4j
-    mvn clean deploy -Djavacpp.platform=android-x86 -am -pl nd4j-backends/nd4j-backend-impls/nd4j-native -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -Dmaven.javadoc.skip -DstagingRepositoryId=$STAGING_REPOSITORY
-
-else
-    # build only partially (on other platforms) and deploy to given repository
-    source change-scala-versions.sh 2.10
-    source change-cuda-versions.sh 7.5
-    mvn clean deploy -am -pl nd4j-backends/nd4j-backend-impls/nd4j-native,nd4j-backends/nd4j-backend-impls/nd4j-cuda -Dgpg.useagent=false -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -Dmaven.javadoc.skip -DstagingRepositoryId=$STAGING_REPOSITORY
-
-    source change-scala-versions.sh 2.11
-    source change-cuda-versions.sh 8.0
-    mvn clean deploy -am -pl nd4j-backends/nd4j-backend-impls/nd4j-native,nd4j-backends/nd4j-backend-impls/nd4j-cuda -Dgpg.useagent=false -DperformRelease -Psonatype-oss-release -DskipTests -Denforcer.skip -Dmaven.javadoc.skip -DstagingRepositoryId=$STAGING_REPOSITORY
 fi
 
-source change-scala-versions.sh 2.11
-source change-cuda-versions.sh 8.0
 git commit -a -m "Update to version $RELEASE_VERSION"
 git tag -a -m "nd4j-$RELEASE_VERSION" "nd4j-$RELEASE_VERSION"
+git tag -a -f -m "nd4j-$RELEASE_VERSION" "latest_release"
 
 mvn versions:set -DallowSnapshots=true -DgenerateBackupPoms=false -DnewVersion=$SNAPSHOT_VERSION
 git commit -a -m "Update to version $SNAPSHOT_VERSION"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow updating the source code for a release before making the final build on the "latest_release" tag.

## How was this patch tested?

Build succeeds with source code modified by the script, with no reference to SNAPSHOT artifacts.