### PR TITLE
Fixes for dilated pooling; tests for max pooling backprop

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
@@ -37,11 +37,11 @@ public class Pooling2D extends DynamicCustomOp {
     /**
      * Divisor mode for average pooling only. 3 modes are supported:
      * MODE_0:
-     * MODE_1:
+     * EXCLUDE_PADDING:
      * INCLUDE_PADDING: Always do sum(window) / (kH*kW) even if padding is present.
      */
     public enum Divisor {
-        MODE_0, MODE_1, INCLUDE_PADDING
+        MODE_0, EXCLUDE_PADDING, INCLUDE_PADDING
     }
 
     public Pooling2D() {}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling2D.java
@@ -41,7 +41,7 @@ public class Pooling2D extends DynamicCustomOp {
      * INCLUDE_PADDING: Always do sum(window) / (kH*kW) even if padding is present.
      */
     public enum Divisor {
-        MODE_0, EXCLUDE_PADDING, INCLUDE_PADDING
+        EXCLUDE_PADDING, INCLUDE_PADDING
     }
 
     public Pooling2D() {}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/config/Pooling2DConfig.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/config/Pooling2DConfig.java
@@ -21,7 +21,7 @@ public class Pooling2DConfig {
      */
     private double extra;
     private Pooling2D.Pooling2DType type;
-    @Builder.Default private Pooling2D.Divisor divisor = Pooling2D.Divisor.MODE_0;
+    @Builder.Default private Pooling2D.Divisor divisor = Pooling2D.Divisor.EXCLUDE_PADDING;
     private boolean isSameMode;
     @Builder.Default private int dh = 1;
     @Builder.Default private int dw = 1;

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTests.java
@@ -2056,15 +2056,15 @@ public class ConvolutionTests extends BaseNd4jTest {
                         {(2+12), (1+3+11+13), (2+4+12+14), (3+5+13+15),  (4+14)},
                         {(7+17), (6+8+16+18), (7+9+17+19), (8+10+18+20), (9+19)},
                         {12,     (11+13),     (12+14),     (13+15),      14}}));
-        INDArray expAvg_1 = sum.dup();
-        expAvg_1.get(point(0), point(0), all(), all()).divi(
+        INDArray expAvgExclude = sum.dup();
+        expAvgExclude.get(point(0), point(0), all(), all()).divi(
                 Nd4j.create(new double[][]{
                         { 1,  2,  2,  2,  1},
                         { 2,  4,  4,  4,  2},
                         { 2,  4,  4,  4,  2},
                         { 1,  2,  2,  2,  1}}));
 
-        INDArray expAvg_2 = sum.div(4.0);
+        INDArray expAvgInclude = sum.div(4.0);
 
 
         int testNum = 0;
@@ -2091,25 +2091,18 @@ public class ConvolutionTests extends BaseNd4jTest {
                         exp = expMax;
                         mode = "max";
                         break;
-                    case 1: //Avg + mode 0 (include padding) - same as mode 2 in this particular case
-                        Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
-                                same, Pooling2D.Pooling2DType.AVG, Pooling2D.Divisor.MODE_0,
-                                0.0, outH, outW, out);
-                        exp = expAvg_2;
-                        mode = "avg_0";
-                        break;
-                    case 2: //Avg + mode 1 (exclude padding)
+                    case 1: //Avg + mode 0 (exclude padding)
                         Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
                                 same, Pooling2D.Pooling2DType.AVG, Pooling2D.Divisor.EXCLUDE_PADDING,
                                 0.0, outH, outW, out);
-                        exp = expAvg_1;
-                        mode = "avg_1";
+                        exp = expAvgExclude;
+                        mode = "avg_0";
                         break;
-                    case 3: //Avg + mode 2
+                    case 2: //Avg + mode 1 (include padding)
                         Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
                                 same, Pooling2D.Pooling2DType.AVG, Pooling2D.Divisor.INCLUDE_PADDING,
                                 0.0, outH, outW, out);
-                        exp = expAvg_2;
+                        exp = expAvgInclude;
                         mode = "avg_2";
                         break;
                     default:

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTests.java
@@ -29,12 +29,16 @@ import org.nd4j.linalg.api.buffer.util.AllocUtil;
 import org.nd4j.linalg.api.buffer.util.DataTypeUtil;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.Pooling2D;
+import org.nd4j.linalg.checkutil.NDArrayCreationUtil;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 import org.nd4j.linalg.indexing.NDArrayIndex;
+import org.nd4j.linalg.primitives.Pair;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -1977,6 +1981,132 @@ public class ConvolutionTests extends BaseNd4jTest {
             INDArray out = op.getOutputArgument(0);
 
             assertEquals("Output order: " + outputOrder, exp, out);
+        }
+    }
+
+
+
+    @Test
+    public void testPoolingDilation(){
+
+        int[] inputShape = {1, 1, 4, 5};
+        int outH = inputShape[2];
+        int outW = inputShape[3];
+
+        int[] kernel = {2, 2};
+        int[] strides = {1, 1};
+        int[] pad = {0, 0};
+        int[] dilation = {2, 2};
+        boolean same = true;
+
+        /*
+        Input:
+        [ 1,  2,  3,  4,  5
+          6,  7,  8,  9, 10
+         11, 12, 13, 14, 15
+         16, 17, 18, 19, 20 ]
+
+        Input with SAME padding:
+        [ 0,  0,  0,  0,  0,  0,  0
+          0,  1,  2,  3,  4,  5,  0
+          0,  6,  7,  8,  9, 10,  0
+          0, 11, 12, 13, 14, 15,  0
+          0, 16, 17, 18, 19, 20,  0
+          0,  0,  0,  0,  0,  0,  0]
+
+         4x5 in
+         Same mode, stride 1, dilation 2, kernel 2
+         kHEffective = (2 + (2-1)*(2-1)) = 3
+         oH = ceil(iH/sH) = 4
+         oW = ceil(iW/sW) = 5
+         totalPadH = (oH-1)*sH + kH - inH = (4-1)*1 + 3 - 4 = 2
+         padTop = 1, padBottom = 1
+
+         totalPadW = (oW-1)*sW + kW - inW = (5-1)*1 + 3 - 5 = 2
+         padLeft = 1, padRight = 1
+
+        [ 0,  0]    [ 0,  0]    [ 0,  0]    [ 0,  0]    [ 0,  0]
+        [ 0,  6]    [ 6,  8]    [ 7,  9]    [ 8, 10]    [ 9,  0]
+
+        [ 0   2]    [ 1,  3]    [ 2,  4]    [ 3,  5]    [ 4,  0]
+        [ 0, 12]    [11, 13]    [12, 14]    [13, 15]    [14,  0]
+
+        [ 0,  7]    [ 6,  8]    [ 7,  9]    [ 9, 10]    [ 9,  0]
+        [ 0, 17]    [16, 18]    [17, 19]    [18, 20]    [19,  0]
+
+        [ 0, 12]    [11, 13]    [12, 14]    [13, 15]    [14,  0]
+        [ 0,  0],   [ 0,  0]    [ 0,  0]    [ 0,  0]    [ 0,  0]
+
+
+
+         */
+
+
+        INDArray expMax = Nd4j.create(1,1,4,5);
+        expMax.get(point(0), point(0), all(), all()).assign(
+                Nd4j.create(new double[][]{
+                        { 6,  8,  9, 10,  9},
+                        {12, 13, 14, 15, 14},
+                        {17, 18, 19, 20, 19},
+                        {12, 13, 14, 15, 14}}));
+
+        INDArray sum = Nd4j.create(1,1,4,5);
+        sum.get(point(0), point(0), all(), all()).assign(
+                Nd4j.create(new double[][]{
+                        { 6,     (6+8),       (7+9),       (8+10),       9},
+                        {(2+12), (1+3+11+13), (2+4+12+14), (3+5+13+15),  (4+14)},
+                        {(7+17), (6+8+16+18), (7+9+17+19), (9+10+18+20), (9+19)},
+                        {12,     (11+13),     (12+14),     (13+15),      14}}));
+        INDArray expAvg_0 = sum.get(point(0), point(0), all(), all()).div(
+                Nd4j.create(new double[][]{
+                        { 1,  2,  2,  2,  1},
+                        { 2,  4,  4,  4,  2},
+                        { 2,  4,  4,  4,  2},
+                        { 1,  2,  2,  2,  1}}));
+
+        INDArray expAvg_2 = sum.div(4.0);
+
+
+        for( int i=0; i<3; i++ ){
+
+
+            List<Pair<INDArray, String>> inputs = NDArrayCreationUtil.getAll4dTestArraysWithShape(12345, inputShape);
+
+            for(Pair<INDArray,String> pIn : inputs){
+                INDArray input = pIn.getFirst();
+
+                INDArray out = Nd4j.create(input.shape(), 'c');
+
+                //TODO Test on weird strides also (i.e., remove the dup here)
+                input = input.dup('c');
+
+                INDArray exp;
+                switch (i){
+                    case 0: //Max
+                        Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
+                                same, Pooling2D.Pooling2DType.MAX, Pooling2D.Divisor.INCLUDE_PADDING,
+                                0.0, outH, outW, out);
+                        exp = expMax;
+                        break;
+                    case 1: //Avg + mode 0
+                        Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
+                                same, Pooling2D.Pooling2DType.AVG, Pooling2D.Divisor.MODE_0,
+                                0.0, outH, outW, out);
+                        exp = expAvg_0;
+                        break;
+                    case 2: //Avg + mode 2
+                        Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
+                                same, Pooling2D.Pooling2DType.AVG, Pooling2D.Divisor.INCLUDE_PADDING,
+                                0.0, outH, outW, out);
+                        exp = expAvg_2;
+                        break;
+                    default:
+                        throw new RuntimeException();
+                }
+
+                String msg = pIn.getSecond();
+                assertEquals(msg, exp, out);
+            }
         }
     }
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTestsC.java
@@ -381,7 +381,7 @@ public class ConvolutionTestsC extends BaseNd4jTest {
 
                     //Runs fine with dups:
 //                    input = input.dup('c');
-//                    epsilon = epsilon.dup('c');
+                    epsilon = epsilon.dup('c');
 
                     DynamicCustomOp op = DynamicCustomOp.builder(fn)
                             .addInputs(input, epsilon)
@@ -401,6 +401,7 @@ public class ConvolutionTestsC extends BaseNd4jTest {
     }
 
     public static INDArray expGradMaxPoolBackPropSame(INDArray input, INDArray gradient, int[] k, int[] s, boolean same){
+        input = input.dup();
         if(!same){
             throw new UnsupportedOperationException("non-Same mode not yet supported here");
         }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/convolution/ConvolutionTestsC.java
@@ -424,7 +424,7 @@ public class ConvolutionTestsC extends BaseNd4jTest {
 
                         //First: work out the *original* position for this kernel...
                         int kTLy = y*s[0] - topPad;
-                        int kTLx = x*s[0] - leftPad;
+                        int kTLx = x*s[1] - leftPad;
 
                         int[] maxPos = {kTLy,kTLx};
                         double max = -Double.MAX_VALUE;


### PR DESCRIPTION
***WIP DO NOT MERGE***

Should only be merged at the same time as the Libnd4j PR:
https://github.com/deeplearning4j/libnd4j/pull/701
(DL4J doesn't need any changes, it seems).

Note that this switches back to 2 divisor modes only: include padding or exclude padding

Why the 2 divisor modes? Simple - there's no reasonable interpretation under which the pytorch SpatialAveragePooling mode can be considered correct.
https://github.com/pytorch/pytorch/blob/6cda6bb34c7f472f031f76c46d64e513d13c615d/torch/lib/THNN/generic/SpatialAveragePooling.c#L165-L180
Note that when count_include_pad is true, the bottom/right padding is still actually excluded from the count (i.e., the *min* op should only be applied *after* the the initial pool_size value is calculated).

One consequence is that some of the comparison tests fail - and I'm 100% fine with that.
![image](https://user-images.githubusercontent.com/2360237/34901073-b95e8e78-f859-11e7-9854-51020484f234.png)
