### PR TITLE
Bundle libgomp.so.1 for nd4j-cuda in addition to nd4j-native

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativeblas/Nd4jCudaPresets.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativeblas/Nd4jCudaPresets.java
@@ -25,8 +25,13 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  *
  * @author saudet
  */
-@Properties(target = "org.nd4j.nativeblas.Nd4jCuda", value = @Platform(include = "NativeOps.h", compiler = "cpp11",
-                library = "jnind4jcuda", link = "nd4jcuda", preload = "libnd4jcuda"))
+@Properties(target = "org.nd4j.nativeblas.Nd4jCuda",
+                value = {@Platform(include = "NativeOps.h", compiler = "cpp11",
+                                library = "jnind4jcuda", link = "nd4jcuda", preload = "libnd4jcuda"),
+                                @Platform(value = "linux", preload = "gomp@.1",
+                                                preloadpath = {"/lib64/", "/lib/", "/usr/lib64/", "/usr/lib/",
+                                                                "/usr/lib/powerpc64-linux-gnu/",
+                                                                "/usr/lib/powerpc64le-linux-gnu/"})})
 public class Nd4jCudaPresets implements InfoMapper {
     @Override
     public void map(InfoMap infoMap) {


### PR DESCRIPTION
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/3873

## What changes were proposed in this pull request?

Because we're using OpenMP in the CUDA backend as well, we should bundle libgomp.so.1 with both backends.

## How was this patch tested?

Verified manually that libgomp.so.1 get bundled for both nd4j-native and nd4j-cuda.