### PR TITLE
test intermediate node shapes/val

### DIFF
--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphTestAllLibnd4j.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphTestAllLibnd4j.java
@@ -10,8 +10,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
+import static org.nd4j.imports.TFGraphTestAllHelper.checkOnlyOutput;
 import static org.nd4j.imports.TFGraphTestAllHelper.fetchTestParams;
-import static org.nd4j.imports.TFGraphTestAllHelper.testSingle;
 
 /**
  * Created by susaneraly on 11/29/17.
@@ -21,6 +21,7 @@ public class TFGraphTestAllLibnd4j {
     private Map<String, INDArray> inputs;
     private Map<String, INDArray> predictions;
     private String modelName;
+    private Map<String, INDArray[]> intermediatePredictions;
     private static final TFGraphTestAllHelper.ExecuteWith executeWith = TFGraphTestAllHelper.ExecuteWith.LIBND4J;
 
     @Parameterized.Parameters
@@ -28,15 +29,17 @@ public class TFGraphTestAllLibnd4j {
         return fetchTestParams(executeWith);
     }
 
-    public TFGraphTestAllLibnd4j(Map<String, INDArray> inputs, Map<String, INDArray> predictions, String modelName) throws IOException {
+    public TFGraphTestAllLibnd4j(Map<String, INDArray> inputs, Map<String, INDArray> predictions, String modelName, Map<String, INDArray[]> intermediatePredictions) throws IOException {
         this.inputs = inputs;
         this.predictions = predictions;
         this.modelName = modelName;
+        this.intermediatePredictions = intermediatePredictions; //currently unused
     }
 
     @Test
     public void test() throws Exception {
         Nd4j.create(1);
-        testSingle(inputs, predictions, modelName, executeWith);
+        checkOnlyOutput(inputs, predictions, modelName, executeWith);
     }
+
 }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphTestAllSameDiff.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphTestAllSameDiff.java
@@ -20,6 +20,7 @@ public class TFGraphTestAllSameDiff {
     private Map<String, INDArray> inputs;
     private Map<String, INDArray> predictions;
     private String modelName;
+    private Map<String, INDArray[]> intermediatePredictions;
     private static final ExecuteWith executeWith = ExecuteWith.SAMEDIFF;
 
     @Parameterized.Parameters
@@ -27,15 +28,25 @@ public class TFGraphTestAllSameDiff {
         return fetchTestParams(executeWith);
     }
 
-    public TFGraphTestAllSameDiff(Map<String, INDArray> inputs, Map<String, INDArray> predictions, String modelName) throws IOException {
+    public TFGraphTestAllSameDiff(Map<String, INDArray> inputs, Map<String, INDArray> predictions, String modelName, Map<String, INDArray[]> intermediatePredictions) throws IOException {
         this.inputs = inputs;
         this.predictions = predictions;
         this.modelName = modelName;
+        this.intermediatePredictions = intermediatePredictions;
     }
 
     @Test
-    public void test() throws Exception {
+    public void testOutputOnly() throws Exception {
         Nd4j.create(1);
-        testSingle(inputs, predictions, modelName, executeWith);
+        checkOnlyOutput(inputs, predictions, modelName, executeWith);
     }
+
+    @Test
+    public void testAlsoIntermediate() throws Exception {
+        Nd4j.create(1);
+        checkIntermediate(inputs,predictions,intermediatePredictions,modelName,executeWith);
+
+    }
+
+
 }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphTestList.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphTestList.java
@@ -27,14 +27,13 @@ public class TFGraphTestList {
 
     public static String[] modelNames = new String[]{
             //"add_n",
-           //"ae_00",
-           // "bias_add",
-           // "conv_0",
-            //"deep_mnist",
-            //NOTE THIS ONE IS BROKEN: THE INPUT VARIABLE IS NOT PRESENT
-           // "deep_mnist_no_dropout",
-            //"g_00",
-            //"g_01",
+            //"ae_00",
+            "bias_add",
+            //"conv_0",
+            //"deep_mnist", //NOTE THIS ONE WILL FAIL because it is expecting a placeholder value for dropout % which we tie to 1.0 in inference
+            //"deep_mnist_no_dropout", //Takes way too long since there are a lot of nodes, would skip for now
+            //"g_00", //This has no placeholders in the graph - not sure how to exec as it gives a NPE
+            "g_01",
             //"math_mul_order",
             //"mlp_00",
             //"mnist_00",
@@ -65,9 +64,18 @@ public class TFGraphTestList {
     }
 
     @Test
-    public void testSome() throws IOException {
+    public void testOutputOnly() throws IOException {
         Map<String, INDArray> inputs = inputVars(modelName, modelDir);
         Map<String, INDArray> predictions = outputVars(modelName, modelDir);
-        testSingle(inputs, predictions, modelName, modelDir, executeWith);
+        checkOnlyOutput(inputs, predictions, modelName, modelDir, executeWith);
+    }
+
+    @Test
+    public void testAlsoIntermediate() throws IOException {
+        Map<String, INDArray> inputs = inputVars(modelName, modelDir);
+        Map<String, INDArray> predictions = outputVars(modelName, modelDir);
+        Map<String, INDArray[]> intermediates = intermediateVars(modelName,modelDir);
+        checkIntermediate(inputs,predictions,intermediates,modelName,executeWith);
+
     }
 }


### PR DESCRIPTION
Adds in test for intermediate shapes and values if we would like.

Needs this to be merged in test resources when this is merged.
https://github.com/deeplearning4j/dl4j-test-resources/pull/25

VERY IMPORTANT:
Don't run TFGraphTestAllLibnd4j or TFGraphTestAllSameDiff as the resources search takes an unreasonably long time, especially when loading up the dict for the intermediate nodes for the deep_mnist tests. I have a workaround in mind for later..

TO RUN:
Use TFGraphTestList and comment out the test you want to run, eg. "bias_add" ..

The intermediateVars in TFGraphTestAllHelper returns Map<String, INDArray[]> 
key is the node name in the graph and the values is an array of the outputs from that node in TF.
