### PR TITLE
Add clipping so softmax / MCXENT to avoil numerical underflow

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/lossfunctions/impl/LossMCXENT.java
@@ -3,6 +3,7 @@ package org.nd4j.linalg.lossfunctions.impl;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.math3.util.Pair;
 import org.nd4j.linalg.activations.IActivation;
 import org.nd4j.linalg.activations.impl.ActivationSoftmax;
@@ -31,7 +32,7 @@ import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
  */
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Getter
+@Getter @Setter
 public class LossMCXENT implements ILossFunction {
     private static final double DEFAULT_SOFTMAX_CLIPPING_EPSILON = 1e-10;
 


### PR DESCRIPTION
Can probably be merged, pending tests and possible optimization - https://github.com/deeplearning4j/nd4j/issues/2028

Tested: DL4J core unit tests (cuda and native) + some examples.