### PR TITLE
SameDiff: Map more ops already available in libnd4j

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -290,6 +290,10 @@ public class DifferentialFunctionFactory   {
 
     }
 
+    public SDVariable atan2(SDVariable y, SDVariable x){
+        return new ATan2(sameDiff(), y, x).outputVariables()[0];
+    }
+
 
     public SDVariable cosh(SDVariable iX) {
         return new Cosh(sameDiff(),iX,null).outputVariables()[0];

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -17,6 +17,7 @@ import org.nd4j.linalg.api.ops.impl.shape.*;
 import org.nd4j.linalg.api.ops.impl.transforms.*;
 import org.nd4j.linalg.api.ops.impl.transforms.SoftMaxDerivative;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.*;
+import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.AddBpOp;
 import org.nd4j.linalg.api.ops.impl.transforms.clip.ClipByNorm;
 import org.nd4j.linalg.api.ops.impl.transforms.clip.ClipByValue;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.*;
@@ -27,9 +28,7 @@ import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.util.ArrayUtil;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 /**
  *
@@ -767,7 +766,11 @@ public class DifferentialFunctionFactory   {
     public SDVariable addi(SDVariable differentialFunction, SDVariable i_v) {
         validateDifferentialFunctionsameDiff(differentialFunction);
         return new AddOp(sameDiff(),new SDVariable[]{differentialFunction,i_v},true).outputVariables()[0];
+    }
 
+    public List<SDVariable> addBp(SDVariable x, SDVariable y, SDVariable grad){
+        SDVariable[] ret = new AddBpOp(sameDiff(), x, y, grad).outputVariables();
+        return Arrays.asList(ret);
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -406,6 +406,14 @@ public class DifferentialFunctionFactory   {
         return new Floor(sameDiff(),iX,null).outputVariables()[0];
     }
 
+    public SDVariable ceil(SDVariable x){
+        return new Ceil(sameDiff(), x).outputVariables()[0];
+    }
+
+    public SDVariable clipByValue(SDVariable x, double clipValueMin, double clipValueMax){
+        return new ClipByValue(sameDiff(), x, clipValueMin, clipValueMax).outputVariables()[0];
+    }
+
 
     public SDVariable relu(SDVariable iX, double cutoff) {
         return new RectifedLinear(sameDiff(),iX,false,cutoff).outputVariables()[0];

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -558,6 +558,10 @@ public class DifferentialFunctionFactory   {
         return new RollAxis(sameDiff(),iX,axis).outputVariables()[0];
     }
 
+    public SDVariable concat(int dimension, SDVariable... inputs){
+        return new Concat(sameDiff(), dimension, inputs).outputVariables()[0];
+    }
+
 
     public SDVariable cosineSimilarity(SDVariable iX, SDVariable i_y, int... dimensions) {
         return new CosineSimilarity(sameDiff(),iX,i_y,dimensions).outputVariables()[0];

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -17,10 +17,7 @@ import org.nd4j.linalg.api.ops.impl.shape.*;
 import org.nd4j.linalg.api.ops.impl.transforms.*;
 import org.nd4j.linalg.api.ops.impl.transforms.SoftMaxDerivative;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.*;
-import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.AddBpOp;
-import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.DivBpOp;
-import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.FloorDivBpOp;
-import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.FloorModBpOp;
+import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.*;
 import org.nd4j.linalg.api.ops.impl.transforms.clip.ClipByNorm;
 import org.nd4j.linalg.api.ops.impl.transforms.clip.ClipByValue;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.*;
@@ -753,11 +750,18 @@ public class DifferentialFunctionFactory   {
         return new RSubOp(sameDiff(),differentialFunction,i_v).outputVariables()[0];
     }
 
+    public List<SDVariable> rsubBp(SDVariable x, SDVariable y, SDVariable grad){
+        return Arrays.asList(new RSubBpOp(sameDiff(), x, y, grad).outputVariables());
+    }
+
 
     public SDVariable rdiv(SDVariable differentialFunction, SDVariable i_v) {
         validateDifferentialFunctionsameDiff(differentialFunction);
         return new RDivOp(sameDiff(),new SDVariable[]{differentialFunction,i_v},false).outputVariables()[0];
+    }
 
+    public List<SDVariable> rdivBp(SDVariable x, SDVariable y, SDVariable grad){
+        return Arrays.asList(new RDivBpOp(sameDiff(),x,y,grad).outputVariables());
     }
 
 
@@ -796,7 +800,10 @@ public class DifferentialFunctionFactory   {
     public SDVariable sub(SDVariable differentialFunction, SDVariable i_v) {
         validateDifferentialFunctionsameDiff(differentialFunction);
         return new SubOp(sameDiff(),new SDVariable[]{differentialFunction,i_v},false).outputVariables()[0];
+    }
 
+    public List<SDVariable> subBp(SDVariable x, SDVariable y, SDVariable grad){
+        return Arrays.asList(new SubBpOp(sameDiff(), x,y,grad).outputVariables());
     }
 
 
@@ -810,7 +817,10 @@ public class DifferentialFunctionFactory   {
     public SDVariable mul(SDVariable differentialFunction, SDVariable i_v) {
         validateDifferentialFunctionsameDiff(differentialFunction);
         return new MulOp(sameDiff(),new SDVariable[]{differentialFunction,i_v},false).outputVariables()[0];
+    }
 
+    public List<SDVariable> mulBp(SDVariable x, SDVariable y, SDVariable grad){
+        return Arrays.asList(new MulBpOp(sameDiff(),x,y,grad).outputVariables());
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -18,6 +18,9 @@ import org.nd4j.linalg.api.ops.impl.transforms.*;
 import org.nd4j.linalg.api.ops.impl.transforms.SoftMaxDerivative;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.*;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.AddBpOp;
+import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.DivBpOp;
+import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.FloorDivBpOp;
+import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp.FloorModBpOp;
 import org.nd4j.linalg.api.ops.impl.transforms.clip.ClipByNorm;
 import org.nd4j.linalg.api.ops.impl.transforms.clip.ClipByValue;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.*;
@@ -405,6 +408,22 @@ public class DifferentialFunctionFactory   {
 
     public SDVariable floor(SDVariable iX) {
         return new Floor(sameDiff(),iX,null).outputVariables()[0];
+    }
+
+    public SDVariable floorDiv(SDVariable x, SDVariable y){
+        return new FloorDivOp(sameDiff(), x, y).outputVariables()[0];
+    }
+
+    public List<SDVariable> floorDivBp(SDVariable x, SDVariable y, SDVariable grad){
+        return Arrays.asList(new FloorDivBpOp(sameDiff(), x, y, grad).outputVariables());
+    }
+
+    public SDVariable floorMod(SDVariable x, SDVariable y){
+        return new FModOp(sameDiff(), x, y).outputVariables()[0];
+    }
+
+    public List<SDVariable> floorModBp(SDVariable x, SDVariable y, SDVariable grad){
+        return Arrays.asList(new FloorModBpOp(sameDiff(), x, y, grad).outputVariables());
     }
 
     public SDVariable ceil(SDVariable x){
@@ -805,6 +824,10 @@ public class DifferentialFunctionFactory   {
     public SDVariable div(SDVariable differentialFunction, SDVariable i_v) {
         validateDifferentialFunctionsameDiff(differentialFunction);
         return new DivOp(sameDiff(),new SDVariable[]{differentialFunction,i_v},false).outputVariables()[0];
+    }
+
+    public List<SDVariable> divBp(SDVariable x, SDVariable y, SDVariable grad){
+        return Arrays.asList(new DivBpOp(sameDiff(),x,y,grad).outputVariables());
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -485,6 +485,10 @@ public class DifferentialFunctionFactory   {
 
     }
 
+    public SDVariable assign(SDVariable x, SDVariable y){
+        return new Assign(sameDiff(),x,y).outputVariables()[0];
+    }
+
 
     public SDVariable softsign(SDVariable iX) {
         return new SoftSign(sameDiff(),iX,null).outputVariables()[0];

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -17,6 +17,8 @@ import org.nd4j.linalg.api.ops.impl.shape.*;
 import org.nd4j.linalg.api.ops.impl.transforms.*;
 import org.nd4j.linalg.api.ops.impl.transforms.SoftMaxDerivative;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.*;
+import org.nd4j.linalg.api.ops.impl.transforms.clip.ClipByNorm;
+import org.nd4j.linalg.api.ops.impl.transforms.clip.ClipByValue;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.*;
 import org.nd4j.linalg.api.ops.impl.transforms.gradient.*;
 import org.nd4j.linalg.api.ops.impl.transforms.gradient.SigmoidDerivative;
@@ -412,6 +414,10 @@ public class DifferentialFunctionFactory   {
 
     public SDVariable clipByValue(SDVariable x, double clipValueMin, double clipValueMax){
         return new ClipByValue(sameDiff(), x, clipValueMin, clipValueMax).outputVariables()[0];
+    }
+
+    public SDVariable clipByNorm(SDVariable x, double clipValue){
+        return new ClipByNorm(sameDiff(), x, clipValue).outputVariables()[0];
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -2048,6 +2048,15 @@ public class SameDiff {
         return updateVariableNameAndReference(ret, name);
     }
 
+    public SDVariable clipByNorm(SDVariable x, double clipValue){
+        return clipByNorm(null, x, clipValue);
+    }
+
+    public SDVariable clipByNorm(String name, SDVariable x, double clipValue){
+        SDVariable ret = f().clipByNorm(x, clipValue);
+        return updateVariableNameAndReference(ret, name);
+    }
+
     /**
      *
      * @param iX

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -2030,6 +2030,24 @@ public class SameDiff {
         return floor(null,iX);
     }
 
+    public SDVariable ceil(SDVariable x){
+        return ceil(null, x);
+    }
+
+    public SDVariable ceil(String name, SDVariable x){
+        SDVariable ret = f().ceil(x);
+        return updateVariableNameAndReference(ret, name);
+    }
+
+    public SDVariable clipByValue(SDVariable x, double clipValueMin, double clipValueMax){
+        return clipByValue(null, x, clipValueMin, clipValueMax);
+    }
+
+    public SDVariable clipByValue(String name, SDVariable x, double clipValueMin, double clipValueMax){
+        SDVariable ret = f().clipByValue(x, clipValueMin, clipValueMax);
+        return updateVariableNameAndReference(ret, name);
+    }
+
     /**
      *
      * @param iX

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -1901,6 +1901,15 @@ public class SameDiff {
         return atan(null,iX);
     }
 
+    public SDVariable atan2(SDVariable y, SDVariable x){
+        return atan2(null, y, x);
+    }
+
+    public SDVariable atan2(String name, SDVariable y, SDVariable x){
+        SDVariable ret = f().atan2(y, x);
+        return updateVariableNameAndReference(ret, name);
+    }
+
     /**
      *
      * @param iX
@@ -4821,7 +4830,7 @@ public class SameDiff {
         }
 
 
-        log.info("Executing op " + differentialFunction.opName());
+//        log.info("Executing op " + differentialFunction.opName());
 
         StringBuilder realShapes = new StringBuilder();
         for(val arg: differentialFunction.args()) {
@@ -4835,7 +4844,7 @@ public class SameDiff {
         }
 
 
-        log.info(realShapes.toString());
+//        log.info(realShapes.toString());
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -4857,7 +4857,7 @@ public class SameDiff {
         }
 
 
-//        log.info("Executing op " + differentialFunction.opName());
+        log.info("Executing op " + differentialFunction.opName());
 
         StringBuilder realShapes = new StringBuilder();
         for(val arg: differentialFunction.args()) {
@@ -4871,7 +4871,7 @@ public class SameDiff {
         }
 
 
-//        log.info(realShapes.toString());
+        log.info(realShapes.toString());
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -2322,6 +2322,15 @@ public class SameDiff {
         return reshape(null,iX,shape);
     }
 
+    public SDVariable assign(SDVariable x, SDVariable y){
+        return assign(null, x, y);
+    }
+
+    public SDVariable assign(String name, SDVariable x, SDVariable y){
+        SDVariable ret = f().assign(x,y);
+        return updateVariableNameAndReference(ret, name);
+    }
+
     /**
      *
      * @param iX

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/DynamicCustomOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/DynamicCustomOp.java
@@ -458,7 +458,7 @@ public class DynamicCustomOp extends DifferentialFunction implements CustomOp {
             throw new ND4JIllegalStateException("Op failure for " + opName() + " Number of inputs is invalid for execution. Specified " + numInputArguments() + " but should be " + descriptor.getNumInputs());
 
         if(descriptor.getNumOutputs() > 0 && numOutputArguments() < descriptor.getNumOutputs())
-            throw new ND4JIllegalStateException("Op failure for " + opName() + " Number of outputs is invalid for execution. Specified " + numOutputArguments() + " but should be " + descriptor.getNumInputs());
+            throw new ND4JIllegalStateException("Op failure for " + opName() + " Number of outputs is invalid for execution. Specified " + numOutputArguments() + " but should be " + descriptor.getNumOutputs());
 
         //< 0 means dynamic size
         if(descriptor.getNumIArgs() >= 0 && numIArguments() < descriptor.getNumIArgs())

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/DynamicCustomOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/DynamicCustomOp.java
@@ -567,7 +567,7 @@ public class DynamicCustomOp extends DifferentialFunction implements CustomOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
-        throw new UnsupportedOperationException("Please extend DynamicCustomOp to run samediff graph operations.");
+        throw new UnsupportedOperationException("Please extend DynamicCustomOp.doDiff to run samediff graph operations.");
     }
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Concat.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Concat.java
@@ -3,6 +3,7 @@ package org.nd4j.linalg.api.ops.impl.shape;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import onnx.OnnxProto3;
+import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.NoOpNameFoundException;
 import org.nd4j.imports.descriptors.properties.PropertyMapping;
@@ -20,6 +21,15 @@ import java.util.Map;
 @Slf4j
 public class Concat extends DynamicCustomOp {
     private int concatDimension;
+
+    public Concat(){
+
+    }
+
+    public Concat(SameDiff sameDiff, int concatDimension, SDVariable... inputs){
+        super(null, sameDiff, inputs);
+        addIArgument(concatDimension);
+    }
 
     @Override
     public String opName() {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/ATan2.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/ATan2.java
@@ -26,6 +26,7 @@ import org.nd4j.imports.NoOpNameFoundException;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseTransformOp;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,16 +36,9 @@ import java.util.List;
  * @author Adam Gibson
  */
 public class ATan2 extends BaseTransformOp {
-    public ATan2(SameDiff sameDiff, SDVariable i_v, boolean inPlace) {
-        super(sameDiff, i_v, inPlace);
-    }
 
-    public ATan2(SameDiff sameDiff, SDVariable i_v, int[] shape, boolean inPlace, Object[] extraArgs) {
-        super(sameDiff, i_v, shape, inPlace, extraArgs);
-    }
-
-    public ATan2(SameDiff sameDiff, SDVariable i_v, Object[] extraArgs) {
-        super(sameDiff, i_v, extraArgs);
+    public ATan2(SameDiff sameDiff, SDVariable y, SDVariable x) {
+        super(sameDiff, x, y );
     }
 
     public ATan2() {}
@@ -89,11 +83,21 @@ public class ATan2 extends BaseTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        val shape = outputVariables()[0].getShape();
+//        SDVariable ret = f().div(f().one(shape),
+//                f().sqrt(f().sub(f().one(shape),f().pow(arg(),2))));
+        //Let z=atan2(r), with r=y/x
+        //dz/dr = 1/(r^2+1), dr/dy = 1/x, dr/dx = -y/x^2
+        SDVariable y = rarg();
+        SDVariable x = larg();
+        SDVariable r = y.div(x);
 
-        SDVariable ret = f().div(f().one(shape),
-                f().sqrt(f().sub(f().one(shape),f().pow(arg(),2))));
+        SDVariable dOutdr = f().square(r).add(1.0).rdiv(1.0);
+        SDVariable drdy = x.rdiv(1.0);
+        SDVariable drdx = f().neg(y).div(f().square(x));
 
-        return Collections.singletonList(ret);
+        SDVariable xGrad = dOutdr.mul(drdx).mul(i_v.get(0));
+        SDVariable yGrad = dOutdr.mul(drdy).mul(i_v.get(0));
+
+        return Arrays.asList(xGrad, yGrad);
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/ATan2.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/ATan2.java
@@ -83,8 +83,6 @@ public class ATan2 extends BaseTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-//        SDVariable ret = f().div(f().one(shape),
-//                f().sqrt(f().sub(f().one(shape),f().pow(arg(),2))));
         //Let z=atan2(r), with r=y/x
         //dz/dr = 1/(r^2+1), dr/dy = 1/x, dr/dx = -y/x^2
         SDVariable y = rarg();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/Assign.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/Assign.java
@@ -9,6 +9,8 @@ import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
 import org.tensorflow.framework.NodeDef;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -53,5 +55,11 @@ public class Assign extends DynamicCustomOp {
     @Override
     public Op.Type opType() {
         return Op.Type.CUSTOM;
+    }
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> f1){
+        //TODO replace with assign backprop op from libnd4j (that handles the broadcast case properly)
+        return Arrays.asList(f().zerosLike(larg()), f1.get(0));
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/Assign.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/Assign.java
@@ -1,6 +1,7 @@
 package org.nd4j.linalg.api.ops.impl.transforms;
 
 import onnx.OnnxProto3;
+import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.ops.Op;
@@ -10,7 +11,18 @@ import org.tensorflow.framework.NodeDef;
 
 import java.util.Map;
 
+/**
+ * Assign op: x = y, with broadcast as required
+ */
 public class Assign extends DynamicCustomOp {
+
+    public Assign(){
+
+    }
+
+    public Assign(SameDiff sameDiff, SDVariable x, SDVariable y){
+        super(null, sameDiff, new SDVariable[]{x,y});
+    }
 
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/BaseDynamicTransformOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/BaseDynamicTransformOp.java
@@ -5,6 +5,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.util.ArrayUtil;
 
 import java.util.Arrays;
@@ -45,12 +46,13 @@ public abstract class BaseDynamicTransformOp extends DynamicCustomOp {
             return Collections.emptyList();
         }
 
+        if(Arrays.equals(firstArgShape, secondArgShape)){
+            return Collections.singletonList(firstArgShape);
+        }
+        //Handle broadcast shape: [1,4]+[3,1] = [3,4]
+        Shape.assertBroadcastable(firstArgShape, secondArgShape);
+        int[] outShape = Shape.broadcastOutputShape(firstArgShape, secondArgShape);
 
-        val firstLength = ArrayUtil.prod(firstArgShape);
-        val secondLength = ArrayUtil.prod(secondArgShape);
-        if(firstLength > secondLength)
-            return Arrays.asList(args[0].getShape());
-        else
-            return Arrays.asList(args[1].getShape());
+        return Collections.singletonList(outShape);
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/Ceil.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/Ceil.java
@@ -24,6 +24,7 @@ import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseTransformOp;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -40,8 +41,8 @@ public class Ceil extends BaseTransformOp {
         super(sameDiff, i_v, shape, inPlace, extraArgs);
     }
 
-    public Ceil(SameDiff sameDiff, SDVariable i_v, Object[] extraArgs) {
-        super(sameDiff, i_v, extraArgs);
+    public Ceil(SameDiff sameDiff, SDVariable i_v) {
+        super(sameDiff, i_v, (Object[])null);
     }
 
     public Ceil() {}
@@ -86,6 +87,7 @@ public class Ceil extends BaseTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
-        return null;
+        //not continuously differentiable, but dOut/dIn = 0 in most places
+        return Collections.singletonList(f().zerosLike(arg()));
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/ClipByValue.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/ClipByValue.java
@@ -1,0 +1,56 @@
+package org.nd4j.linalg.api.ops.impl.transforms;
+
+import onnx.OnnxProto3;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.tensorflow.framework.AttrValue;
+import org.tensorflow.framework.GraphDef;
+import org.tensorflow.framework.NodeDef;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ClipByValue extends DynamicCustomOp {
+
+    private double clipValueMin;
+    private double clipValueMax;
+
+    public ClipByValue(){
+
+    }
+
+    public ClipByValue(SameDiff sameDiff, SDVariable x, double clipValueMin, double clipValueMax){
+        super(null, sameDiff, new SDVariable[]{x});
+        this.clipValueMin = clipValueMin;
+        this.clipValueMax = clipValueMax;
+        addTArgument(clipValueMin, clipValueMax);
+    }
+
+    @Override
+    public String opName() {
+        return "clipbyvalue";
+    }
+
+    @Override
+    public void initFromTensorFlow(NodeDef nodeDef, SameDiff initWith, Map<String, AttrValue> attributesForNode, GraphDef graph) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void initFromOnnx(OnnxProto3.NodeProto node, SameDiff initWith, Map<String, OnnxProto3.AttributeProto> attributesForNode, OnnxProto3.GraphProto graph) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> grad){
+        //dOut/dIn is 0 if clipped, 1 otherwise
+        SDVariable out = outputVariables()[0];
+        SDVariable notClippedLower = f().gt(arg(), clipValueMin);
+        SDVariable notClippedUpper = f().lt(arg(), clipValueMax);
+        SDVariable ret = notClippedLower.mul(notClippedUpper).mul(grad.get(0));
+        return Collections.singletonList(ret);
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/DivOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/DivOp.java
@@ -64,12 +64,7 @@ public class DivOp extends BaseDynamicTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        SDVariable gradWrtX = f().div(i_v.get(0),rarg());
-        SDVariable gradWrtY = f().mul(f().neg(gradWrtX),f().div(larg(),rarg()));
-        List<SDVariable> ret = new ArrayList<>(2);
-        ret.add(gradWrtX);
-        ret.add(gradWrtY);
-        return ret;
+        return f().divBp(larg(), rarg(), i_v.get(0));
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/FModOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/FModOp.java
@@ -95,6 +95,6 @@ public class FModOp extends BaseTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
-        return Arrays.asList(outputVariables()[0]);
+        return f().floorModBp(larg(), rarg(), f1.get(0));
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/FloorDivOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/FloorDivOp.java
@@ -35,6 +35,10 @@ import java.util.List;
 public class FloorDivOp extends BaseDynamicTransformOp {
     public FloorDivOp() {}
 
+    public FloorDivOp(SameDiff sameDiff, SDVariable x, SDVariable y){
+        this(sameDiff, new SDVariable[]{x,y}, false);
+    }
+
     public FloorDivOp( SameDiff sameDiff, SDVariable[] args, boolean inPlace) {
         super(sameDiff, args, inPlace);
     }
@@ -63,13 +67,6 @@ public class FloorDivOp extends BaseDynamicTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        SDVariable gradWrtX = f().div(i_v.get(0),rarg());
-        SDVariable gradWrtY = f().mul(f().neg(gradWrtX),f().div(larg(),rarg()));
-        List<SDVariable> ret = new ArrayList<>(2);
-        ret.add(gradWrtX);
-        ret.add(gradWrtY);
-        return ret;
+        return f().floorDivBp(larg(), rarg(), i_v.get(0));
     }
-
-
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/MulOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/MulOp.java
@@ -66,10 +66,7 @@ public class MulOp  extends BaseDynamicTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        SDVariable g = sameDiff.setupFunction(i_v.get(0));
-        SDVariable gradWrtX = f().mul(g,rarg());
-        SDVariable gradWrtY = f().mul(g,larg());
-        return Arrays.asList(gradWrtX, gradWrtY);
+        return f().mulBp(larg(), rarg(), i_v.get(0));
     }
 
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/RDivOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/RDivOp.java
@@ -62,16 +62,6 @@ public class RDivOp extends BaseDynamicTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        //If y=b/a,then:
-        //dy/db = 1/a
-        //dy/da = -b/a^2
-        SDVariable gradWrtX = f().neg(rarg().div(sameDiff.square(larg())).mul(i_v.get(0)));
-        SDVariable gradWrtY = i_v.get(0).div(larg());
-
-
-        List<SDVariable> ret = new ArrayList<>(2);
-        ret.add(gradWrtX);
-        ret.add(gradWrtY);
-        return ret;
+        return f().rdivBp(larg(), rarg(), i_v.get(0));
     }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/RSubOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/RSubOp.java
@@ -71,12 +71,7 @@ public class RSubOp extends BaseDynamicTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        SDVariable gradWrtX = sameDiff.neg(i_v.get(0));
-        SDVariable gradWrtY = i_v.get(0);
-        List<SDVariable> ret = new ArrayList<>(2);
-        ret.add(gradWrtX);
-        ret.add(gradWrtY);
-        return ret;
+        return f().rsubBp(larg(), rarg(), i_v.get(0));
     }
 
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/SubOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/SubOp.java
@@ -64,12 +64,7 @@ public class SubOp extends BaseDynamicTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        SDVariable gradWrtX = i_v.get(0);
-        SDVariable gradWrtY = f().neg(i_v.get(0));
-        List<SDVariable> ret = new ArrayList<>();
-        ret.add(gradWrtX);
-        ret.add(gradWrtY);
-        return ret;
+        return f().subBp(larg(), rarg(), i_v.get(0));
     }
 
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/AddBpOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/AddBpOp.java
@@ -17,7 +17,7 @@
  *
  */
 
-package org.nd4j.linalg.api.ops.impl.transforms.arithmetic;
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
 
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
@@ -29,45 +29,20 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Addition operation
+ * Addition backprop operation. Supports 'undoing' of auto broadcast as applied in add op forward pass
  *
- * @author Adam Gibson
+ * @author Alex Black
  */
-public class AddOp extends BaseDynamicTransformOp {
+public class AddBpOp extends BaseArithmeticBackpropOp {
 
-    public AddOp() {}
+    public AddBpOp() {}
 
-    public AddOp( SameDiff sameDiff, SDVariable[] args, boolean inPlace) {
-        super(sameDiff, args, inPlace);
-    }
-
-    public AddOp( INDArray[] inputs, INDArray[] outputs) {
-        super(inputs, outputs);
+    public AddBpOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, x,y,eps);
     }
 
     @Override
     public String opName() {
-        return "add";
+        return "add_bp";
     }
-
-
-    @Override
-    public String onnxName() {
-        return "Add";
-    }
-
-    @Override
-    public String tensorflowName() {
-        return "Add";
-    }
-
-
-
-
-    @Override
-    public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        return f().addBp(larg(), rarg(), i_v.get(0));
-    }
-
-
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/BaseArithmeticBackpropOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/BaseArithmeticBackpropOp.java
@@ -17,57 +17,36 @@
  *
  */
 
-package org.nd4j.linalg.api.ops.impl.transforms.arithmetic;
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
 
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
-import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.BaseDynamicTransformOp;
+import org.nd4j.linalg.factory.Nd4j;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
- * Addition operation
+ * Base arithmetic backprop operation
  *
- * @author Adam Gibson
+ * @author Alex Black
  */
-public class AddOp extends BaseDynamicTransformOp {
+public abstract class BaseArithmeticBackpropOp extends BaseDynamicTransformOp {
 
-    public AddOp() {}
+    public BaseArithmeticBackpropOp() {}
 
-    public AddOp( SameDiff sameDiff, SDVariable[] args, boolean inPlace) {
-        super(sameDiff, args, inPlace);
+    public BaseArithmeticBackpropOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, new SDVariable[]{x,y,eps}, false);
     }
-
-    public AddOp( INDArray[] inputs, INDArray[] outputs) {
-        super(inputs, outputs);
-    }
-
-    @Override
-    public String opName() {
-        return "add";
-    }
-
-
-    @Override
-    public String onnxName() {
-        return "Add";
-    }
-
-    @Override
-    public String tensorflowName() {
-        return "Add";
-    }
-
-
-
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        return f().addBp(larg(), rarg(), i_v.get(0));
+        throw new UnsupportedOperationException("Not supported");
     }
 
+    @Override
+    public List<int[]> calculateOutputShape(){
+        return Nd4j.getExecutioner().calculateOutputShape(this);
+    }
 
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/DivBpOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/DivBpOp.java
@@ -1,0 +1,42 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+
+/**
+ * Division backprop operation. Supports 'undoing' of auto broadcast as applied in div op forward pass
+ *
+ * @author Alex Black
+ */
+public class DivBpOp extends BaseArithmeticBackpropOp {
+
+    public DivBpOp() {}
+
+    public DivBpOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, x,y,eps);
+    }
+
+    @Override
+    public String opName() {
+        return "divide_bp";
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/FloorDivBpOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/FloorDivBpOp.java
@@ -1,0 +1,42 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+
+/**
+ * Floor div backprop operation. Supports 'undoing' of auto broadcast as applied in floor div op forward pass
+ *
+ * @author Alex Black
+ */
+public class FloorDivBpOp extends BaseArithmeticBackpropOp {
+
+    public FloorDivBpOp() {}
+
+    public FloorDivBpOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, x,y,eps);
+    }
+
+    @Override
+    public String opName() {
+        return "floordiv_bp";
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/FloorModBpOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/FloorModBpOp.java
@@ -1,0 +1,42 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+
+/**
+ * Floor div backprop operation. Supports 'undoing' of auto broadcast as applied in floor div op forward pass
+ *
+ * @author Alex Black
+ */
+public class FloorModBpOp extends BaseArithmeticBackpropOp {
+
+    public FloorModBpOp() {}
+
+    public FloorModBpOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, x,y,eps);
+    }
+
+    @Override
+    public String opName() {
+        return "floormod_bp";
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/MulBpOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/MulBpOp.java
@@ -1,0 +1,42 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+
+/**
+ * Division backprop operation. Supports 'undoing' of auto broadcast as applied in div op forward pass
+ *
+ * @author Alex Black
+ */
+public class MulBpOp extends BaseArithmeticBackpropOp {
+
+    public MulBpOp() {}
+
+    public MulBpOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, x,y,eps);
+    }
+
+    @Override
+    public String opName() {
+        return "multiply_bp";
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/RDivBpOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/RDivBpOp.java
@@ -1,0 +1,42 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+
+/**
+ * Division backprop operation. Supports 'undoing' of auto broadcast as applied in div op forward pass
+ *
+ * @author Alex Black
+ */
+public class RDivBpOp extends BaseArithmeticBackpropOp {
+
+    public RDivBpOp() {}
+
+    public RDivBpOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, x,y,eps);
+    }
+
+    @Override
+    public String opName() {
+        return "reversedivide_bp";
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/RSubBpOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/RSubBpOp.java
@@ -1,0 +1,42 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+
+/**
+ * Division backprop operation. Supports 'undoing' of auto broadcast as applied in div op forward pass
+ *
+ * @author Alex Black
+ */
+public class RSubBpOp extends BaseArithmeticBackpropOp {
+
+    public RSubBpOp() {}
+
+    public RSubBpOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, x,y,eps);
+    }
+
+    @Override
+    public String opName() {
+        return "reversesubtract_bp";
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/SubBpOp.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/arithmetic/bp/SubBpOp.java
@@ -1,0 +1,42 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.arithmetic.bp;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+
+/**
+ * Division backprop operation. Supports 'undoing' of auto broadcast as applied in div op forward pass
+ *
+ * @author Alex Black
+ */
+public class SubBpOp extends BaseArithmeticBackpropOp {
+
+    public SubBpOp() {}
+
+    public SubBpOp(SameDiff sameDiff, SDVariable x, SDVariable y, SDVariable eps) {
+        super(sameDiff, x,y,eps);
+    }
+
+    @Override
+    public String opName() {
+        return "subtract_bp";
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/clip/ClipByNorm.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/clip/ClipByNorm.java
@@ -1,0 +1,71 @@
+package org.nd4j.linalg.api.ops.impl.transforms.clip;
+
+import onnx.OnnxProto3;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.shape.Shape;
+import org.tensorflow.framework.AttrValue;
+import org.tensorflow.framework.GraphDef;
+import org.tensorflow.framework.NodeDef;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ClipByNorm extends DynamicCustomOp {
+
+    private double clipValue;
+
+    public ClipByNorm(){
+
+    }
+
+    public ClipByNorm(SameDiff sameDiff, SDVariable x, double clipValue, int... dimensions){
+        super(null, sameDiff, new SDVariable[]{x});
+        this.clipValue = clipValue;
+        this.dimensions = dimensions;
+        addIArgument(dimensions);
+        addTArgument(clipValue);
+    }
+
+    @Override
+    public String opName() {
+        return "clipbynorm";
+    }
+
+    @Override
+    public void initFromTensorFlow(NodeDef nodeDef, SameDiff initWith, Map<String, AttrValue> attributesForNode, GraphDef graph) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void initFromOnnx(OnnxProto3.NodeProto node, SameDiff initWith, Map<String, OnnxProto3.AttributeProto> attributesForNode, OnnxProto3.GraphProto graph) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> grad){
+        //dOut/dIn is ??? if clipped, 1 otherwise
+        int origRank = Shape.rankFromShape(arg().getShape());
+        SDVariable l2norm = f().norm2(arg(), dimensions);
+        SDVariable broadcastableNorm = f().reductionBroadcastableWithOrigShape(origRank, dimensions, l2norm);
+        SDVariable isClippedBC = f().gte(broadcastableNorm, clipValue);
+        SDVariable notClippedBC = isClippedBC.rsub(1.0);
+
+        SDVariable dnormdx = arg().div(broadcastableNorm);
+        SDVariable sqNorm = f().square(broadcastableNorm);
+//        SDVariable dOutdInClipped = sqNorm.rdiv(-1).mul(dnormdx).mul(arg()) //-1/(norm2(x))^2 * x/norm2(x)
+//                .add(broadcastableNorm.rdiv(1.0))
+//                .mul(clipValue);
+
+        SDVariable dOutdInClipped = f().neg(f().square(arg()).div(f().cube(broadcastableNorm))) //-x^2/(norm2(x))^3
+                .add(broadcastableNorm.rdiv(1.0))   //+ 1/norm(x)
+                .mul(clipValue).mul(isClippedBC);
+
+
+        SDVariable ret = notClippedBC.add(dOutdInClipped).mul(grad.get(0));
+        return Collections.singletonList(ret);
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/clip/ClipByValue.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/clip/ClipByValue.java
@@ -1,4 +1,4 @@
-package org.nd4j.linalg.api.ops.impl.transforms;
+package org.nd4j.linalg.api.ops.impl.transforms.clip;
 
 import onnx.OnnxProto3;
 import org.nd4j.autodiff.samediff.SDVariable;

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
@@ -21,6 +21,7 @@ package org.nd4j.linalg.api.shape;
 
 
 import com.google.common.primitives.Ints;
+import lombok.NonNull;
 import lombok.val;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.complex.IComplexNDArray;
@@ -133,6 +134,7 @@ public class Shape {
      * @return
      */
     public static int[] broadcastOutputShape(int[] left,int[] right) {
+        assertBroadcastable(left, right);
         if(Arrays.equals(left,right))
             return left;
         int n = Math.max(left.length,right.length);
@@ -2436,5 +2438,29 @@ public class Shape {
             throw new ND4JIllegalStateException("Cannot get rank from null shape array");
         }
         return shape.length;
+    }
+
+    public static void assertBroadcastable(@NonNull INDArray x, @NonNull INDArray y){
+        assertBroadcastable(x.shape(), y.shape());
+    }
+
+    public static void assertBroadcastable(@NonNull int[] x, @NonNull int[] y){
+        if(!areShapesBroadcastable(x, y)){
+            throw new ND4JIllegalStateException("Arrays are different shape and are not broadcastable." +
+                    " Array 1 shape = " + Arrays.toString(x) + ", array 2 shape = " + Arrays.toString(y));
+        }
+    }
+
+    public static boolean areShapesBroadcastable(@NonNull int[] x, @NonNull int[] y){
+        //Ported from: https://github.com/deeplearning4j/libnd4j/blob/master/include/helpers/impl/ShapeUtils.cpp
+
+        int minRank = Math.min(x.length, y.length);
+        for( int i=-1; i>= -minRank; i--){
+            if(x[x.length + i] != y[y.length + i] && x[x.length + i] != 1 && y[y.length + i] != 1){
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckMisc.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckMisc.java
@@ -208,7 +208,7 @@ public class GradCheckMisc {
             int[] in2Shape = {3, 4, 5};
             in2Shape[dim_sz1] = 1;
 
-            for (int i = 0; i < 8; i++) {
+            for (int i = 2; i < 3; i++) {
 
                 SameDiff sd = SameDiff.create();
 
@@ -293,40 +293,56 @@ public class GradCheckMisc {
 
         List<String> allFailed = new ArrayList<>();
 
-        for (int[] dim_sz1s : new int[][]{{0, 1}, {0, 2}, {1, 2}}) {
+        for (int[] dim_sz1s : new int[][]{{0, 1}, {0, 2}, {1, 2}, {0,1,2}}) {
 
-            int[] in1Shape = {3, 4, 5};
-            in1Shape[dim_sz1s[0]] = 1;
-            in1Shape[dim_sz1s[1]] = 1;
+            int[] otherShape = {3, 4, 5};
+            otherShape[dim_sz1s[0]] = 1;
+            otherShape[dim_sz1s[1]] = 1;
+            if(dim_sz1s.length == 3){
+                otherShape[dim_sz1s[2]] = 1;
+            }
 
             for (int i = 0; i < 6; i++) {
 
                 SameDiff sd = SameDiff.create();
 
-                int nOut = 4;
-                int minibatch = 10;
-                SDVariable in3 = sd.var("in3", Nd4j.rand(new int[]{3, 4, 5}));
-                SDVariable in2 = sd.var("in2", in1Shape);
+                SDVariable in3 = sd.var("in3", new int[]{3, 4, 5});
+                SDVariable in2 = sd.var("inToBc", otherShape);
 
+                String name;
                 SDVariable bcOp;
                 switch (i) {
                     case 0:
                         bcOp = in3.add(in2);
+                        name = "add";
                         break;
                     case 1:
                         bcOp = in3.sub(in2);
+                        name = "sub";
                         break;
                     case 2:
                         bcOp = in3.mul(in2);
+                        name = "mul";
                         break;
                     case 3:
                         bcOp = in3.div(in2);
+                        name = "div";
                         break;
                     case 4:
                         bcOp = in3.rsub(in2);
+                        name = "rsub";
                         break;
                     case 5:
                         bcOp = in3.rdiv(in2);
+                        name = "rdiv";
+                        break;
+                    case 6:
+                        bcOp = sd.f().floorDiv(in3, in2);
+                        name = "floordiv";
+                        break;
+                    case 7:
+                        bcOp = sd.f().floorMod(in3, in2);
+                        name = "floormod";
                         break;
                     default:
                         throw new RuntimeException();
@@ -334,11 +350,11 @@ public class GradCheckMisc {
 
                 SDVariable outVar = sd.sum(bcOp);
 
-                String msg = "(test " + i + ", dimensions=" + Arrays.toString(dim_sz1s) + ")";
+                String msg = "(test " + i + ": " + name + ", dimensions=" + Arrays.toString(dim_sz1s) + ")";
                 log.info("*** Starting test: " + msg);
 
-                INDArray in3Arr = Nd4j.randn(minibatch, nOut).muli(100);
-                INDArray in2Arr = Nd4j.randn(minibatch, nOut).muli(100);
+                INDArray in3Arr = Nd4j.randn(new int[]{3,4,5}).muli(100);
+                INDArray in2Arr = Nd4j.randn(otherShape).muli(100);
 
                 sd.associateArrayWithVariable(in3Arr, in3);
                 sd.associateArrayWithVariable(in2Arr, in2);
@@ -347,6 +363,114 @@ public class GradCheckMisc {
                     INDArray out = sd.execAndEndResult();
                     assertNotNull(out);
                     assertArrayEquals(new int[]{1, 1}, out.shape());
+
+//                    System.out.println(sd.asFlatPrint());
+
+                    boolean ok = GradCheckUtil.checkGradients(sd);
+                    if (!ok) {
+                        allFailed.add(msg);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    allFailed.add(msg + " - EXCEPTION");
+                }
+            }
+        }
+
+        assertEquals("Failed: " + allFailed, 0, allFailed.size());
+    }
+
+    @Test
+    public void testGradientAutoBroadcast3() {
+        //These tests: output size > input sizes
+
+        Nd4j.getRandom().setSeed(12345);
+
+        List<String> allFailed = new ArrayList<>();
+
+        //Test cases: in1Shape, in2Shape, shapeOf(op(in1,in2))
+        List<Triple<int[],int[], int[]>> testCases = new ArrayList<>();
+        testCases.add(new Triple<>(new int[]{3,1}, new int[]{1,4}, new int[]{3,4}));
+        testCases.add(new Triple<>(new int[]{3,1}, new int[]{3,4}, new int[]{3,4}));
+        testCases.add(new Triple<>(new int[]{3,4}, new int[]{1,4}, new int[]{3,4}));
+        testCases.add(new Triple<>(new int[]{3,4,1}, new int[]{1,1,5}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,4,1}, new int[]{3,1,5}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,1,5}, new int[]{1,4,1}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,1,5}, new int[]{1,4,5}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,1,5}, new int[]{3,4,5}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,1,1,1}, new int[]{1,4,5,6}, new int[]{3,4,5,6}));
+        testCases.add(new Triple<>(new int[]{1,1,1,6}, new int[]{3,4,5,6}, new int[]{3,4,5,6}));
+        testCases.add(new Triple<>(new int[]{1,4,5,1}, new int[]{3,1,1,6}, new int[]{3,4,5,6}));
+        testCases.add(new Triple<>(new int[]{1,6}, new int[]{3,4,5,1}, new int[]{3,4,5,6}));
+
+        for (Triple<int[],int[],int[]> p : testCases) {
+
+            for (int i = 0; i < 6; i++) {
+
+                SameDiff sd = SameDiff.create();
+
+                SDVariable in3 = sd.var("in1", p.getFirst());
+                SDVariable in2 = sd.var("in2", p.getSecond());
+
+                String name;
+                SDVariable bcOp;
+                switch (i) {
+                    case 0:
+                        bcOp = in3.add(in2);
+                        name = "add";
+                        break;
+                    case 1:
+                        bcOp = in3.sub(in2);
+                        name = "sub";
+                        break;
+                    case 2:
+                        bcOp = in3.mul(in2);
+                        name = "mul";
+                        break;
+                    case 3:
+                        bcOp = in3.div(in2);
+                        name = "div";
+                        break;
+                    case 4:
+                        bcOp = in3.rsub(in2);
+                        name = "rsub";
+                        break;
+                    case 5:
+                        bcOp = in3.rdiv(in2);
+                        name = "rdiv";
+                        break;
+                    case 6:
+                        bcOp = sd.f().floorDiv(in3, in2);
+                        name = "floordiv";
+                        break;
+                    case 7:
+                        bcOp = sd.f().floorMod(in3, in2);
+                        name = "floormod";
+                        break;
+                    default:
+                        throw new RuntimeException();
+                }
+
+                SDVariable outVar = sd.sum(bcOp);
+
+                String msg = "(test " + i + ": " + name + ", array 1 size =" + Arrays.toString(p.getFirst())
+                        + ", array 2 size = " + Arrays.toString(p.getSecond()) + ")";
+                log.info("*** Starting test: " + msg);
+
+                INDArray in3Arr = Nd4j.randn(p.getFirst()).muli(100);
+                INDArray in2Arr = Nd4j.randn(p.getSecond()).muli(100);
+
+                sd.associateArrayWithVariable(in3Arr, in3);
+                sd.associateArrayWithVariable(in2Arr, in2);
+
+                try {
+                    INDArray out = sd.execAndEndResult();
+                    assertNotNull(out);
+                    assertArrayEquals(new int[]{1, 1}, out.shape());
+
+                    INDArray bcOut = bcOp.getArr();
+                    assertNotNull(bcOp);
+                    assertArrayEquals(p.getThird(), bcOut.shape());
 
 //                    System.out.println(sd.asFlatPrint());
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckMisc.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckMisc.java
@@ -39,6 +39,16 @@ public class GradCheckMisc {
     doRepeat
      */
 
+    @Test
+    public void testConcat(){
+
+        int[] concatDim = new int[]{0,0,0,1,1,1,2,2,2};
+        List<List<int[]>> origShapes = new ArrayList<>();
+        origShapes.add(Arrays.asList(new int[]{3,4}, new int[]{5,4}));
+
+
+        fail("not yet implemented");
+    }
 
     @Test
     public void testReshapeGradient() {

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckMisc.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckMisc.java
@@ -208,7 +208,7 @@ public class GradCheckMisc {
             int[] in2Shape = {3, 4, 5};
             in2Shape[dim_sz1] = 1;
 
-            for (int i = 0; i < 6; i++) {
+            for (int i = 7; i < 8; i++) {
 
                 SameDiff sd = SameDiff.create();
 
@@ -234,6 +234,12 @@ public class GradCheckMisc {
                         break;
                     case 5:
                         bcOp = in3.rdiv(in2);
+                        break;
+                    case 6:
+                        bcOp = sd.f().floorDiv(in3, in2);
+                        break;
+                    case 7:
+                        bcOp = sd.f().floorMod(in3, in2);
                         break;
                     default:
                         throw new RuntimeException();

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckMisc.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckMisc.java
@@ -208,7 +208,7 @@ public class GradCheckMisc {
             int[] in2Shape = {3, 4, 5};
             in2Shape[dim_sz1] = 1;
 
-            for (int i = 7; i < 8; i++) {
+            for (int i = 0; i < 8; i++) {
 
                 SameDiff sd = SameDiff.create();
 
@@ -216,30 +216,39 @@ public class GradCheckMisc {
                 SDVariable in2 = sd.var("in2", in2Shape);
 
                 SDVariable bcOp;
+                String name;
                 switch (i) {
                     case 0:
                         bcOp = in3.add(in2);
+                        name = "add";
                         break;
                     case 1:
                         bcOp = in3.sub(in2);
+                        name = "sub";
                         break;
                     case 2:
                         bcOp = in3.mul(in2);
+                        name = "mul";
                         break;
                     case 3:
                         bcOp = in3.div(in2);
+                        name = "div";
                         break;
                     case 4:
                         bcOp = in3.rsub(in2);
+                        name = "rsub";
                         break;
                     case 5:
                         bcOp = in3.rdiv(in2);
+                        name = "rdiv";
                         break;
                     case 6:
                         bcOp = sd.f().floorDiv(in3, in2);
+                        name = "floordiv";
                         break;
                     case 7:
                         bcOp = sd.f().floorMod(in3, in2);
+                        name = "floormod";
                         break;
                     default:
                         throw new RuntimeException();
@@ -247,7 +256,7 @@ public class GradCheckMisc {
 
                 SDVariable outVar = sd.sum(bcOp);
 
-                String msg = "(test " + i + ", dimension=" + dim_sz1 + ")";
+                String msg = "(test " + i + ": " + name + ", dimension=" + dim_sz1 + ")";
                 log.info("*** Starting test: " + msg);
 
                 INDArray in3Arr = Nd4j.randn(new int[]{3, 4, 5}).muli(100);

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckTransforms.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckTransforms.java
@@ -314,7 +314,8 @@ public class GradCheckTransforms {
         Nd4j.getRandom().setSeed(12345);
 
         List<String> allFailed = new ArrayList<>();
-        for (int i = 0; i < 19; i++) {
+        for (int i = 0; i < 20; i++) {
+
             SameDiff sd = SameDiff.create();
 
             int nOut = 4;
@@ -412,6 +413,10 @@ public class GradCheckTransforms {
                 case 18:
                     t = sd.assign(in1,in2);
                     expOut = ib;
+                    break;
+                case 19:
+                    t = sd.atan2(in1, in2);
+                    expOut = Transforms.atan2(ib, ia);    //Note: y,x order for samediff; x,y order for transforms
                     break;
                 default:
                     throw new RuntimeException();

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckTransforms.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckTransforms.java
@@ -40,10 +40,6 @@ public class GradCheckTransforms {
         List<String> allFailed = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
 
-            if(i < 49){
-                continue;
-            }
-
             SameDiff sd = SameDiff.create();
 
             int nOut = 4;

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckTransforms.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckTransforms.java
@@ -314,7 +314,7 @@ public class GradCheckTransforms {
         Nd4j.getRandom().setSeed(12345);
 
         List<String> allFailed = new ArrayList<>();
-        for (int i = 0; i < 18; i++) {
+        for (int i = 0; i < 19; i++) {
             SameDiff sd = SameDiff.create();
 
             int nOut = 4;
@@ -408,6 +408,10 @@ public class GradCheckTransforms {
                     ib = Nd4j.getExecutioner().exec(new BernoulliDistribution(ib, 0.5));
                     t = sd.xor(in1, in2);
                     expOut = Transforms.xor(ia, ib);
+                    break;
+                case 18:
+                    t = sd.assign(in1,in2);
+                    expOut = ib;
                     break;
                 default:
                     throw new RuntimeException();

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckTransforms.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/gradcheck/GradCheckTransforms.java
@@ -15,6 +15,8 @@ import org.nd4j.linalg.api.ops.impl.transforms.comparison.OldMax;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.OldMin;
 import org.nd4j.linalg.api.ops.random.impl.BernoulliDistribution;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.BooleanIndexing;
+import org.nd4j.linalg.indexing.conditions.Conditions;
 import org.nd4j.linalg.ops.transforms.Transforms;
 
 import java.util.ArrayList;
@@ -36,7 +38,8 @@ public class GradCheckTransforms {
         Nd4j.getRandom().setSeed(12345);
 
         List<String> allFailed = new ArrayList<>();
-        for (int i = 0; i < 47; i++) {
+        for (int i = 0; i < 49; i++) {
+
 
             SameDiff sd = SameDiff.create();
 
@@ -256,6 +259,17 @@ public class GradCheckTransforms {
                     t = sd.neq(in, 2.0);
                     ia = Nd4j.linspace(1,minibatch*nOut, minibatch*nOut).reshape('c', minibatch, nOut);
                     expOut = ia.neq(2.0);
+                    break;
+                case 47:
+                    t = sd.ceil(in);
+                    expOut = Transforms.ceil(ia, true);
+                    break;
+                case 48:
+                    ia = Nd4j.randn(ia.shape()).muli(2);
+                    t = sd.clipByValue(in, -3, 2);
+                    expOut = ia.dup();
+                    BooleanIndexing.replaceWhere(expOut, -3, Conditions.lessThan(-3));
+                    BooleanIndexing.replaceWhere(expOut, 2, Conditions.greaterThan(2));
                     break;
                 default:
                     throw new RuntimeException();

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/ShapeTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/ShapeTests.java
@@ -9,6 +9,10 @@ import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.NDArrayIndex;
+import org.nd4j.linalg.primitives.Triple;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -203,6 +207,32 @@ public class ShapeTests extends BaseNd4jTest {
         assertEquals(columnVectorSecond, baseArr.tensorAlongDimension(1, 0, 1));
     }
 
+    @Test
+    public void testBroadcastShapes(){
+        //Test cases: in1Shape, in2Shape, shapeOf(op(in1,in2))
+        List<Triple<int[],int[], int[]>> testCases = new ArrayList<>();
+        testCases.add(new Triple<>(new int[]{3,1}, new int[]{1,4}, new int[]{3,4}));
+        testCases.add(new Triple<>(new int[]{3,1}, new int[]{3,4}, new int[]{3,4}));
+        testCases.add(new Triple<>(new int[]{3,4}, new int[]{1,4}, new int[]{3,4}));
+        testCases.add(new Triple<>(new int[]{3,4,1}, new int[]{1,1,5}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,4,1}, new int[]{3,1,5}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,1,5}, new int[]{1,4,1}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,1,5}, new int[]{1,4,5}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,1,5}, new int[]{3,4,5}, new int[]{3,4,5}));
+        testCases.add(new Triple<>(new int[]{3,1,1,1}, new int[]{1,4,5,6}, new int[]{3,4,5,6}));
+        testCases.add(new Triple<>(new int[]{1,1,1,6}, new int[]{3,4,5,6}, new int[]{3,4,5,6}));
+        testCases.add(new Triple<>(new int[]{1,4,5,1}, new int[]{3,1,1,6}, new int[]{3,4,5,6}));
+        testCases.add(new Triple<>(new int[]{1,6}, new int[]{3,4,5,1}, new int[]{3,4,5,6}));
+
+        for(Triple<int[], int[], int[]> t : testCases){
+            int[] x = t.getFirst();
+            int[] y = t.getSecond();
+            int[] exp = t.getThird();
+
+            int[] act = Shape.broadcastOutputShape(x,y);
+            assertArrayEquals(exp,act);
+        }
+    }
 
 
     @Override


### PR DESCRIPTION

Also switches to new (broadcast-handling) transform backprop ops.

Basically:
- Add Java classes where required
- Add SameDiff and DifferentialFunctionFactory methods
- Check forward pass + gradient check
