### PR TITLE
Switch default op profiler mode to SCOPE_PANIC

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
@@ -51,7 +51,7 @@ import java.util.Properties;
 @Slf4j
 public class DefaultOpExecutioner implements OpExecutioner {
 
-    protected ProfilingMode profilingMode = ProfilingMode.DISABLED;
+    protected ProfilingMode profilingMode = ProfilingMode.SCOPE_PANIC;
     protected ExecutionMode executionMode = ExecutionMode.JAVA;
 
     public DefaultOpExecutioner() {}


### PR DESCRIPTION
Addresses: https://github.com/deeplearning4j/nd4j/issues/2569
(See issue for motivation)

Results from a simple benchmark suggest this should have negligible performance impact:
https://gist.github.com/AlexDBlack/73b570325ccefdfb821c362283da6448
