### PR TITLE
Fix mmul: ensure SameDiff instance is available via constructor when setInstanceId is called

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/TensorMmul.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/TensorMmul.java
@@ -62,6 +62,7 @@ public class TensorMmul extends DynamicCustomOp {
                       SDVariable i_v2,
                       int[][] dimensions,
                       MMulTranspose mMulTranspose) {
+        super(null, sameDiff, new SDVariable[]{i_v1,i_v2});
         this.sameDiff = sameDiff;
         this.mMulTranspose = mMulTranspose;
         this.axes = dimensions;
@@ -69,9 +70,6 @@ public class TensorMmul extends DynamicCustomOp {
         if(!addedEdges && sameDiff.getOutputsForFunction(this) == null) {
             addedEdges = true;
         }
-
-        sameDiff.addArgsFor(new SDVariable[]{i_v1,i_v2},this);
-
     }
 
     @Override

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
@@ -1361,5 +1361,35 @@ public class SameDiffTests {
         assertEquals(28,output.getDouble(0),1e-1);
     }
 
+
+    @Test
+    public void testDenseLayerForwardPass() {
+        Nd4j.getRandom().setSeed(12345);
+
+        SameDiff sd = SameDiff.create();
+
+        INDArray iInput = Nd4j.rand(3,4);
+        INDArray iWeights = Nd4j.rand(4,5);
+        INDArray iBias = Nd4j.rand(1,5);
+
+        SDVariable input = sd.var("input", iInput);
+        SDVariable weights = sd.var("weights", iWeights);
+        SDVariable bias = sd.var("bias", iBias);
+
+        SDVariable mmul = sd.mmul("mmul", input, weights);
+        SDVariable z = mmul.add("z", bias);
+        SDVariable out = sd.sigmoid("out", z);
+
+        INDArray expMmul = iInput.mmul(iWeights);
+        INDArray expZ = expMmul.addRowVector(iBias);
+        INDArray expOut = Transforms.sigmoid(expZ, true);
+
+        sd.exec();
+
+        assertEquals(expMmul, mmul.getArr());
+        assertEquals(expZ, z.getArr());
+        assertEquals(expOut, out.getArr());
+    }
+
 }
 


### PR DESCRIPTION
Before: setInstanceId() was called in superclass no-arg constructor, and sameDiff field was null -> mmul op not added to graph.