### PR TITLE
Add .travis.yml and build scripts for Linux and Mac OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ services:
 matrix:
   include:
     - os: linux
+      env: OS=android-arm SCALA=2.10
+      install: true
+      script: bash ./ci/build-android.sh
+    - os: linux
+      env: OS=android-x86 SCALA=2.11
+      install: true
+      script: bash ./ci/build-android.sh
+    - os: linux
       env: OS=linux-x86_64 CUDA=8.0 CUDNN=6 SCALA=2.10
       install: true
       script: bash ./ci/build-linux-x86_64.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+dist: trusty
+sudo: required
+cache:
+  directories:
+    - $HOME/.m2
+language: java
+services:
+  - docker
+matrix:
+  include:
+    - os: linux
+      env: OS=linux-x86_64 CUDA=8.0 CUDNN=6 SCALA=2.10
+      install: true
+      script: bash ./ci/build-linux-x86_64.sh
+    - os: linux
+      env: OS=linux-x86_64 CUDA=9.0 CUDNN=7 SCALA=2.11
+      install: true
+      script: bash ./ci/build-linux-x86_64.sh
+    - os: osx
+      osx_image: xcode7.3
+      env: OS=macosx-x86_64 CUDA=8.0 CUDNN=6 SCALA=2.10
+      install: true
+      script: bash ./ci/build-macosx-x86_64.sh
+    - os: osx
+      osx_image: xcode8.3
+      env: OS=macosx-x86_64 CUDA=9.0 CUDNN=7 SCALA=2.11
+      install: true
+      script: bash ./ci/build-macosx-x86_64.sh
+

--- a/ci/build-android.sh
+++ b/ci/build-android.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -evx
+
+while true; do echo .; sleep 60; done &
+
+if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+    MAVEN_PHASE="deploy"
+else
+    MAVEN_PHASE="install"
+fi
+
+if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$TRAVIS_BRANCH; then
+     git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50
+fi
+
+mkdir $HOME/Android/
+curl -L https://dl.google.com/android/repository/android-ndk-r16b-linux-x86_64.zip -o $HOME/Android/android-ndk.zip
+unzip -qq $HOME/Android/android-ndk.zip -d $HOME/Android/
+ln -s $HOME/Android/android-ndk-r16b $HOME/Android/android-ndk
+export ANDROID_NDK=$HOME/Android/android-ndk
+
+cd $TRAVIS_BUILD_DIR/../libnd4j/
+sed -i /cmake_minimum_required/d CMakeLists.txt
+MAKEJ=2 bash buildnativeoperations.sh -platform $OS
+cd $TRAVIS_BUILD_DIR/
+source change-scala-versions.sh $SCALA
+mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -Dlocal.software.repository=sonatype \
+    -Djavacpp.platform=$OS -pl '!nd4j-backends/nd4j-backend-impls/nd4j-cuda,!nd4j-backends/nd4j-backend-impls/nd4j-cuda-platform,!nd4j-backends/nd4j-tests'
+

--- a/ci/build-linux-x86_64.sh
+++ b/ci/build-linux-x86_64.sh
@@ -3,6 +3,11 @@ set -evx
 
 while true; do echo .; sleep 60; done &
 
+sudo fallocate -l 4GB /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+
 if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
     MAVEN_PHASE="deploy"
 else

--- a/ci/build-linux-x86_64.sh
+++ b/ci/build-linux-x86_64.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -evx
+
+while true; do echo .; sleep 60; done &
+
+if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+    MAVEN_PHASE="deploy"
+else
+    MAVEN_PHASE="install"
+fi
+
+if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$TRAVIS_BRANCH; then
+     git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50
+fi
+
+docker run -ti -e SONATYPE_USERNAME -e SONATYPE_PASSWORD -v $HOME/.m2:/root/.m2 -v $TRAVIS_BUILD_DIR/..:/build \
+    nvidia/cuda:$CUDA-cudnn$CUDNN-devel-centos6 /bin/bash -evxc "\
+        yum -y install centos-release-scl-rh epel-release; \
+        yum -y install devtoolset-4-toolchain rh-maven33 cmake3 git java-1.8.0-openjdk-devel; \
+        source scl_source enable devtoolset-4 rh-maven33 || true; \
+        cd /build/libnd4j/; \
+        sed -i /cmake_minimum_required/d CMakeLists.txt
+        MAKEJ=2 bash buildnativeoperations.sh; \
+        MAKEJ=1 bash buildnativeoperations.sh -c cuda -v $CUDA -cc 30; \
+        cd /build/nd4j/; \
+        source change-cuda-versions.sh $CUDA; \
+        source change-scala-versions.sh $SCALA; \
+        mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.test.skip=true -Dlocal.software.repository=sonatype;"
+

--- a/ci/build-macosx-x86_64.sh
+++ b/ci/build-macosx-x86_64.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -evx
+
+while true; do echo .; sleep 60; done &
+
+if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+    MAVEN_PHASE="deploy"
+else
+    MAVEN_PHASE="install"
+fi
+
+if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$TRAVIS_BRANCH; then
+     git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50
+fi
+
+brew update > /dev/null
+brew install gcc || true
+brew link --overwrite gcc
+
+if [[ $CUDA == "8.0" ]]; then
+    curl -L https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_mac-dmg -o $HOME/cuda.dmg
+else
+    curl -L https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_mac-dmg -o $HOME/cuda.dmg
+fi
+hdiutil mount $HOME/cuda.dmg
+sleep 5
+sudo /Volumes/CUDAMacOSXInstaller/CUDAMacOSXInstaller.app/Contents/MacOS/CUDAMacOSXInstaller --accept-eula --no-window
+
+cd $TRAVIS_BUILD_DIR/../libnd4j/
+sed -i="" /cmake_minimum_required/d CMakeLists.txt
+MAKEJ=2 bash buildnativeoperations.sh
+MAKEJ=1 bash buildnativeoperations.sh -c cuda -v $CUDA -cc 30
+cd $TRAVIS_BUILD_DIR/
+source change-cuda-versions.sh $CUDA
+source change-scala-versions.sh $SCALA
+mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.test.skip=true -Dlocal.software.repository=sonatype
+

--- a/ci/build-macosx-x86_64.sh
+++ b/ci/build-macosx-x86_64.sh
@@ -33,5 +33,5 @@ MAKEJ=1 bash buildnativeoperations.sh -c cuda -v $CUDA -cc 30
 cd $TRAVIS_BUILD_DIR/
 source change-cuda-versions.sh $CUDA
 source change-scala-versions.sh $SCALA
-mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.test.skip=true -Dlocal.software.repository=sonatype
+mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -Dlocal.software.repository=sonatype
 

--- a/ci/settings.xml
+++ b/ci/settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativeblas/Nd4jCudaPresets.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativeblas/Nd4jCudaPresets.java
@@ -57,7 +57,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
                         "ops/declarable/BooleanOp.h",
                         "ops/declarable/LogicOp.h",
                         "ops/declarable/OpRegistrator.h",
-                        "ops/declarable/CustomOperations.h"}, compiler = "cpp11",
+                        "ops/declarable/CustomOperations.h"}, compiler = {"cpp11", "nowarnings"},
                                 library = "jnind4jcuda", link = "nd4jcuda", preload = "libnd4jcuda"),
                                 @Platform(value = "linux", preload = "gomp@.1",
                                                 preloadpath = {"/lib64/", "/lib/", "/usr/lib64/", "/usr/lib/",

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -254,6 +254,17 @@
             </properties>
         </profile>
         <profile>
+            <id>macosx-gcc7</id>
+            <activation>
+                <file>
+                    <exists>/usr/local/bin/g++-7</exists>
+                </file>
+            </activation>
+            <properties>
+                <javacpp.platform.compiler>/usr/local/bin/g++-7</javacpp.platform.compiler>
+            </properties>
+        </profile>
+        <profile>
             <id>macosx-gcc6</id>
             <activation>
                 <file>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
@@ -94,7 +94,7 @@ import java.util.Scanner;
                                               "ops/declarable/headers/loss.h",
                                               "ops/declarable/headers/datatypes.h",
                                               "ops/declarable/headers/third_party.h"},
-                                compiler = "cpp11", library = "jnind4jcpu", link = "nd4jcpu", preload = "libnd4jcpu"),
+                                compiler = {"cpp11", "nowarnings"}, library = "jnind4jcpu", link = "nd4jcpu", preload = "libnd4jcpu"),
                                 @Platform(value = "linux", preload = "gomp@.1",
                                                 preloadpath = {"/lib64/", "/lib/", "/usr/lib64/", "/usr/lib/",
                                                                 "/usr/lib/powerpc64-linux-gnu/",

--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,9 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <quiet>true</quiet>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -460,6 +463,7 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
                             <additionalparam>-Xdoclint:none</additionalparam>
+                            <quiet>true</quiet>
                         </configuration>
                         <executions>
                             <execution>
@@ -680,6 +684,9 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <quiet>true</quiet>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -770,6 +777,7 @@
                     <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
                         <additionalparam>-Xdoclint:none</additionalparam>
+                        <quiet>true</quiet>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let Travis CI make builds and deploy SNAPSHOT artifacts to Sonatype OSS automatically for CPU and CUDA on Linux and Mac OS X.

## How was this patch tested?

Builds for Linux and Mac OS X pass on Travis CI.