### PR TITLE
setShape and setStride are deprecated

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -1053,7 +1053,11 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape(), stride, 0, elementWiseStride(),
                         ordering()));
     }
-
+    
+    @Override
+    public void setShapeAndStride(int[] shape, int[] stride) {
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape, stride, 0, -1, ordering()));
+    }
 
 
     /**

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
@@ -1209,6 +1209,11 @@ public abstract class BaseSparseNDArray implements ISparseNDArray {
     public void setShape(int... shape) {
 
     }
+    
+    @Override
+    public void setShapeAndStride(int[] shape, int[] stride) {
+
+    }
 
     @Override
     public void setOrder(char order) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
@@ -1836,13 +1836,17 @@ public interface INDArray extends Serializable {
     /**
      * stride setter
      * @param stride
+     * @deprecated, use {@link #reshape(int...) }
      */
+    @Deprecated
     void setStride(int... stride);
 
     /**
      * Shape setter
      * @param shape
+     * @deprecated, use {@link #reshape(int...) }
      */
+    @Deprecated
     void setShape(int... shape);
 
     /**

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
@@ -1848,6 +1848,13 @@ public interface INDArray extends Serializable {
      */
     @Deprecated
     void setShape(int... shape);
+    
+    /**
+     * Shape and stride setter
+     * @param shape
+     * @param stride 
+     */
+    public void setShapeAndStride(int[] shape, int[] stride);
 
     /**
      * Set the ordering


### PR DESCRIPTION
We can't reshape ndarray by using setShape()

```java
INDArray ar = Nd4j.create(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
INDArray ar2 =  ar.reshape(new int[]{3,2,2}); //work
ar.setShape(new int[]{3,2,2}); //java.lang.IllegalStateException: Shape and stride must be the same length
```
https://github.com/deeplearning4j/nd4j/blob/700fe97d83d8f56ef09bb4246bcd679a272f8b64/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/NDArrayIndex.java#L133-L145

https://github.com/deeplearning4j/nd4j/blob/700fe97d83d8f56ef09bb4246bcd679a272f8b64/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java#L1045-L1055