### PR TITLE
Add libnd4j-assembly Maven profile to unpack from dependencies

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -271,6 +271,73 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>libnd4j-assembly</id>
+            <activation>
+                <property>
+                    <name>libnd4j-assembly</name>
+                </property>
+            </activation>
+            <properties>
+                <libnd4jhome>${project.build.directory}/libnd4j/</libnd4jhome>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>libnd4j</artifactId>
+                    <version>${project.version}</version>
+                    <type>zip</type>
+                    <classifier>${javacpp.platform}-cuda-${cuda.version}</classifier>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>libnd4j-checks</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>3.0.2</version>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.nd4j</groupId>
+                                            <artifactId>libnd4j</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>zip</type>
+                                            <classifier>${javacpp.platform}-cuda-${cuda.version}</classifier>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -349,6 +349,73 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>libnd4j-assembly</id>
+            <activation>
+                <property>
+                    <name>libnd4j-assembly</name>
+                </property>
+            </activation>
+            <properties>
+                <libnd4jhome>${project.build.directory}/libnd4j/</libnd4jhome>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>libnd4j</artifactId>
+                    <version>${project.version}</version>
+                    <type>zip</type>
+                    <classifier>${javacpp.platform}${javacpp.platform.extension}</classifier>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>libnd4j-checks</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>3.0.2</version>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.nd4j</groupId>
+                                            <artifactId>libnd4j</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>zip</type>
+                                            <classifier>${javacpp.platform}${javacpp.platform.extension}</classifier>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Complement of https://github.com/deeplearning4j/libnd4j/pull/702. When executing a build with say `mvn clean install -Plibnd4j-assembly -Djavacpp.extension=avx2`, it will not require libnd4j to be available anywhere. It will pick up assemblies from Maven dependencies, unpack in the private `target` directory, and use its binaries automatically.

@sshepel BTW, if I were to refactor nd4j-native and nd4-cuda, I think I'd try to use classifiers for different versions of CUDA. Having to change the version with a script isn't necessary like it is with Scala because in case of CUDA, the compiled Java classes are the same. So, I think it's a good idea to start doing it that way for libnd4j at least. What do you think?

## How was this patch tested?

Build manually tested for nd4j-native and nd4j-cuda.
