### PR TITLE
Pooling Divisor

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
@@ -79,8 +79,8 @@ public class Pooling2D extends DynamicCustomOp {
         addIArgument(config.getDh());
         addIArgument(config.getDw());
         addIArgument(ArrayUtil.fromBoolean(config.isSameMode()));
+        addIArgument(config.getDivisor().ordinal());    //TODO is it 0-2 or 1-3 here???
         addIArgument((int) config.getExtra());
-        addIArgument(config.getDivisor().ordinal());
     }
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
@@ -34,6 +34,16 @@ public class Pooling2D extends DynamicCustomOp {
         MAX, AVG, PNORM,
     }
 
+    /**
+     * Divisor mode for average pooling only. 3 modes are supported:
+     * MODE_0:
+     * MODE_1:
+     * INCLUDE_PADDING: Always do sum(window) / (kH*kW) even if padding is present.
+     */
+    public enum Divisor {
+        MODE_0, MODE_1, INCLUDE_PADDING
+    }
+
     public Pooling2D() {}
 
     @Builder(builderMethodName = "builder")
@@ -70,7 +80,7 @@ public class Pooling2D extends DynamicCustomOp {
         addIArgument(config.getDw());
         addIArgument(ArrayUtil.fromBoolean(config.isSameMode()));
         addIArgument((int) config.getExtra());
-
+        addIArgument(config.getDivisor().ordinal());
     }
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
@@ -79,8 +79,8 @@ public class Pooling2D extends DynamicCustomOp {
         addIArgument(config.getDh());
         addIArgument(config.getDw());
         addIArgument(ArrayUtil.fromBoolean(config.isSameMode()));
-        addIArgument(config.getDivisor().ordinal());    //TODO is it 0-2 or 1-3 here???
-        addIArgument((int) config.getExtra());
+        addIArgument((config.getType() == Pooling2DType.AVG) ? config.getDivisor().ordinal() : (int)config.getExtra());
+        addIArgument(ArrayUtil.fromBoolean(config.isNHWC()));
     }
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/config/Pooling2DConfig.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/config/Pooling2DConfig.java
@@ -21,6 +21,7 @@ public class Pooling2DConfig {
      */
     private double extra;
     private Pooling2D.Pooling2DType type;
+    @Builder.Default private Pooling2D.Divisor divisor = Pooling2D.Divisor.MODE_0;
     private boolean isSameMode;
     @Builder.Default private int dh = 1;
     @Builder.Default private int dw = 1;

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/convolution/Convolution.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/convolution/Convolution.java
@@ -234,8 +234,8 @@ public class Convolution {
      * @return
      */
     public static INDArray pooling2D(INDArray img, int kh, int kw, int sy, int sx, int ph, int pw,
-                                     int dh, int dw, boolean isSameMode, Pooling2D.Pooling2DType type, double extra, int virtualHeight, int virtualWidth,
-                                     INDArray out) {
+                                     int dh, int dw, boolean isSameMode, Pooling2D.Pooling2DType type, Pooling2D.Divisor divisor,
+                                     double extra, int virtualHeight, int virtualWidth, INDArray out) {
         Pooling2D pooling = Pooling2D.builder()
                 .arrayInputs(new INDArray[]{img})
                 .arrayOutputs(new INDArray[] {out})
@@ -253,6 +253,7 @@ public class Convolution {
                         .virtualHeight(virtualHeight)
                         .virtualWidth(virtualWidth)
                         .type(type)
+                        .divisor(divisor)
                         .build())
                 .build();
         Nd4j.getExecutioner().exec(pooling);

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTestsC.java
@@ -235,19 +235,22 @@ public class ConvolutionTestsC extends BaseNd4jTest {
                                                             Transforms.pow(reduced, (1.0 / pnorm), false);
 
                                                             Convolution.pooling2D(in, kh, kw, sh, sw, ph, pw, 1, 1,
-                                                                    true, Pooling2D.Pooling2DType.PNORM, (double) pnorm, outSize[0], outSize[1], output);
+                                                                    true, Pooling2D.Pooling2DType.PNORM, Pooling2D.Divisor.INCLUDE_PADDING,
+                                                                    (double) pnorm, outSize[0], outSize[1], output);
 
                                                             break;
                                                         case MAX:
                                                             Convolution.pooling2D(in, kh, kw, sh, sw, ph, pw,1, 1,
-                                                                    true, Pooling2D.Pooling2DType.MAX, 0.0, outSize[0], outSize[1], output);
+                                                                    true, Pooling2D.Pooling2DType.MAX, Pooling2D.Divisor.INCLUDE_PADDING,
+                                                                    0.0, outSize[0], outSize[1], output);
 
                                                             reduced = col2d.max(1);
                                                             break;
                                                         case AVG:
 
                                                             Convolution.pooling2D(in, kh, kw, sh, sw, ph, pw, 1, 1,
-                                                                    true, Pooling2D.Pooling2DType.AVG, 0.0, outSize[0], outSize[1], output);
+                                                                    true, Pooling2D.Pooling2DType.AVG, Pooling2D.Divisor.INCLUDE_PADDING,
+                                                                    0.0, outSize[0], outSize[1], output);
 
                                                             reduced = col2d.mean(1);
                                                             break;


### PR DESCRIPTION
Aims to address: https://github.com/deeplearning4j/deeplearning4j/issues/4492

Should be merged at same time as DL4J changes.

Adds Divisor enum for pooling divisor.

Only test is failing: ConvolutionTestsC.testPooling2D_1()
Note that DL4J pooling + same mode tests are also failing here: https://github.com/deeplearning4j/deeplearning4j/pull/4495