### PR TITLE
Add basic momentum optimizer

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/MomentumUpdater.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/MomentumUpdater.java
@@ -1,0 +1,59 @@
+package org.nd4j.linalg.learning;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.learning.config.Momentum;
+
+public class MomentumUpdater implements GradientUpdater<Momentum> {
+    private final Momentum config;
+    private INDArray v;
+    private char gradientReshapeOrder;
+
+    public MomentumUpdater(final Momentum config) {
+        this.config = config;
+    }
+
+    @Override
+    public Momentum getConfig() {
+        return config;
+    }
+
+    @Override
+    public void setStateViewArray(final INDArray viewArray, final int[] gradientShape, final char gradientOrder,
+                                  final boolean initialize) {
+        if (!viewArray.isRowVector()) {
+            throw new IllegalArgumentException("Invalid input: expect row vector input");
+        }
+
+        if (initialize) {
+            viewArray.assign(0);
+        }
+
+        this.v = viewArray;
+
+        // Reshape to match the expected shape of the input gradient arrays
+        this.v = Shape.newShapeNoCopy(this.v, gradientShape, gradientOrder == 'f');
+
+        if (this.v == null) {
+            throw new IllegalStateException("Could not correctly reshape gradient view array");
+        }
+
+        this.gradientReshapeOrder = gradientOrder;
+    }
+
+    @Override
+    public void applyUpdater(final INDArray gradient, final int iteration) {
+        if (v == null) {
+            throw new IllegalStateException("Updater has not been initialized with view state");
+        }
+
+        final double momentum = config.getMomentum();
+        final double learningRate = config.getLearningRate();
+
+        // Standard momentum: v = mu * v_prev - learning_rate * gradient(x)
+        final INDArray vPrev = v.dup(gradientReshapeOrder);
+        vPrev.muli(momentum).subi(gradient.dup(gradientReshapeOrder).muli(learningRate));
+
+        gradient.addi(vPrev);
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/MomentumUpdater.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/MomentumUpdater.java
@@ -51,9 +51,8 @@ public class MomentumUpdater implements GradientUpdater<Momentum> {
         final double learningRate = config.getLearningRate();
 
         // Standard momentum: v = mu * v_prev - learning_rate * gradient(x)
-        final INDArray vPrev = v.dup(gradientReshapeOrder);
-        vPrev.muli(momentum).subi(gradient.dup(gradientReshapeOrder).muli(learningRate));
+        v.muli(momentum).addi(gradient.dup(gradientReshapeOrder).muli(learningRate));
 
-        gradient.addi(vPrev);
+        gradient.assign(vPrev);
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/config/Momentum.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/config/Momentum.java
@@ -1,0 +1,59 @@
+package org.nd4j.linalg.learning.config;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.learning.GradientUpdater;
+import org.nd4j.linalg.learning.MomentumUpdater;
+
+public class Momentum implements IUpdater {
+    public static final double DEFAULT_MOMENTUM = 0.9;
+    public static final double DEFAULT_LEARNING_RATE = 0.1;
+
+    private final double momentum;
+    private double learningRate;
+
+    public Momentum() {
+        this(DEFAULT_LEARNING_RATE, DEFAULT_MOMENTUM);
+    }
+
+    public Momentum(double momentum) {
+        this(DEFAULT_LEARNING_RATE, momentum);
+    }
+
+    public Momentum(final double learningRate, final double momentum) {
+        this.learningRate = learningRate;
+        this.momentum = momentum;
+    }
+
+    @Override
+    public long stateSize(final long numParams) {
+        return numParams;
+    }
+
+    @Override
+    public void applySchedules(final int iteration, final double newLearningRate) {
+        this.learningRate = newLearningRate;
+        // TODO: LR schedule?
+    }
+
+    @Override
+    public GradientUpdater instantiate(final INDArray viewArray, final boolean initializeViewArray) {
+        final MomentumUpdater momentumUpdater = new MomentumUpdater(this);
+        momentumUpdater.setStateViewArray(viewArray, viewArray.shape(), viewArray.ordering(), initializeViewArray);
+
+        return momentumUpdater;
+    }
+
+    @Override
+    @SuppressWarnings("MethodDoesntCallSuperMethod")
+    public IUpdater clone() {
+        return new Momentum(learningRate, momentum);
+    }
+
+    public double getMomentum() {
+        return momentum;
+    }
+
+    public double getLearningRate() {
+        return learningRate;
+    }
+}


### PR DESCRIPTION
This PR adds the rudimentary momentum optimizer to the DL4J repertoar of optimizers.
The implementation is straight forward; basically a stripped down version of the nesterovs optimizer.

It is not uncommon to see these two combined into one class/function call, with a parameter defining `nesterovs = true/false`.

Either way, this seems to work for me and figured I'd share it with you.