### PR TITLE
#2559 Fix shading build issue

### DIFF
--- a/nd4j-shade/jackson/pom.xml
+++ b/nd4j-shade/jackson/pom.xml
@@ -134,6 +134,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <forceCreation>true</forceCreation>
+                </configuration>
                 <executions>
                     <execution>
                         <id>empty-javadoc-jar</id>


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/nd4j/issues/2559

A very simple configuration change that took forever to debug and find... I tested the build 20 times without issue (previously it was occuring once in every 2 or 3 builds for me)

Reason this helps: For some reason, the maven shade plugin will reference the already shaded JAR in the target directory. Of course, this (when combined with the other dependencies to be shaded) meant that the same files would be included twice. The forceCreation=true configuration ensures that the relevant JARs are always rebuilt from scratch.