### PR TITLE
remove mavenn compiler changes for  node

### DIFF
--- a/nd4j-parameter-server-parent/nd4j-parameter-server-node/pom.xml
+++ b/nd4j-parameter-server-parent/nd4j-parameter-server-node/pom.xml
@@ -11,11 +11,6 @@
     <packaging>jar</packaging>
 
     <name>nd4j-parameter-server-node</name>
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
-    </properties>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
More java 9 related changes. (Remove last maven compiler canges from node)
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
