### PR TITLE
Fix build for Maven 3.5.2

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -123,7 +123,7 @@
             </activation>
             <properties>
                 <dependency.groupId>${project.parent.groupId}</dependency.groupId>
-                <dependency.artifactId>${project.artifactId}</dependency.artifactId>
+                <dependency.artifactId>${project.parent.artifactId}</dependency.artifactId>
                 <dependency.version>${project.parent.version}</dependency.version>
                 <dependency.packaging>pom</dependency.packaging>
                 <dependency.classifier></dependency.classifier>


### PR DESCRIPTION
Fixes #2240 

## What changes were proposed in this pull request?

Modify dummy "dependency.artifactId" to satisfy Maven 3.5.2.

## How was this patch tested?

Build passes with either Maven 3.3.9 or 3.5.2. Also confirmed manually that the change does not interfere with Gradle or sbt builds consuming the new artifacts.