### PR TITLE
Back to Java 7

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -39,8 +39,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -99,12 +99,6 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.4.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>guru.nidi</groupId>
-            <artifactId>graphviz-java</artifactId>
-            <version>0.1.4</version>
         </dependency>
 
         <dependency>

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -3420,7 +3420,7 @@ public class SameDiff {
      * @param function
      */
     public void defineFunction(String function,SameDiffFunctionDefinition functionDefinition) {
-        defineFunction(function,functionDefinition, new HashMap<>());
+        defineFunction(function,functionDefinition, new HashMap<String,INDArray>());
     }
 
     /**
@@ -3870,7 +3870,7 @@ public class SameDiff {
         }
 
         if(!resolvedVariables)
-            resolveVariablesWith(Collections.emptyMap());
+            resolveVariablesWith(Collections.<String,INDArray>emptyMap());
 
         List<DifferentialFunction> ops = new ArrayList<>();
         List<OpExecAction> opExecActions = graph().getOpOrder().getActions();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/Linear.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/Linear.java
@@ -11,6 +11,7 @@ import org.nd4j.imports.NoOpNameFoundException;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseModule;
+import org.nd4j.linalg.api.ops.Module;
 import org.nd4j.linalg.api.ops.impl.accum.Mmul;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.weightinit.WeightInitScheme;
@@ -43,7 +44,7 @@ public class Linear extends BaseModule {
         super(null,
                 getParams(nIn,nOut,weightInitScheme,biasWeightInitScheme),
                 new INDArray[]{},
-                new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                new ArrayList<Double>(), new ArrayList<Integer>(), new ArrayList<Module>());
         this.weightInitScheme = weightInitScheme;
         this.biasWeightInitScheme = biasWeightInitScheme;
         this.nIn = nIn;
@@ -56,7 +57,7 @@ public class Linear extends BaseModule {
                   int nOut,
                   WeightInitScheme weightInitScheme,
                   WeightInitScheme biasWeightInitScheme) {
-        super(null, sameDiff, null, false, new ArrayList<>());
+        super(null, sameDiff, null, false, new ArrayList<Module>());
         this.weightInitScheme = weightInitScheme;
         this.biasWeightInitScheme = biasWeightInitScheme;
 

--- a/nd4j-common/pom.xml
+++ b/nd4j-common/pom.xml
@@ -11,8 +11,8 @@
 
     <name>nd4j-common</name>
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <profiles>

--- a/nd4j-common/src/main/java/org/nd4j/linalg/collection/IntArrayKeyMap.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/collection/IntArrayKeyMap.java
@@ -73,6 +73,11 @@ public class IntArrayKeyMap<V> implements Map<int[],V> {
     }
 
     @Override
+    public Collection<V> values() {
+        return map.values();
+    }
+
+    @Override
     public Set<Entry<int[], V>> entrySet() {
         Set<Map.Entry<IntArray,V>> intArrays = map.entrySet();
         Set<Entry<int[], V>> ret = new LinkedHashSet<>();

--- a/nd4j-common/src/main/java/org/nd4j/linalg/collection/IntArrayKeyMap.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/collection/IntArrayKeyMap.java
@@ -73,34 +73,30 @@ public class IntArrayKeyMap<V> implements Map<int[],V> {
     }
 
     @Override
-    public Collection<V> values() {
-        return map.values();
-    }
-
-    @Override
     public Set<Entry<int[], V>> entrySet() {
         Set<Map.Entry<IntArray,V>> intArrays = map.entrySet();
         Set<Entry<int[], V>> ret = new LinkedHashSet<>();
-        for(Map.Entry<IntArray,V> intArray : intArrays)
-            ret.add(new Map.Entry<int[],V>() {
+        for(Map.Entry<IntArray,V> intArray : intArrays) {
+            final Map.Entry<IntArray,V> intArray2 = intArray;
+            ret.add(new Map.Entry<int[], V>() {
                 @Override
                 public int[] getKey() {
-                    return intArray.getKey().backingArray;
+                    return intArray2.getKey().backingArray;
                 }
 
                 @Override
                 public V getValue() {
-                    return intArray.getValue();
+                    return intArray2.getValue();
                 }
 
                 @Override
                 public V setValue(V v) {
-                    return intArray.setValue(v);
+                    return intArray2.setValue(v);
                 }
             });
+        }
         return ret;
     }
-
 
 
     public static class IntArray implements Comparable<IntArray> {


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/nd4j/issues/2352

Tested locally: this builds, and I checked the impacted dependencies via mvn site, looks like everything that is supposed to be java 7 is back to java 7 (nd4j-native and nd4j-cuda still show java 8 in mvn site, but the dependencies are test scope).