### PR TITLE
Specifying the value of a property with a name that conflicts with an environment variable is not a default, it's an override.

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -12,7 +12,6 @@
     <properties>
         <cuda.version>9.0</cuda.version>
         <cudnn.version>7.0</cudnn.version>
-        <env.LIBND4J_HOME>${basedir}/../../../../libnd4j/</env.LIBND4J_HOME>
     </properties>
 
     <build>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -12,7 +12,6 @@
     <properties>
         <openblas.version>0.2.19</openblas.version>
         <mkl.version>2017.3</mkl.version>
-        <env.LIBND4J_HOME>${basedir}/../../../../libnd4j/</env.LIBND4J_HOME>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This ignored any libnd4j directory that isn't an immediate sibling
of the nd4j checkout (breaking, e.g. native packaging, or any custom
build).

it does mean we'll have to set the LIBND4J_HOME variable.