### PR TITLE
#2623 Call commit() before closing workspace to avoid scope panic

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
@@ -572,6 +572,10 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
             return;
         }
 
+        // this is for safety. We have to be sure that no ops were left non-processed
+        //Furthermore, need to commit before marking workspace as closed, to avoid (incorrectly) hitting scope panic
+        Nd4j.getExecutioner().commit();
+
         // since this workspace block is finished, we restore previous one. Even if it's null
         Nd4j.getMemoryManager().setCurrentWorkspace(previousWorkspace);
         isOpen.set(false);
@@ -602,10 +606,6 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
 
             maxCycle.set(cycleAllocations.get());
         }
-
-        // this is for safety. We have to be sure that no ops were left non-processed
-        Nd4j.getExecutioner().commit();
-
 
         // checking, if we should reallocate this workspace to higher amount of memory
         if (workspaceConfiguration.getPolicyLearning() != LearningPolicy.NONE && maxCycle.get() > 0) {


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/nd4j/issues/2623