### PR TITLE
Check underlying/original data buffers in BaseNDArray.isAttached()

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -5288,7 +5288,9 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public boolean isAttached() {
-        return data.isAttached();
+        return data.isAttached() ||
+                (data.underlyingDataBuffer() != null && data.underlyingDataBuffer().isAttached()) ||
+                (data.originalDataBuffer() != null && data.originalDataBuffer().isAttached());
     }
 
     /**

--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -96,6 +96,13 @@ public abstract class BaseDataBuffer implements DataBuffer {
 
     @Override
     public long getGenerationId() {
+        if(parentWorkspace != null){
+            return workspaceGenerationId;
+        } else if(wrappedDataBuffer != null && wrappedDataBuffer.isAttached()){
+            return wrappedDataBuffer.getGenerationId();
+        } else if(originalBuffer != null && originalBuffer.isAttached()){
+            return originalBuffer.getGenerationId();
+        }
         return workspaceGenerationId;
     }
 
@@ -1527,7 +1534,16 @@ public abstract class BaseDataBuffer implements DataBuffer {
 
     @Override
     public MemoryWorkspace getParentWorkspace() {
-        return parentWorkspace;
+        if(parentWorkspace != null){
+            return parentWorkspace;
+        }
+        if(wrappedDataBuffer != null && wrappedDataBuffer.isAttached() && wrappedDataBuffer.getParentWorkspace() != null){
+            return wrappedDataBuffer.getParentWorkspace();
+        }
+        if(originalBuffer != null && originalBuffer.isAttached() && originalBuffer.getParentWorkspace() != null){
+            return originalBuffer.getParentWorkspace();
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
I don't know if this is the best possible fix, but it seems to work.
Original issue: https://github.com/deeplearning4j/deeplearning4j/issues/4609

Seems to impact scalars only. Reproducable in DL4J using this (note that the ```out``` variable here is wrong the first time, as it's never migrated out of the workspace - out2 seems correct):

```
    @Test
    public void testOutput() {

        Nd4j.getRandom().setSeed(12345);
        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                .weightInit(WeightInit.XAVIER)
                .seed(12345)
                .trainingWorkspaceMode(WorkspaceMode.SEPARATE).inferenceWorkspaceMode(WorkspaceMode.SEPARATE)
                .list()
                .layer(new OutputLayer.Builder().nIn(3).nOut(1).activation(Activation.SIGMOID).build())
                .build();

        MultiLayerNetwork net = new MultiLayerNetwork(conf);
        net.init();

        INDArray input = Nd4j.linspace(1, 3, 3);
        INDArray out = net.output(input);
        INDArray out2 = net.output(input);

        assertEquals(out2, out);
    }
```

Note that apparently the array is NOT attached, but the underlying/wrapped buffers ARE attached.
Consequently, workspace migration doesn't occur correctly for this scalar hase.

![image](https://user-images.githubusercontent.com/2360237/35788355-8597370c-0a88-11e8-8499-421a86aa7e79.png)
