### PR TITLE
Synchronize calls to DefaultOpExecutioner.getCustomOperations()

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaExecutioner.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaExecutioner.java
@@ -2403,7 +2403,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
 
     @Override
-    public Map<String, CustomOpDescriptor> getCustomOperations() {
+    public synchronized Map<String, CustomOpDescriptor> getCustomOperations() {
         String list = nativeOps.getAllCustomOps();
 
         val map = new HashMap<String, CustomOpDescriptor>();

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
@@ -1484,7 +1484,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
 
     @Override
-    public Map<String, CustomOpDescriptor> getCustomOperations() {
+    public synchronized Map<String, CustomOpDescriptor> getCustomOperations() {
         if (customOps == null) {
             String list = loop.getAllCustomOps();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Probably fixes https://github.com/deeplearning4j/rl4j/issues/86

## How was this patch tested?

RL4J Toy example doesn't crash anymore in ND4J with A3C.