### PR TITLE
https://github.com/deeplearning4j/deeplearning4j/issues/4467:

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java
@@ -292,6 +292,8 @@ public abstract class BasicWorkspaceManager implements MemoryWorkspaceManager {
 
                         referenceMap.remove(reference.getKey());
                     }
+                } catch (InterruptedException e) {
+                    return; /* terminate thread when being interrupted */
                 } catch (Exception e) {
                     //
                 }


### PR DESCRIPTION
# properly terminate daemon when being stopped by Thread#interrupt()

## What changes were proposed in this pull request?

terminate the thread when Thread#interrupt() is invoked on it

## How was this patch tested?

running maven exec (which does not hang anymore)
  