### PR TITLE
Fix for obtaining own IP by parameter server client

### DIFF
--- a/nd4j-parameter-server-parent/nd4j-parameter-server-node/src/main/java/org/nd4j/parameterserver/distributed/VoidParameterServer.java
+++ b/nd4j-parameter-server-parent/nd4j-parameter-server-node/src/main/java/org/nd4j/parameterserver/distributed/VoidParameterServer.java
@@ -334,7 +334,7 @@ public class VoidParameterServer {
             }
 
 
-        String sparkIp = System.getenv("SPARK_PUBLIC_DNS");
+        String sparkIp = null;
 
 
         if (sparkIp == null && voidConfiguration.getNetworkMask() != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

VoidParameterServer now doesn't assume SPARK_PUBLIC_DNS as it's IP first.

## How was this patch tested?

Ran MNIST parameter server example after building this and analogous deeplearning4j change with expected result
