### PR TITLE
Fixed wrong totalCount() after setCount() in Counter

### DIFF
--- a/nd4j-common/src/main/java/org/nd4j/linalg/primitives/Counter.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/primitives/Counter.java
@@ -84,10 +84,13 @@ public class Counter<T> implements Serializable {
      */
     public double setCount(T element, double count) {
         AtomicDouble t = map.get(element);
-        if (t != null)
-            return t.getAndSet(count);
-        else {
+        if (t != null) {
+            double val = t.getAndSet(count);
+            dirty.set(true);
+            return val;
+        } else {
             map.put(element, new AtomicDouble(count));
+            totalCount.addAndGet(count);
             return 0;
         }
 

--- a/nd4j-common/src/test/java/org/nd4j/linalg/primitives/CounterTest.java
+++ b/nd4j-common/src/test/java/org/nd4j/linalg/primitives/CounterTest.java
@@ -88,4 +88,29 @@ public class CounterTest {
         assertEquals("B", list.get(3));
         assertEquals("A", list.get(4));
     }
+    
+    @Test
+    public void testCounterTotal() {
+        Counter<String> counter = new Counter<>();
+
+        counter.incrementCount("A", 1);
+        counter.incrementCount("B", 1);
+        counter.incrementCount("C", 1);
+
+        assertEquals(3.0, counter.totalCount(), 1e-5);
+        
+        counter.setCount("B", 234);
+
+        assertEquals(236.0, counter.totalCount(), 1e-5);
+        
+        counter.setCount("D", 1);
+        
+        assertEquals(237.0, counter.totalCount(), 1e-5);
+        
+        counter.removeKey("B");
+        
+        assertEquals(3.0, counter.totalCount(), 1e-5);
+        
+    }
+    
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Behaviour of org.nd4j.linalg.primitives.Counter.totalCount() is wrong after setCount() is called
- Fixed missing dirty.set(true)
- Added Unit Test

## How was this patch tested?

- Unit Test (attached)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
