### PR TITLE
Split initializeDevicesAndFunctions(functions) into initializeFunctions()

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -1188,7 +1188,7 @@ public abstract class NativeOps extends Pointer {
      */
     public abstract void initializeDevicesAndFunctions();
 
-    public native void initializeDevicesAndFunctions(PointerPointer functions);
+    public abstract void initializeFunctions(PointerPointer functions);
 
     public abstract Pointer mallocHost(long memorySize, int flags);
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOpsHolder.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOpsHolder.java
@@ -3,7 +3,6 @@ package org.nd4j.nativeblas;
 import lombok.Getter;
 import org.bytedeco.javacpp.Loader;
 import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.PointerPointer;
 import org.nd4j.context.Nd4jContext;
 import org.nd4j.linalg.factory.Nd4j;
 import org.slf4j.Logger;
@@ -30,25 +29,7 @@ public class NativeOpsHolder {
             Class<? extends NativeOps> nativeOpsClazz = Class.forName(name).asSubclass(NativeOps.class);
             deviceNativeOps = nativeOpsClazz.newInstance();
 
-            PointerPointer functions = new PointerPointer(15);
-            functions.put(0, Loader.addressof("cblas_sgemv"));
-            functions.put(1, Loader.addressof("cblas_dgemv"));
-            functions.put(2, Loader.addressof("cblas_sgemm"));
-            functions.put(3, Loader.addressof("cblas_dgemm"));
-            functions.put(4, Loader.addressof("cblas_sgemm_batch"));
-            functions.put(5, Loader.addressof("cblas_dgemm_batch"));
-
-            functions.put(6, Loader.addressof("cublasSgemv_v2"));
-            functions.put(7, Loader.addressof("cublasDgemv_v2"));
-            functions.put(8, Loader.addressof("cublasHgemm"));
-            functions.put(9, Loader.addressof("cublasSgemm_v2"));
-            functions.put(10, Loader.addressof("cublasDgemm_v2"));
-            functions.put(11, Loader.addressof("cublasSgemmEx"));
-            functions.put(12, Loader.addressof("cublasHgemmBatched"));
-            functions.put(13, Loader.addressof("cublasSgemmBatched"));
-            functions.put(14, Loader.addressof("cublasDgemmBatched"));
-            deviceNativeOps.initializeDevicesAndFunctions(functions);
-
+            deviceNativeOps.initializeDevicesAndFunctions();
             int numThreads;
             String numThreadsString = System.getenv("OMP_NUM_THREADS");
             if (numThreadsString != null && !numThreadsString.isEmpty()) {

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -89,6 +89,17 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
     @Override
     public void createBlas() {
         blas = new CudaBlas();
+        PointerPointer functions = new PointerPointer(9);
+        functions.put(0, Loader.addressof("cublasSgemv_v2"));
+        functions.put(1, Loader.addressof("cublasDgemv_v2"));
+        functions.put(2, Loader.addressof("cublasHgemm"));
+        functions.put(3, Loader.addressof("cublasSgemm_v2"));
+        functions.put(4, Loader.addressof("cublasDgemm_v2"));
+        functions.put(5, Loader.addressof("cublasSgemmEx"));
+        functions.put(6, Loader.addressof("cublasHgemmBatched"));
+        functions.put(7, Loader.addressof("cublasSgemmBatched"));
+        functions.put(8, Loader.addressof("cublasDgemmBatched"));
+        nativeOps.initializeFunctions(functions);
     }
 
     @Override

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaExecutioner.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaExecutioner.java
@@ -2022,7 +2022,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             props.put(Nd4jEnvironment.BACKEND_KEY, "CUDA");
             props.put(Nd4jEnvironment.CUDA_NUM_GPUS_KEY, nativeOps.getAvailableDevices());
             props.put(Nd4jEnvironment.CUDA_DEVICE_INFORMATION_KEY, devicesList);
-            props.put(Nd4jEnvironment.BLAS_VENDOR_KEY, Nd4jBlas.Vendor.CUBLAS.toString());
+            props.put(Nd4jEnvironment.BLAS_VENDOR_KEY, (Nd4j.factory().blas()).getBlasVendor().toString());
             props.put(Nd4jEnvironment.HOST_FREE_MEMORY_KEY, Pointer.maxBytes() - Pointer.totalBytes());
 
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativeblas/Nd4jCuda.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativeblas/Nd4jCuda.java
@@ -2954,7 +2954,7 @@ public static class NativeOps extends org.nd4j.nativeblas.NativeOps {
      */
     public native void initializeDevicesAndFunctions();
 
-    public native void initializeDevicesAndFunctions(@Cast("Nd4jPointer*") PointerPointer functions);
+    public native void initializeFunctions(@Cast("Nd4jPointer*") PointerPointer functions);
 
     /**
      * This method acquires memory chunk of requested size on host side

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
@@ -87,6 +87,14 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
     @Override
     public void createBlas() {
         blas = new CpuBlas();
+        PointerPointer functions = new PointerPointer(6);
+        functions.put(0, Loader.addressof("cblas_sgemv"));
+        functions.put(1, Loader.addressof("cblas_dgemv"));
+        functions.put(2, Loader.addressof("cblas_sgemm"));
+        functions.put(3, Loader.addressof("cblas_dgemm"));
+        functions.put(4, Loader.addressof("cblas_sgemm_batch"));
+        functions.put(5, Loader.addressof("cblas_dgemm_batch"));
+        nativeOps.initializeFunctions(functions);
     }
 
     @Override

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpu.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpu.java
@@ -3560,7 +3560,7 @@ public static class NativeOps extends org.nd4j.nativeblas.NativeOps {
      */
     public native void initializeDevicesAndFunctions();
 
-    public native void initializeDevicesAndFunctions(@Cast("Nd4jPointer*") PointerPointer functions);
+    public native void initializeFunctions(@Cast("Nd4jPointer*") PointerPointer functions);
 
     /**
      * This method acquires memory chunk of requested size on host side


### PR DESCRIPTION
## What changes were proposed in this pull request?

NativeOpsHolder needs to be initialized with initializeDevicesAndFunctions() before CpuNDArrayFactory and JCublasNDArrayFactory can be instantiated and BLAS functions loaded, so we need another initialization function to set those functions pointers.

## How was this patch tested?

Manually checked that the pointers are not NULL for CPU (MKL). For CUDA, returns NULL on Linux, but that's an issue in JavaCPP I will be working on...