### PR TITLE
Update version of OpenBLAS to 0.2.20

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-native-platform/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native-platform/pom.xml
@@ -10,7 +10,7 @@
     <name>nd4j-native-platform</name>
 
     <properties>
-        <openblas.version>0.2.19</openblas.version>
+        <openblas.version>0.2.20</openblas.version>
         <mkl.version>2017.3</mkl.version>
         <nd4j.backend>nd4j-native</nd4j.backend>
     </properties>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -10,7 +10,7 @@
     <name>nd4j-native</name>
 
     <properties>
-        <openblas.version>0.2.19</openblas.version>
+        <openblas.version>0.2.20</openblas.version>
         <mkl.version>2017.3</mkl.version>
         <env.LIBND4J_HOME>${basedir}/../../../../libnd4j/</env.LIBND4J_HOME>
     </properties>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuBlas.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuBlas.java
@@ -1,5 +1,7 @@
 package org.nd4j.linalg.cpu.nativecpu.blas;
 
+import lombok.extern.slf4j.Slf4j;
+import org.bytedeco.javacpp.mkl_rt;
 import org.nd4j.nativeblas.Nd4jBlas;
 
 import static org.bytedeco.javacpp.openblas.*;
@@ -9,6 +11,7 @@ import static org.bytedeco.javacpp.openblas.*;
  *
  * @author saudet
  */
+@Slf4j
 public class CpuBlas extends Nd4jBlas {
 
     /**
@@ -114,6 +117,14 @@ public class CpuBlas extends Nd4jBlas {
 
     @Override
     public void setMaxThreads(int num) {
+        try {
+            // this is required to work around some loading issue with MKL under Linux
+            mkl_rt.MKL_Set_Num_Threads(num);
+            //mkl_rt.MKL_Domain_Set_Num_Threads(num);
+            mkl_rt.MKL_Set_Num_Threads_Local(num);
+        } catch (UnsatisfiedLinkError e) {
+            log.trace("Could not load MKL", e);
+        }
         blas_set_num_threads(num);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -476,7 +476,7 @@
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.10</slf4j.version>
         <logback.version>1.1.2</logback.version>
-        <javacpp.version>1.3.3</javacpp.version>
+        <javacpp.version>1.3.4-SNAPSHOT</javacpp.version>
         <javacpp-presets.version>1.3</javacpp-presets.version>
         <process-classes.skip> false</process-classes.skip>  <!-- To skip native compilation phase: -Dprocess-classes.skip=true    -->
         <javacpp.platform>${os.name}-${os.arch}</javacpp.platform> <!-- For Android: -Dplatform=android-arm                                        -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Probably fixes issue #2060, https://github.com/deeplearning4j/deeplearning4j/issues/3903, https://github.com/deeplearning4j/deeplearning4j/issues/4011, and https://github.com/deeplearning4j/deeplearning4j/issues/4132

The JAR package of this version also includes header files, making it possible for libnd4j to link with it and rely on JavaCPP's loader (for MKL, etc).

## How was this patch tested?

Unit tests pass and MLPMnistSingleLayerExample runs fine, on linux-x86_64, macsox-x86_64, windows-x86_64, with either OpenBLAS or MKL