### PR TITLE
Add JavaCPP extension for AVX2 to Nd4jCpuPresets and CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,9 +11,11 @@ environment:
     - CUDA: 8.0
       CUDNN: 6
       SCALA: 2.10
+      EXT:
     - CUDA: 9.0
       CUDNN: 7
       SCALA: 2.11
+      EXT: avx2
 
 init:
   - wmic computersystem set AutomaticManagedPagefile=False

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,21 +22,21 @@ matrix:
       install: true
       script: bash ./ci/build-android.sh
     - os: linux
-      env: OS=linux-x86_64 CUDA=8.0 CUDNN=6 SCALA=2.10
+      env: OS=linux-x86_64 CUDA=8.0 CUDNN=6 SCALA=2.10 EXT=
       install: true
       script: bash ./ci/build-linux-x86_64.sh
     - os: linux
-      env: OS=linux-x86_64 CUDA=9.0 CUDNN=7 SCALA=2.11
+      env: OS=linux-x86_64 CUDA=9.0 CUDNN=7 SCALA=2.11 EXT=avx2
       install: true
       script: bash ./ci/build-linux-x86_64.sh
     - os: osx
       osx_image: xcode7.3
-      env: OS=macosx-x86_64 CUDA=8.0 CUDNN=6 SCALA=2.10
+      env: OS=macosx-x86_64 CUDA=8.0 CUDNN=6 SCALA=2.10 EXT=
       install: true
       script: bash ./ci/build-macosx-x86_64.sh
     - os: osx
       osx_image: xcode8.3
-      env: OS=macosx-x86_64 CUDA=9.0 CUDNN=7 SCALA=2.11
+      env: OS=macosx-x86_64 CUDA=9.0 CUDNN=7 SCALA=2.11 EXT=avx2
       install: true
       script: bash ./ci/build-macosx-x86_64.sh
 

--- a/ci/build-android.sh
+++ b/ci/build-android.sh
@@ -4,12 +4,14 @@ set -evx
 while true; do echo .; sleep 60; done &
 
 if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+    BRANCH=$TRAVIS_BRANCH
     MAVEN_PHASE="deploy"
 else
+    BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
     MAVEN_PHASE="install"
 fi
 
-if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$TRAVIS_BRANCH; then
+if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$BRANCH; then
      git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50
 fi
 

--- a/ci/build-linux-x86_64.sh
+++ b/ci/build-linux-x86_64.sh
@@ -9,12 +9,14 @@ sudo mkswap /swapfile
 sudo swapon /swapfile
 
 if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+    BRANCH=$TRAVIS_BRANCH
     MAVEN_PHASE="deploy"
 else
+    BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
     MAVEN_PHASE="install"
 fi
 
-if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$TRAVIS_BRANCH; then
+if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$BRANCH; then
      git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50
 fi
 
@@ -32,10 +34,10 @@ docker run -ti -e SONATYPE_USERNAME -e SONATYPE_PASSWORD -v $HOME/.m2:/root/.m2 
         make -j2; \
         cd /build/libnd4j/; \
         sed -i /cmake_minimum_required/d CMakeLists.txt
-        MAKEJ=2 bash buildnativeoperations.sh; \
+        MAKEJ=2 bash buildnativeoperations.sh -c cpu -e $EXT; \
         MAKEJ=1 bash buildnativeoperations.sh -c cuda -v $CUDA -cc 30; \
         cd /build/nd4j/; \
         source change-cuda-versions.sh $CUDA; \
         source change-scala-versions.sh $SCALA; \
-        mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.test.skip=true -Dlocal.software.repository=sonatype -DprotocCommand=/build/protobuf-$PROTOBUF/src/protoc;"
+        mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.test.skip=true -Dlocal.software.repository=sonatype -Djavacpp.extension=$EXT -DprotocCommand=/build/protobuf-$PROTOBUF/src/protoc;"
 

--- a/ci/build-macosx-x86_64.sh
+++ b/ci/build-macosx-x86_64.sh
@@ -4,12 +4,14 @@ set -evx
 while true; do echo .; sleep 60; done &
 
 if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+    BRANCH=$TRAVIS_BRANCH
     MAVEN_PHASE="deploy"
 else
+    BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
     MAVEN_PHASE="install"
 fi
 
-if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$TRAVIS_BRANCH; then
+if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$BRANCH; then
      git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50
 fi
 
@@ -32,10 +34,10 @@ sudo /Volumes/CUDAMacOSXInstaller/CUDAMacOSXInstaller.app/Contents/MacOS/CUDAMac
 
 cd $TRAVIS_BUILD_DIR/../libnd4j/
 sed -i="" /cmake_minimum_required/d CMakeLists.txt
-MAKEJ=2 bash buildnativeoperations.sh
+MAKEJ=2 bash buildnativeoperations.sh -c cpu -e $EXT
 MAKEJ=1 bash buildnativeoperations.sh -c cuda -v $CUDA -cc 30
 cd $TRAVIS_BUILD_DIR/
 source change-cuda-versions.sh $CUDA
 source change-scala-versions.sh $SCALA
-mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -Dlocal.software.repository=sonatype
+mvn clean $MAVEN_PHASE -B -U --settings ./ci/settings.xml -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -Dlocal.software.repository=sonatype -Djavacpp.extension=$EXT
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -105,7 +105,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <environmentVariables>
-                        <LD_LIBRARY_PATH>${env.LD_LIBRARY_PATH}:${user.dir}:${libnd4jhome}/blasbuild/cpu${javacpp.extension}/blas/</LD_LIBRARY_PATH>
+                        <LD_LIBRARY_PATH>${env.LD_LIBRARY_PATH}:${user.dir}:${libnd4jhome}/blasbuild/cpu${javacpp.platform.extension}/blas/</LD_LIBRARY_PATH>
                     </environmentVariables>
                     <includes>
                         <include>*.java</include>
@@ -160,6 +160,10 @@
                             <name>platform.compiler</name>
                             <value>${javacpp.platform.compiler}</value>
                         </property>
+                        <property>
+                            <name>platform.extension</name>
+                            <value>${javacpp.platform.extension}</value>
+                        </property>
                     </propertyKeysAndValues>
                     <classPaths>
                         <classPath>${project.build.outputDirectory}</classPath>
@@ -174,7 +178,7 @@
                         <includePath>${libnd4jhome}/include/cnpy</includePath>
                         <includePath>${libnd4jhome}/include/indexing</includePath>
                     </includePaths>
-                    <linkPath>${libnd4jhome}/blasbuild/cpu${javacpp.extension}/blas</linkPath>
+                    <linkPath>${libnd4jhome}/blasbuild/cpu${javacpp.platform.extension}/blas</linkPath>
                 </configuration>
                 <executions>
                     <execution>
@@ -227,7 +231,7 @@
                                 <requireFilesExist>
                                     <files>
                                         <file>${libnd4jhome}/blas/NativeOps.h</file>
-                                        <file>${libnd4jhome}/blasbuild/cpu${javacpp.extension}/blas</file>
+                                        <file>${libnd4jhome}/blasbuild/cpu${javacpp.platform.extension}/blas</file>
                                     </files>
                                     <message>!!! You have to compile libnd4j with cpu support first!</message>
                                 </requireFilesExist>
@@ -242,15 +246,27 @@
 
     <profiles>
         <profile>
+            <id>avx2</id>
+            <activation>
+                <property>
+                    <name>javacpp.extension</name>
+                    <value>avx2</value>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.extension>-avx2</javacpp.platform.extension>
+            </properties>
+        </profile>
+        <profile>
             <id>avx512</id>
             <activation>
                 <property>
-                    <name>javacpp.platform.extension</name>
+                    <name>javacpp.extension</name>
                     <value>avx512</value>
                 </property>
             </activation>
             <properties>
-                <javacpp.extension>-avx512</javacpp.extension>
+                <javacpp.platform.extension>-avx512</javacpp.platform.extension>
             </properties>
         </profile>
         <profile>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
@@ -103,7 +103,7 @@ import java.util.Scanner;
                                 "mkl_avx512#mkl_avx512", "mkl_avx512_mic#mkl_avx512_mic", "mkl_def#mkl_def",
                                 "mkl_mc#mkl_mc", "mkl_mc3#mkl_mc3", "mkl_core#mkl_core", "mkl_intel_lp64#mkl_intel_lp64",
                                 "mkl_intel_thread#mkl_intel_thread", "mkl_rt#mkl_rt", "libnd4jcpu"}),
-                @Platform(extension = "-avx512") })
+                @Platform(extension = {"-avx512", "-avx2"}) })
 public class Nd4jCpuPresets implements InfoMapper, BuildEnabled {
 
     private Logger logger;

--- a/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -113,22 +113,22 @@
                             </goals>
                             <configuration>
                                 <excludes>
-                                    <exclude>org/nd4j/nativeblas/${javacpp.platform}${javacpp.extension}/*</exclude>
+                                    <exclude>org/nd4j/nativeblas/${javacpp.platform}${javacpp.platform.extension}/*</exclude>
                                     <exclude>lib/**</exclude>
                                 </excludes>
                             </configuration>
                         </execution>
                         <execution>
-                            <id>${javacpp.platform}${javacpp.extension}</id>
+                            <id>${javacpp.platform}${javacpp.platform.extension}</id>
                             <phase>package</phase>
                             <goals>
                                 <goal>jar</goal>
                             </goals>
                             <configuration>
-                                <classifier>${javacpp.platform}${javacpp.extension}</classifier>
+                                <classifier>${javacpp.platform}${javacpp.platform.extension}</classifier>
                                 <skipIfEmpty>true</skipIfEmpty>
                                 <includes>
-                                    <include>org/nd4j/nativeblas/${javacpp.platform}${javacpp.extension}/*</include>
+                                    <include>org/nd4j/nativeblas/${javacpp.platform}${javacpp.platform.extension}/*</include>
                                     <include>lib/**</include>
                                 </includes>
                             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -553,10 +553,10 @@
         <javacpp.version>1.3.4-SNAPSHOT</javacpp.version>
         <javacpp-presets.version>1.3</javacpp-presets.version>
         <process-classes.skip> false</process-classes.skip>  <!-- To skip native compilation phase: -Dprocess-classes.skip=true    -->
-        <javacpp.extension />
         <javacpp.platform>${os.name}-${os.arch}</javacpp.platform> <!-- For Android: -Dplatform=android-arm                                        -->
         <javacpp.platform.root />            <!--              -Dplatform.root=/path/to/android-ndk/                         -->
         <javacpp.platform.compiler />    <!--              -Dplatform.compiler=/path/to/arm-linux-androideabi-g++        -->
+        <javacpp.platform.extension />
         <spark.version>1.6.3</spark.version>
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <sbt-compiler-maven-plugin.version>1.0.0-beta8</sbt-compiler-maven-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add necessary modifications to support AVX2 and to build on AppVeyor and Travis CI.

## How was this patch tested?

Builds and runs fine locally, but wait until we get the green light from the CI services before merging.