### PR TITLE
Use the JavaCPP Presets to detect the presence of CUDA

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasBackend.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasBackend.java
@@ -19,11 +19,13 @@
 
 package org.nd4j.linalg.jcublas;
 
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.javacpp.cublas;
+import org.bytedeco.javacpp.cuda;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.io.ClassPathResource;
 import org.nd4j.linalg.io.Resource;
 import org.nd4j.linalg.jcublas.complex.JCublasComplexNDArray;
-import org.nd4j.linalg.util.Paths;
 
 /**
  *
@@ -40,6 +42,9 @@ public class JCublasBackend extends Nd4jBackend {
             if (!canRun())
                 return false;
         } catch (Throwable e) {
+            while (e.getCause() != null) {
+                e = e.getCause();
+            }
             throw new RuntimeException(e);
         }
         return true;
@@ -47,13 +52,12 @@ public class JCublasBackend extends Nd4jBackend {
 
     @Override
     public boolean canRun() {
-        // legacy check
-        /*
-        boolean res = Paths.nameExistsInPath("nvcc") || Paths.nameExistsInPath("nvcc.exe");
-        if (!res)
-            throw new RuntimeException("CUDA backend can't find NVCC within PATH environment variable");
-
-        */
+        int[] count = { 0 };
+        cuda.cudaGetDeviceCount(count);
+        if (count[0] <= 0) {
+            throw new RuntimeException("No CUDA devices were found in system");
+        }
+        Loader.load(cublas.class);
         return true;
     }
 


### PR DESCRIPTION
Fixes #2065 

## What changes were proposed in this pull request?

Use the JavaCPP Presets to test the presence of CUDA instead of relying on the path to NVCC.

## How was this patch tested?

Tested on examples, both for when CUDA libraries are missing and when the number of devices is 0: ND4J falls back automatically on the CPU backend.