### PR TITLE
Fix buildmultipleScalaVersions.sh for the Mac

### DIFF
--- a/buildmultiplescalaversions.sh
+++ b/buildmultiplescalaversions.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-BASEDIR=$(dirname $(readlink -f "$0"))
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function echoError() {
     (>&2 echo "$1")


### PR DESCRIPTION
No `readlink -f` available without coreutils installed on OSX
