### PR TITLE
Add builds for android-arm64 and android-x86_64 platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,20 @@ matrix:
       install: true
       script: bash ./ci/build-android.sh
     - os: linux
-      env: OS=android-x86 SCALA=2.11
+      env: OS=android-arm64 SCALA=2.11
+      install: true
+      script: bash ./ci/build-android.sh
+    - os: linux
+      env: OS=android-x86 SCALA=2.10
+      install: true
+      script: bash ./ci/build-android.sh
+    - os: linux
+      env: OS=android-x86_64 SCALA=2.11
       install: true
       script: bash ./ci/build-android.sh
     - os: osx
       osx_image: xcode7.3
-      env: OS=ios-arm SCALA=2.10
-      install: true
-      script: bash ./ci/build-ios.sh
-    - os: osx
-      osx_image: xcode7.3
-      env: OS=ios-arm64 SCALA=2.11
-      install: true
-      script: bash ./ci/build-ios.sh
-    - os: osx
-      osx_image: xcode7.3
-      env: OS=ios-x86 SCALA=2.10
+      env: OS=ios-arm64 SCALA=2.10
       install: true
       script: bash ./ci/build-ios.sh
     - os: osx

--- a/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -246,6 +246,20 @@
           </properties>
         </profile>
         <profile>
+          <id>android-arm64-default</id>
+          <activation>
+            <property>
+              <name>javacpp.platform</name>
+              <value>android-arm64</value>
+            </property>
+          </activation>
+          <properties>
+            <javacpp.platform>android-arm64</javacpp.platform>
+            <javacpp.platform.root>${env.ANDROID_NDK}</javacpp.platform.root>
+            <javacpp.platform.compiler>toolchains/aarch64-linux-android-4.9/prebuilt/${os.name}-${os.arch}/bin/aarch64-linux-android-g++</javacpp.platform.compiler>
+          </properties>
+        </profile>
+        <profile>
           <id>android-x86-default</id>
           <activation>
             <property>
@@ -257,6 +271,20 @@
             <javacpp.platform>android-x86</javacpp.platform>
             <javacpp.platform.root>${env.ANDROID_NDK}</javacpp.platform.root>
             <javacpp.platform.compiler>toolchains/x86-4.9/prebuilt/${os.name}-${os.arch}/bin/i686-linux-android-g++</javacpp.platform.compiler>
+          </properties>
+        </profile>
+        <profile>
+          <id>android-x86_64-default</id>
+          <activation>
+            <property>
+              <name>javacpp.platform</name>
+              <value>android-x86_64</value>
+            </property>
+          </activation>
+          <properties>
+            <javacpp.platform>android-x86_64</javacpp.platform>
+            <javacpp.platform.root>${env.ANDROID_NDK}</javacpp.platform.root>
+            <javacpp.platform.compiler>toolchains/x86_64-4.9/prebuilt/${os.name}-${os.arch}/bin/x86_64-linux-android-g++</javacpp.platform.compiler>
           </properties>
         </profile>
         <profile>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update .travis.yml and nd4j-backend's pom.xml file to add support for 64-bit Android platforms

## How was this patch tested?

Manually tested that builds pass, but let's wait for confirmation from Travis CI before merging...