### PR TITLE
SameDiff: Dynamic partitioning and stitching (forward only for now)

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -2,6 +2,7 @@ package org.nd4j.autodiff.functions;
 
 import com.google.common.base.Preconditions;
 import lombok.Data;
+import org.apache.commons.lang3.ArrayUtils;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
@@ -856,15 +857,17 @@ public class DifferentialFunctionFactory   {
                 .outputVariables()[0];
     }
 
-    public SDVariable dynamicPartition(SDVariable differentialFunction, SDVariable partitions, int numPartitions) {
+    public SDVariable[] dynamicPartition(SDVariable differentialFunction, SDVariable partitions, int numPartitions) {
         validateDifferentialFunctionsameDiff(differentialFunction);
         return new DynamicPartition(sameDiff(), new SDVariable[] {differentialFunction, partitions}, numPartitions)
-                .outputVariables()[0];
+                .outputVariables();
     }
 
-    public SDVariable dynamicStitch(SDVariable differentialFunction, SDVariable indices) {
-        validateDifferentialFunctionsameDiff(differentialFunction);
-        return new DynamicStitch(sameDiff(), new SDVariable[] {differentialFunction, indices})
+    public SDVariable dynamicStitch(SDVariable[] differentialFunctions, SDVariable[] indices) {
+        for (SDVariable df: differentialFunctions)
+            validateDifferentialFunctionsameDiff(df);
+
+        return new DynamicStitch(sameDiff(), differentialFunctions, indices)
                 .outputVariables()[0];
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -859,15 +859,15 @@ public class DifferentialFunctionFactory   {
 
     public SDVariable[] dynamicPartition(SDVariable differentialFunction, SDVariable partitions, int numPartitions) {
         validateDifferentialFunctionsameDiff(differentialFunction);
-        return new DynamicPartition(sameDiff(), new SDVariable[] {differentialFunction, partitions}, numPartitions)
+        return new DynamicPartition(sameDiff(), differentialFunction, partitions, numPartitions)
                 .outputVariables();
     }
 
-    public SDVariable dynamicStitch(SDVariable[] differentialFunctions, SDVariable[] indices) {
+    public SDVariable dynamicStitch(SDVariable[] indices, SDVariable[] differentialFunctions) {
         for (SDVariable df: differentialFunctions)
             validateDifferentialFunctionsameDiff(df);
 
-        return new DynamicStitch(sameDiff(), differentialFunctions, indices)
+        return new DynamicStitch(sameDiff(), indices, differentialFunctions)
                 .outputVariables()[0];
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -856,6 +856,18 @@ public class DifferentialFunctionFactory   {
                 .outputVariables()[0];
     }
 
+    public SDVariable dynamicPartition(SDVariable differentialFunction, SDVariable partitions, int numPartitions) {
+        validateDifferentialFunctionsameDiff(differentialFunction);
+        return new DynamicPartition(sameDiff(), new SDVariable[] {differentialFunction, partitions}, numPartitions)
+                .outputVariables()[0];
+    }
+
+    public SDVariable dynamicStitch(SDVariable differentialFunction, SDVariable indices) {
+        validateDifferentialFunctionsameDiff(differentialFunction);
+        return new DynamicStitch(sameDiff(), new SDVariable[] {differentialFunction, indices})
+                .outputVariables()[0];
+    }
+
     public SDVariable cross(SDVariable a, SDVariable b) {
         validateDifferentialFunctionsameDiff(a);
         return new Cross(sameDiff(), new SDVariable[]{a,b}).outputVariables()[0];

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -2142,12 +2142,12 @@ public class SameDiff {
         return updateVariableNamesAndReferences(ret, name);
     }
 
-    public SDVariable dynamicStitch(SDVariable[] iX, SDVariable[] indices) {
-        return dynamicStitch(null, iX, indices);
+    public SDVariable dynamicStitch(SDVariable[] indices, SDVariable[] iX) {
+        return dynamicStitch(null, indices, iX);
     }
 
-    public SDVariable dynamicStitch(String name, SDVariable[] iX, SDVariable[] indices) {
-        SDVariable ret = f().dynamicStitch(iX, indices);
+    public SDVariable dynamicStitch(String name, SDVariable[] indices, SDVariable[] iX) {
+        SDVariable ret = f().dynamicStitch(indices, iX);
         return updateVariableNameAndReference(ret, name);
     }
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -2133,20 +2133,20 @@ public class SameDiff {
     }
 
 
-    public SDVariable dynamicPartition(SDVariable iX, SDVariable partitions, int numPartitions) {
+    public SDVariable[] dynamicPartition(SDVariable iX, SDVariable partitions, int numPartitions) {
         return dynamicPartition(null, iX, partitions, numPartitions);
     }
 
-    public SDVariable dynamicPartition(String name, SDVariable iX, SDVariable partitions, int numPartitions) {
-        SDVariable ret = f().dynamicPartition(iX, partitions, numPartitions);
-        return updateVariableNameAndReference(ret, name);
+    public SDVariable[] dynamicPartition(String[] name, SDVariable iX, SDVariable partitions, int numPartitions) {
+        SDVariable[] ret = f().dynamicPartition(iX, partitions, numPartitions);
+        return updateVariableNamesAndReferences(ret, name);
     }
 
-    public SDVariable dynamicStitch(SDVariable iX, SDVariable indices) {
+    public SDVariable dynamicStitch(SDVariable[] iX, SDVariable[] indices) {
         return dynamicStitch(null, iX, indices);
     }
 
-    public SDVariable dynamicStitch(String name, SDVariable iX, SDVariable indices) {
+    public SDVariable dynamicStitch(String name, SDVariable[] iX, SDVariable[] indices) {
         SDVariable ret = f().dynamicStitch(iX, indices);
         return updateVariableNameAndReference(ret, name);
     }
@@ -4662,6 +4662,29 @@ public class SameDiff {
         varToUpdate.setVarName(newVarName);
         updateVariableName(oldVarName, newVarName);
         return varToUpdate;
+    }
+
+
+    /**
+     * Updates the variable name property on the passed in variables,
+     * its reference in samediff, and returns the variable.
+     *
+     * @param variablesToUpdate the variable to update
+     * @param newVariableNames  the new variable name
+     * @return the updated, passed in variables
+     */
+    public SDVariable[] updateVariableNamesAndReferences(SDVariable[] variablesToUpdate, String[] newVariableNames) {
+
+        int numVariables = variablesToUpdate.length;
+        SDVariable[] updatedVariables = new SDVariable[numVariables];
+
+        for (int i = 0; i < numVariables; i++) {
+            SDVariable varToUpdate = variablesToUpdate[i];
+            String name = newVariableNames[i];
+            updatedVariables[i] = updateVariableNameAndReference(varToUpdate, name);
+        }
+
+        return updatedVariables;
     }
 
     /**

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -2132,6 +2132,26 @@ public class SameDiff {
         return updateVariableNameAndReference(ret, name);
     }
 
+
+    public SDVariable dynamicPartition(SDVariable iX, SDVariable partitions, int numPartitions) {
+        return dynamicPartition(null, iX, partitions, numPartitions);
+    }
+
+    public SDVariable dynamicPartition(String name, SDVariable iX, SDVariable partitions, int numPartitions) {
+        SDVariable ret = f().dynamicPartition(iX, partitions, numPartitions);
+        return updateVariableNameAndReference(ret, name);
+    }
+
+    public SDVariable dynamicStitch(SDVariable iX, SDVariable indices) {
+        return dynamicStitch(null, iX, indices);
+    }
+
+    public SDVariable dynamicStitch(String name, SDVariable iX, SDVariable indices) {
+        SDVariable ret = f().dynamicStitch(iX, indices);
+        return updateVariableNameAndReference(ret, name);
+    }
+
+
     public SDVariable cross(SDVariable a, SDVariable b) {
         return cross(null, a, b);
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Conv2D.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Conv2D.java
@@ -92,8 +92,6 @@ public class Conv2D extends DynamicCustomOp {
     public void initFromTensorFlow(NodeDef nodeDef, SameDiff initWith, Map<String, AttrValue> attributesForNode, GraphDef graph) {
         TFGraphMapper.getInstance().initFunctionFromProperties(nodeDef.getOp(), this, attributesForNode, nodeDef, graph);
         addArgs();
-
-
     }
 
     @Override

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicPartition.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicPartition.java
@@ -5,7 +5,6 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.descriptors.properties.PropertyMapping;
 import org.nd4j.imports.graphmapper.tf.TFGraphMapper;
-import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
@@ -50,9 +49,10 @@ public class DynamicPartition extends DynamicCustomOp {
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
         // DynamicPartition and DynamicStitch are mutually inverse
-        SDVariable gradient = i_v.get(0);
-        SDVariable ret = sameDiff.dynamicStitch(gradient, partitions);
-        return Collections.singletonList(ret);
+        SDVariable[] gradients = (SDVariable[]) i_v.toArray();
+        // TODO: compute indices from partitions
+//        SDVariable ret = sameDiff.dynamicStitch(gradients, partitions);
+        return Collections.singletonList(i_v.get(0));
     }
 
     protected void addArgs() {
@@ -92,10 +92,10 @@ public class DynamicPartition extends DynamicCustomOp {
     public String tensorflowName() {
         return "DynamicPartition";
     }
-    
+
     @Override
     public String onnxName() {
-        throw new IllegalStateException("Dynamic partitioning currently not supported by ONNX");
+        return "Dynamic partitioning currently not supported by ONNX";
     }
 
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicPartition.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicPartition.java
@@ -1,0 +1,101 @@
+package org.nd4j.linalg.api.ops.impl.transforms;
+
+import lombok.val;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.imports.descriptors.properties.PropertyMapping;
+import org.nd4j.imports.graphmapper.tf.TFGraphMapper;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.tensorflow.framework.AttrValue;
+import org.tensorflow.framework.GraphDef;
+import org.tensorflow.framework.NodeDef;
+
+import java.util.*;
+
+
+/**
+ * Transforms a given input tensor into numPartitions partitions, as indicated by the indices in "partitions".
+ * Output tensor has one more dimension than input tensor, the first dimension indicates the partition.
+ *
+ * Example:
+ *
+ * input:           [4, 3, 5, 7, 8, 0]
+ * input shape:     [1, 6]
+ * partitions:      [1, 0, 1, 0, 0, 1]
+ * numPartitions:   2
+ * outputs[0]:      [3, 7, 8]
+ * outputs[1]:      [4, 5, 0]
+ *
+ * @author Max Pumperla
+ */
+public class DynamicPartition extends DynamicCustomOp {
+
+    private int numPartitions;
+    private SDVariable partitions;
+
+    public DynamicPartition() {
+    }
+
+    public DynamicPartition(SameDiff sameDiff, SDVariable[] inputAndpartitions, int numPartitions) {
+        super(null, sameDiff, inputAndpartitions, false);
+        SDVariable sdPartitions = inputAndpartitions[1];
+
+        this.partitions = sdPartitions;
+        this.numPartitions = numPartitions;
+        addArgs();
+    }
+
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> i_v) {
+        // DynamicPartition and DynamicStitch are mutually inverse
+        SDVariable gradient = i_v.get(0);
+        SDVariable ret = sameDiff.dynamicStitch(gradient, partitions);
+        return Collections.singletonList(ret);
+    }
+
+    protected void addArgs() {
+        addIArgument(numPartitions);
+    }
+
+    @Override
+    public void initFromTensorFlow(NodeDef nodeDef, SameDiff initWith, Map<String, AttrValue> attributesForNode, GraphDef graph) {
+        TFGraphMapper.getInstance().initFunctionFromProperties(nodeDef.getOp(), this, attributesForNode, nodeDef, graph);
+        addArgs();
+    }
+
+
+    @Override
+    public Map<String, Map<String, PropertyMapping>> mappingsForFunction() {
+        Map<String, Map<String, PropertyMapping>> ret = new HashMap<>();
+        Map<String,PropertyMapping> attrs = new LinkedHashMap<>();
+
+        val numPartitions = PropertyMapping.builder()
+                .tfAttrName("num_partitions")
+                .propertyNames(new String[]{"numPartitions"})
+                .build();
+        attrs.put("numPartitions", numPartitions);
+
+        ret.put(tensorflowName(),attrs);
+        return ret;
+    }
+
+
+    @Override
+    public String opName() {
+        return "dynamic_partition";
+    }
+
+
+    @Override
+    public String tensorflowName() {
+        return "DynamicPartition";
+    }
+    
+    @Override
+    public String onnxName() {
+        throw new IllegalStateException("Dynamic partitioning currently not supported by ONNX");
+    }
+
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicPartition.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicPartition.java
@@ -1,6 +1,7 @@
 package org.nd4j.linalg.api.ops.impl.transforms;
 
 import lombok.val;
+import org.apache.commons.lang3.ArrayUtils;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.descriptors.properties.PropertyMapping;
@@ -36,24 +37,24 @@ public class DynamicPartition extends DynamicCustomOp {
     public DynamicPartition() {
     }
 
-    public DynamicPartition(SameDiff sameDiff, SDVariable[] inputAndpartitions, int numPartitions) {
-        super(null, sameDiff, inputAndpartitions, false);
-        SDVariable sdPartitions = inputAndpartitions[1];
+    public DynamicPartition(SameDiff sameDiff, SDVariable input,  SDVariable partitions, int numPartitions) {
+        super(null, sameDiff,  new SDVariable[] {input, partitions}, false);
 
-        this.partitions = sdPartitions;
+        this.partitions = partitions;
         this.numPartitions = numPartitions;
         addArgs();
     }
 
 
-    @Override
-    public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        // DynamicPartition and DynamicStitch are mutually inverse
-        SDVariable[] gradients = (SDVariable[]) i_v.toArray();
-        // TODO: compute indices from partitions
-//        SDVariable ret = sameDiff.dynamicStitch(gradients, partitions);
-        return Collections.singletonList(i_v.get(0));
-    }
+//    @Override
+//    public List<SDVariable> doDiff(List<SDVariable> i_v) {
+//        // DynamicPartition and DynamicStitch are mutually inverse
+//        SDVariable[] gradients = (SDVariable[]) i_v.toArray();
+////         TODO: compute indices from partitions
+//        SDVariable[] indices = f(partitions, numPartitions);
+//        SDVariable ret = sameDiff.dynamicStitch(gradients, indices);
+//        return Collections.singletonList(i_v.get(0));
+//    }
 
     protected void addArgs() {
         addIArgument(numPartitions);

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicStitch.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicStitch.java
@@ -1,0 +1,82 @@
+package org.nd4j.linalg.api.ops.impl.transforms;
+
+import lombok.val;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.imports.descriptors.properties.PropertyMapping;
+import org.nd4j.imports.graphmapper.tf.TFGraphMapper;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.indexing.INDArrayIndex;
+import org.tensorflow.framework.AttrValue;
+import org.tensorflow.framework.GraphDef;
+import org.tensorflow.framework.NodeDef;
+
+import java.util.*;
+
+
+/**
+ * Transforms a given input tensor into numPartitions partitions, as indicated by the indices in "partitions".
+ * Output tensor has one more dimension than input tensor, the first dimension indicates the partition.
+ * <p>
+ * Example:
+ * <p>
+ * input:           [4, 3, 5, 7, 8, 0]
+ * input shape:     [1, 6]
+ * partitions:      [1, 0, 1, 0, 0, 1]
+ * numPartitions:   2
+ * outputs[0]:      [3, 7, 8]
+ * outputs[1]:      [4, 5, 0]
+ *
+ * @author Max Pumperla
+ */
+public class DynamicStitch extends DynamicCustomOp {
+
+    private int numPartitions;
+    private SDVariable indices;
+
+    public DynamicStitch() {
+    }
+
+    public DynamicStitch(SameDiff sameDiff, SDVariable[] inputAndpartitions) {
+        super(null, sameDiff, inputAndpartitions, false);
+
+        SDVariable input = inputAndpartitions[0];
+        SDVariable sdPartitions = inputAndpartitions[1];
+
+        this.indices = sdPartitions;
+        this.numPartitions = input.getArr().shape()[0];
+    }
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> i_v) {
+        // DynamicPartition and DynamicStitch are mutually inverse
+        SDVariable gradient = i_v.get(0);
+        SDVariable ret = sameDiff.dynamicPartition(gradient, indices, numPartitions);
+        return Collections.singletonList(ret);
+    }
+
+
+    @Override
+    public void initFromTensorFlow(NodeDef nodeDef, SameDiff initWith, Map<String, AttrValue> attributesForNode, GraphDef graph) {
+        TFGraphMapper.getInstance().initFunctionFromProperties(nodeDef.getOp(), this, attributesForNode, nodeDef, graph);
+    }
+
+
+    @Override
+    public String opName() {
+        return "dynamic_stitch";
+    }
+
+
+    @Override
+    public String tensorflowName() {
+        return "DynamicStitch";
+    }
+
+    @Override
+    public String onnxName() {
+        throw new IllegalStateException("Dynamic partitioning currently not supported by ONNX");
+    }
+
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicStitch.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/DynamicStitch.java
@@ -35,8 +35,8 @@ public class DynamicStitch extends DynamicCustomOp {
     public DynamicStitch() {
     }
 
-    public DynamicStitch(SameDiff sameDiff, SDVariable[] inputs, SDVariable[] indices) {
-        super(null, sameDiff, ArrayUtils.addAll(inputs, indices), false);
+    public DynamicStitch(SameDiff sameDiff, SDVariable[] indices, SDVariable[] inputs) {
+        super(null, sameDiff, ArrayUtils.addAll(indices, inputs), false);
 
         this.indices = indices;
         this.numPartitions = inputs.length;


### PR DESCRIPTION
Before I go insane mapping partitions to stitch indices and vice versa, I'm going to merge this and come back for `doDiff` later.
