### PR TITLE
Introduces an optional profile for removing prior artifact versions of the project.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,6 @@
             </build>
         </profile>
 
-
         <profile>
             <id>release-sign-artifacts</id>
             <activation>
@@ -388,6 +387,30 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+          <id>trimSnapshots</id>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                  <execution>
+                    <id>remove-old-artifacts</id>
+                    <phase>package</phase>
+                    <goals>
+                      <goal>remove-project-artifact</goal>
+                    </goals>
+                    <configuration>
+                      <removeAll>true</removeAll><!-- remove all versions of built artifacts including all versions.  Install phase will regenerate -->
+                    </configuration>
+                  </execution>
+                </executions>
+              </plugin>
+            </plugins>
+          </build>
         </profile>
     </profiles>
     <scm>


### PR DESCRIPTION
(Please fill in changes proposed in this fix)


(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.

- essential to keep CI local repos trim
- useful for developers (esp. if reliant on mirrors)