### PR TITLE
Cleanup and refactoring of utility classes/methods

### DIFF
--- a/nd4j-common/pom.xml
+++ b/nd4j-common/pom.xml
@@ -107,6 +107,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/nd4j-common/pom.xml
+++ b/nd4j-common/pom.xml
@@ -101,6 +101,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons-compress.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/nd4j-common/src/main/java/org/nd4j/linalg/collection/MultiDimensionalMap.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/collection/MultiDimensionalMap.java
@@ -1,0 +1,458 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.nd4j.linalg.collection;
+
+import org.nd4j.linalg.primitives.Pair;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * Multiple key map
+ */
+public class MultiDimensionalMap<K, T, V> implements Serializable {
+
+    private Map<Pair<K, T>, V> backedMap;
+
+    /**
+     * Thread safe sorted map implementation
+     * @param <K>
+     * @param <T>
+     * @param <V>
+     * @return
+     */
+    public static <K, T, V> MultiDimensionalMap<K, T, V> newThreadSafeTreeBackedMap() {
+        return new MultiDimensionalMap<>(new ConcurrentSkipListMap<Pair<K, T>, V>());
+    }
+
+    /**
+     * Thread safe hash map implementation
+     * @param <K>
+     * @param <T>
+     * @param <V>
+     * @return
+     */
+    public static <K, T, V> MultiDimensionalMap<K, T, V> newThreadSafeHashBackedMap() {
+        return new MultiDimensionalMap<>(new ConcurrentHashMap<Pair<K, T>, V>());
+    }
+
+    /**
+     * Thread safe hash map impl
+     * @param <K>
+     * @param <T>
+     * @param <V>
+     * @return
+     */
+    public static <K, T, V> MultiDimensionalMap<K, T, V> newHashBackedMap() {
+        return new MultiDimensionalMap<>(new HashMap<Pair<K, T>, V>());
+    }
+
+    /**
+     * Tree map implementation
+     * @param <K>
+     * @param <T>
+     * @param <V>
+     * @return
+     */
+    public static <K, T, V> MultiDimensionalMap<K, T, V> newTreeBackedMap() {
+        return new MultiDimensionalMap<>(new TreeMap<Pair<K, T>, V>());
+    }
+
+    public MultiDimensionalMap(Map<Pair<K, T>, V> backedMap) {
+        this.backedMap = backedMap;
+    }
+
+    protected MultiDimensionalMap(){ }
+
+    /**
+     * Returns the number of key-value mappings in this map.  If the
+     * map contains more than <tt>Integer.MAX_VALUE</tt> elements, returns
+     * <tt>Integer.MAX_VALUE</tt>.
+     *
+     * @return the number of key-value mappings in this map
+     */
+    public int size() {
+        return backedMap.size();
+    }
+
+    /**
+     * Returns <tt>true</tt> if this map contains no key-value mappings.
+     *
+     * @return <tt>true</tt> if this map contains no key-value mappings
+     */
+    public boolean isEmpty() {
+        return backedMap.isEmpty();
+    }
+
+    /**
+     * Returns <tt>true</tt> if this map contains a mapping for the specified
+     * key.  More formally, returns <tt>true</tt> if and only if
+     * this map contains a mapping for a key <tt>k</tt> such that
+     * <tt>(key==null ? k==null : key.equals(k))</tt>.  (There can be
+     * at most one such mapping.)
+     *
+     * @param key key whose presence in this map is to be tested
+     * @return <tt>true</tt> if this map contains a mapping for the specified
+     * key
+     * @throws ClassCastException   if the key is of an inappropriate type for
+     *                              this map
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException if the specified key is null and this map
+     *                              does not permit null keys
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     */
+
+    public boolean containsKey(Object key) {
+        return backedMap.containsKey(key);
+    }
+
+    /**
+     * Returns <tt>true</tt> if this map maps one or more keys to the
+     * specified value.  More formally, returns <tt>true</tt> if and only if
+     * this map contains at least one mapping to a value <tt>v</tt> such that
+     * <tt>(value==null ? v==null : value.equals(v))</tt>.  This operation
+     * will probably require time linear in the map size for most
+     * implementations of the <tt>Map</tt> interface.
+     *
+     * @param value value whose presence in this map is to be tested
+     * @return <tt>true</tt> if this map maps one or more keys to the
+     * specified value
+     * @throws ClassCastException   if the value is of an inappropriate type for
+     *                              this map
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException if the specified value is null and this
+     *                              map does not permit null values
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     */
+
+    public boolean containsValue(Object value) {
+        return backedMap.containsValue(value);
+    }
+
+    /**
+     * Returns the value to which the specified key is mapped,
+     * or {@code null} if this map contains no mapping for the key.
+     * <p/>
+     * <p>More formally, if this map contains a mapping from a key
+     * {@code k} to a value {@code v} such that {@code (key==null ? k==null :
+     * key.equals(k))}, then this method returns {@code v}; otherwise
+     * it returns {@code null}.  (There can be at most one such mapping.)
+     * <p/>
+     * <p>If this map permits null values, then a return value of
+     * {@code null} does not <i>necessarily</i> indicate that the map
+     * contains no mapping for the key; it's also possible that the map
+     * explicitly maps the key to {@code null}.  The {@link #containsKey
+     * containsKey} operation may be used to distinguish these two cases.
+     *
+     * @param key the key whose associated value is to be returned
+     * @return the value to which the specified key is mapped, or
+     * {@code null} if this map contains no mapping for the key
+     * @throws ClassCastException   if the key is of an inappropriate type for
+     *                              this map
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException if the specified key is null and this map
+     *                              does not permit null keys
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     */
+
+    public V get(Object key) {
+        return backedMap.get(key);
+    }
+
+    /**
+     * Associates the specified value with the specified key in this map
+     * (optional operation).  If the map previously contained a mapping for
+     * the key, the old value is replaced by the specified value.  (A map
+     * <tt>m</tt> is said to contain a mapping for a key <tt>k</tt> if and only
+     * if {@link #containsKey(Object) m.containsKey(k)} would return
+     * <tt>true</tt>.)
+     *
+     * @param key   key with which the specified value is to be associated
+     * @param value value to be associated with the specified key
+     * @return the previous value associated with <tt>key</tt>, or
+     * <tt>null</tt> if there was no mapping for <tt>key</tt>.
+     * (A <tt>null</tt> return can also indicate that the map
+     * previously associated <tt>null</tt> with <tt>key</tt>,
+     * if the implementation supports <tt>null</tt> values.)
+     * @throws UnsupportedOperationException if the <tt>put</tt> operation
+     *                                       is not supported by this map
+     * @throws ClassCastException            if the class of the specified key or value
+     *                                       prevents it from being stored in this map
+     * @throws NullPointerException          if the specified key or value is null
+     *                                       and this map does not permit null keys or values
+     * @throws IllegalArgumentException      if some property of the specified key
+     *                                       or value prevents it from being stored in this map
+     */
+
+    public V put(Pair<K, T> key, V value) {
+        return backedMap.put(key, value);
+    }
+
+    /**
+     * Removes the mapping for a key from this map if it is present
+     * (optional operation).   More formally, if this map contains a mapping
+     * from key <tt>k</tt> to value <tt>v</tt> such that
+     * <code>(key==null ?  k==null : key.equals(k))</code>, that mapping
+     * is removed.  (The map can contain at most one such mapping.)
+     * <p/>
+     * <p>Returns the value to which this map previously associated the key,
+     * or <tt>null</tt> if the map contained no mapping for the key.
+     * <p/>
+     * <p>If this map permits null values, then a return value of
+     * <tt>null</tt> does not <i>necessarily</i> indicate that the map
+     * contained no mapping for the key; it's also possible that the map
+     * explicitly mapped the key to <tt>null</tt>.
+     * <p/>
+     * <p>The map will not contain a mapping for the specified key once the
+     * call returns.
+     *
+     * @param key key whose mapping is to be removed from the map
+     * @return the previous value associated with <tt>key</tt>, or
+     * <tt>null</tt> if there was no mapping for <tt>key</tt>.
+     * @throws UnsupportedOperationException if the <tt>remove</tt> operation
+     *                                       is not supported by this map
+     * @throws ClassCastException            if the key is of an inappropriate type for
+     *                                       this map
+     *                                       (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException          if the specified key is null and this
+     *                                       map does not permit null keys
+     *                                       (<a href="Collection.html#optional-restrictions">optional</a>)
+     */
+
+    public V remove(Object key) {
+        return backedMap.remove(key);
+    }
+
+    /**
+     * Copies all of the mappings from the specified map to this map
+     * (optional operation).  The effect of this call is equivalent to that
+     * of calling {@link Map<>#put(k, v)} on this map once
+     * for each mapping from key <tt>k</tt> to value <tt>v</tt> in the
+     * specified map.  The behavior of this operation is undefined if the
+     * specified map is modified while the operation is in progress.
+     *
+     * @param m mappings to be stored in this map
+     * @throws UnsupportedOperationException if the <tt>putAll</tt> operation
+     *                                       is not supported by this map
+     * @throws ClassCastException            if the class of a key or value in the
+     *                                       specified map prevents it from being stored in this map
+     * @throws NullPointerException          if the specified map is null, or if
+     *                                       this map does not permit null keys or values, and the
+     *                                       specified map contains null keys or values
+     * @throws IllegalArgumentException      if some property of a key or value in
+     *                                       the specified map prevents it from being stored in this map
+     */
+
+    public void putAll(Map<? extends Pair<K, T>, ? extends V> m) {
+        backedMap.putAll(m);
+    }
+
+    /**
+     * Removes all of the mappings from this map (optional operation).
+     * The map will be empty after this call returns.
+     *
+     * @throws UnsupportedOperationException if the <tt>clear</tt> operation
+     *                                       is not supported by this map
+     */
+
+    public void clear() {
+        backedMap.clear();
+    }
+
+    /**
+     * Returns a {@link Set} view of the keys contained in this map.
+     * The applyTransformToDestination is backed by the map, so changes to the map are
+     * reflected in the applyTransformToDestination, and vice-versa.  If the map is modified
+     * while an iteration over the applyTransformToDestination is in progress (except through
+     * the iterator's own <tt>remove</tt> operation), the results of
+     * the iteration are undefined.  The applyTransformToDestination supports element removal,
+     * which removes the corresponding mapping from the map, via the
+     * <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
+     * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
+     * operations.  It does not support the <tt>add</tt> or <tt>addAll</tt>
+     * operations.
+     *
+     * @return a applyTransformToDestination view of the keys contained in this map
+     */
+
+    public Set<Pair<K, T>> keySet() {
+        return backedMap.keySet();
+    }
+
+    /**
+     * Returns a {@link Collection} view of the values contained in this map.
+     * The collection is backed by the map, so changes to the map are
+     * reflected in the collection, and vice-versa.  If the map is
+     * modified while an iteration over the collection is in progress
+     * (except through the iterator's own <tt>remove</tt> operation),
+     * the results of the iteration are undefined.  The collection
+     * supports element removal, which removes the corresponding
+     * mapping from the map, via the <tt>Iterator.remove</tt>,
+     * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
+     * <tt>retainAll</tt> and <tt>clear</tt> operations.  It does not
+     * support the <tt>add</tt> or <tt>addAll</tt> operations.
+     *
+     * @return a collection view of the values contained in this map
+     */
+
+    public Collection<V> values() {
+        return backedMap.values();
+    }
+
+    /**
+     * Returns a {@link Set} view of the mappings contained in this map.
+     * The applyTransformToDestination is backed by the map, so changes to the map are
+     * reflected in the applyTransformToDestination, and vice-versa.  If the map is modified
+     * while an iteration over the applyTransformToDestination is in progress (except through
+     * the iterator's own <tt>remove</tt> operation, or through the
+     * <tt>setValue</tt> operation on a map entry returned by the
+     * iterator) the results of the iteration are undefined.  The applyTransformToDestination
+     * supports element removal, which removes the corresponding
+     * mapping from the map, via the <tt>Iterator.remove</tt>,
+     * <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt> and
+     * <tt>clear</tt> operations.  It does not support the
+     * <tt>add</tt> or <tt>addAll</tt> operations.
+     *
+     * @return a applyTransformToDestination view of the mappings contained in this map
+     */
+
+    public Set<Entry<K, T, V>> entrySet() {
+        Set<Entry<K, T, V>> ret = new HashSet<>();
+        for (Pair<K, T> pair : backedMap.keySet()) {
+            ret.add(new Entry<>(pair.getFirst(), pair.getSecond(), backedMap.get(pair)));
+        }
+        return ret;
+    }
+
+    public V get(K k, T t) {
+        return get(new Pair<>(k, t));
+    }
+
+    public void put(K k, T t, V v) {
+        put(new Pair<>(k, t), v);
+    }
+
+
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof MultiDimensionalMap))
+            return false;
+
+        MultiDimensionalMap that = (MultiDimensionalMap) o;
+
+        return !(backedMap != null ? !backedMap.equals(that.backedMap) : that.backedMap != null);
+
+    }
+
+
+    public int hashCode() {
+        return backedMap != null ? backedMap.hashCode() : 0;
+    }
+
+
+    public String toString() {
+        return "MultiDimensionalMap{" + "backedMap=" + backedMap + '}';
+    }
+
+
+    public boolean contains(K k, T t) {
+        return containsKey(new Pair<>(k, t));
+    }
+
+
+    public static class Entry<K, T, V> implements Map.Entry<Pair<K, T>, V> {
+
+        private K firstKey;
+        private T secondKey;
+        private V value;
+
+        public Entry(K firstKey, T secondKey, V value) {
+            this.firstKey = firstKey;
+            this.secondKey = secondKey;
+            this.value = value;
+        }
+
+        public K getFirstKey() {
+            return firstKey;
+        }
+
+        public void setFirstKey(K firstKey) {
+            this.firstKey = firstKey;
+        }
+
+        public T getSecondKey() {
+            return secondKey;
+        }
+
+        public void setSecondKey(T secondKey) {
+            this.secondKey = secondKey;
+        }
+
+        public V getValue() {
+            return value;
+        }
+
+        /**
+         * Replaces the value corresponding to this entry with the specified
+         * value (optional operation).  (Writes through to the map.)  The
+         * behavior of this call is undefined if the mapping has already been
+         * removed from the map (by the iterator's <tt>remove</tt> operation).
+         *
+         * @param value new value to be stored in this entry
+         * @return old value corresponding to the entry
+         * @throws UnsupportedOperationException if the <tt>put</tt> operation
+         *                                       is not supported by the backing map
+         * @throws ClassCastException            if the class of the specified value
+         *                                       prevents it from being stored in the backing map
+         * @throws NullPointerException          if the backing map does not permit
+         *                                       null values, and the specified value is null
+         * @throws IllegalArgumentException      if some property of this value
+         *                                       prevents it from being stored in the backing map
+         * @throws IllegalStateException         implementations may, but are not
+         *                                       required to, throw this exception if the entry has been
+         *                                       removed from the backing map.
+         */
+
+        public V setValue(V value) {
+            V old = this.value;
+            this.value = value;
+            return old;
+        }
+
+
+        /**
+         * Returns the key corresponding to this entry.
+         *
+         * @return the key corresponding to this entry
+         * @throws IllegalStateException implementations may, but are not
+         *                               required to, throw this exception if the entry has been
+         *                               removed from the backing map.
+         */
+
+        public Pair<K, T> getKey() {
+            return new Pair<>(firstKey, secondKey);
+        }
+    }
+
+
+
+}

--- a/nd4j-common/src/main/java/org/nd4j/linalg/collection/MultiDimensionalSet.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/collection/MultiDimensionalSet.java
@@ -1,0 +1,360 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.nd4j.linalg.collection;
+
+import org.nd4j.linalg.primitives.Pair;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+/**
+ * Created by agibsonccc on 4/29/14.
+ */
+public class MultiDimensionalSet<K, V> implements Set<Pair<K, V>> {
+
+
+    private Set<Pair<K, V>> backedSet;
+
+    public MultiDimensionalSet(Set<Pair<K, V>> backedSet) {
+        this.backedSet = backedSet;
+    }
+
+    public static <K, V> MultiDimensionalSet<K, V> hashSet() {
+        return new MultiDimensionalSet<>(new HashSet<Pair<K, V>>());
+    }
+
+
+    public static <K, V> MultiDimensionalSet<K, V> treeSet() {
+        return new MultiDimensionalSet<>(new TreeSet<Pair<K, V>>());
+    }
+
+
+
+    public static <K, V> MultiDimensionalSet<K, V> concurrentSkipListSet() {
+        return new MultiDimensionalSet<>(new ConcurrentSkipListSet<Pair<K, V>>());
+    }
+
+    /**
+     * Returns the number of elements in this applyTransformToDestination (its cardinality).  If this
+     * applyTransformToDestination contains more than <tt>Integer.MAX_VALUE</tt> elements, returns
+     * <tt>Integer.MAX_VALUE</tt>.
+     *
+     * @return the number of elements in this applyTransformToDestination (its cardinality)
+     */
+    @Override
+    public int size() {
+        return backedSet.size();
+    }
+
+    /**
+     * Returns <tt>true</tt> if this applyTransformToDestination contains no elements.
+     *
+     * @return <tt>true</tt> if this applyTransformToDestination contains no elements
+     */
+    @Override
+    public boolean isEmpty() {
+        return backedSet.isEmpty();
+    }
+
+    /**
+     * Returns <tt>true</tt> if this applyTransformToDestination contains the specified element.
+     * More formally, returns <tt>true</tt> if and only if this applyTransformToDestination
+     * contains an element <tt>e</tt> such that
+     * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>.
+     *
+     * @param o element whose presence in this applyTransformToDestination is to be tested
+     * @return <tt>true</tt> if this applyTransformToDestination contains the specified element
+     * @throws ClassCastException   if the type of the specified element
+     *                              is incompatible with this applyTransformToDestination
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException if the specified element is null and this
+     *                              applyTransformToDestination does not permit null elements
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     */
+    @Override
+    public boolean contains(Object o) {
+        return backedSet.contains(o);
+    }
+
+    /**
+     * Returns an iterator over the elements in this applyTransformToDestination.  The elements are
+     * returned in no particular order (unless this applyTransformToDestination is an instance of some
+     * class that provides a guarantee).
+     *
+     * @return an iterator over the elements in this applyTransformToDestination
+     */
+    @Override
+    public Iterator<Pair<K, V>> iterator() {
+        return backedSet.iterator();
+    }
+
+    /**
+     * Returns an array containing all of the elements in this applyTransformToDestination.
+     * If this applyTransformToDestination makes any guarantees as to what order its elements
+     * are returned by its iterator, this method must return the
+     * elements in the same order.
+     * <p/>
+     * <p>The returned array will be "safe" in that no references to it
+     * are maintained by this applyTransformToDestination.  (In other words, this method must
+     * allocate a new array even if this applyTransformToDestination is backed by an array).
+     * The caller is thus free to modify the returned array.
+     * <p/>
+     * <p>This method acts as bridge between array-based and collection-based
+     * APIs.
+     *
+     * @return an array containing all the elements in this applyTransformToDestination
+     */
+    @Override
+    public Object[] toArray() {
+        return backedSet.toArray();
+    }
+
+    /**
+     * Returns an array containing all of the elements in this applyTransformToDestination; the
+     * runtime type of the returned array is that of the specified array.
+     * If the applyTransformToDestination fits in the specified array, it is returned therein.
+     * Otherwise, a new array is allocated with the runtime type of the
+     * specified array and the size of this applyTransformToDestination.
+     * <p/>
+     * <p>If this applyTransformToDestination fits in the specified array with room to spare
+     * (i.e., the array has more elements than this applyTransformToDestination), the element in
+     * the array immediately following the end of the applyTransformToDestination is applyTransformToDestination to
+     * <tt>null</tt>.  (This is useful in determining the length of this
+     * applyTransformToDestination <i>only</i> if the caller knows that this applyTransformToDestination does not contain
+     * any null elements.)
+     * <p/>
+     * <p>If this applyTransformToDestination makes any guarantees as to what order its elements
+     * are returned by its iterator, this method must return the elements
+     * in the same order.
+     * <p/>
+     * <p>Like the {@link #toArray()} method, this method acts as bridge between
+     * array-based and collection-based APIs.  Further, this method allows
+     * precise control over the runtime type of the output array, and may,
+     * under certain circumstances, be used to save allocation costs.
+     * <p/>
+     * <p>Suppose <tt>x</tt> is a applyTransformToDestination known to contain only strings.
+     * The following code can be used to dump the applyTransformToDestination into a newly allocated
+     * array of <tt>String</tt>:
+     * <p/>
+     * <pre>
+     *     String[] y = x.toArray(new String[0]);</pre>
+     *
+     * Note that <tt>toArray(new Object[0])</tt> is identical in function to
+     * <tt>toArray()</tt>.
+     *
+     * @param a the array into which the elements of this applyTransformToDestination are to be
+     *          stored, if it is big enough; otherwise, a new array of the same
+     *          runtime type is allocated for this purpose.
+     * @return an array containing all the elements in this applyTransformToDestination
+     * @throws ArrayStoreException  if the runtime type of the specified array
+     *                              is not a supertype of the runtime type of every element in this
+     *                              applyTransformToDestination
+     * @throws NullPointerException if the specified array is null
+     */
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return backedSet.toArray(a);
+    }
+
+    /**
+     * Adds the specified element to this applyTransformToDestination if it is not already present
+     * (optional operation).  More formally, adds the specified element
+     * <tt>e</tt> to this applyTransformToDestination if the applyTransformToDestination contains no element <tt>e2</tt>
+     * such that
+     * <tt>(e==null&nbsp;?&nbsp;e2==null&nbsp;:&nbsp;e.equals(e2))</tt>.
+     * If this applyTransformToDestination already contains the element, the call leaves the applyTransformToDestination
+     * unchanged and returns <tt>false</tt>.  In combination with the
+     * restriction on constructors, this ensures that sets never contain
+     * duplicate elements.
+     * <p/>
+     * <p>The stipulation above does not imply that sets must accept all
+     * elements; sets may refuse to add any particular element, including
+     * <tt>null</tt>, and throw an exception, as described in the
+     * specification for {@link Collection#add Collection.add}.
+     * Individual applyTransformToDestination implementations should clearly document any
+     * restrictions on the elements that they may contain.
+     *
+     * @param kvPair element to be added to this applyTransformToDestination
+     * @return <tt>true</tt> if this applyTransformToDestination did not already contain the specified
+     * element
+     * @throws UnsupportedOperationException if the <tt>add</tt> operation
+     *                                       is not supported by this applyTransformToDestination
+     * @throws ClassCastException            if the class of the specified element
+     *                                       prevents it from being added to this applyTransformToDestination
+     * @throws NullPointerException          if the specified element is null and this
+     *                                       applyTransformToDestination does not permit null elements
+     * @throws IllegalArgumentException      if some property of the specified element
+     *                                       prevents it from being added to this applyTransformToDestination
+     */
+    @Override
+    public boolean add(Pair<K, V> kvPair) {
+        return backedSet.add(kvPair);
+    }
+
+    /**
+     * Removes the specified element from this applyTransformToDestination if it is present
+     * (optional operation).  More formally, removes an element <tt>e</tt>
+     * such that
+     * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>, if
+     * this applyTransformToDestination contains such an element.  Returns <tt>true</tt> if this applyTransformToDestination
+     * contained the element (or equivalently, if this applyTransformToDestination changed as a
+     * result of the call).  (This applyTransformToDestination will not contain the element once the
+     * call returns.)
+     *
+     * @param o object to be removed from this applyTransformToDestination, if present
+     * @return <tt>true</tt> if this applyTransformToDestination contained the specified element
+     * @throws ClassCastException            if the type of the specified element
+     *                                       is incompatible with this applyTransformToDestination
+     *                                       (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException          if the specified element is null and this
+     *                                       applyTransformToDestination does not permit null elements
+     *                                       (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws UnsupportedOperationException if the <tt>remove</tt> operation
+     *                                       is not supported by this applyTransformToDestination
+     */
+    @Override
+    public boolean remove(Object o) {
+        return backedSet.remove(o);
+    }
+
+    /**
+     * Returns <tt>true</tt> if this applyTransformToDestination contains all of the elements of the
+     * specified collection.  If the specified collection is also a applyTransformToDestination, this
+     * method returns <tt>true</tt> if it is a <i>subset</i> of this applyTransformToDestination.
+     *
+     * @param c collection to be checked for containment in this applyTransformToDestination
+     * @return <tt>true</tt> if this applyTransformToDestination contains all of the elements of the
+     * specified collection
+     * @throws ClassCastException   if the types of one or more elements
+     *                              in the specified collection are incompatible with this
+     *                              applyTransformToDestination
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException if the specified collection contains one
+     *                              or more null elements and this applyTransformToDestination does not permit null
+     *                              elements
+     *                              (<a href="Collection.html#optional-restrictions">optional</a>),
+     *                              or if the specified collection is null
+     * @see #contains(Object)
+     */
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return backedSet.containsAll(c);
+    }
+
+    /**
+     * Adds all of the elements in the specified collection to this applyTransformToDestination if
+     * they're not already present (optional operation).  If the specified
+     * collection is also a applyTransformToDestination, the <tt>addAll</tt> operation effectively
+     * modifies this applyTransformToDestination so that its value is the <i>union</i> of the two
+     * sets.  The behavior of this operation is undefined if the specified
+     * collection is modified while the operation is in progress.
+     *
+     * @param c collection containing elements to be added to this applyTransformToDestination
+     * @return <tt>true</tt> if this applyTransformToDestination changed as a result of the call
+     * @throws UnsupportedOperationException if the <tt>addAll</tt> operation
+     *                                       is not supported by this applyTransformToDestination
+     * @throws ClassCastException            if the class of an element of the
+     *                                       specified collection prevents it from being added to this applyTransformToDestination
+     * @throws NullPointerException          if the specified collection contains one
+     *                                       or more null elements and this applyTransformToDestination does not permit null
+     *                                       elements, or if the specified collection is null
+     * @throws IllegalArgumentException      if some property of an element of the
+     *                                       specified collection prevents it from being added to this applyTransformToDestination
+     * @see #add(Object)
+     */
+    @Override
+    public boolean addAll(Collection<? extends Pair<K, V>> c) {
+        return backedSet.addAll(c);
+    }
+
+    /**
+     * Retains only the elements in this applyTransformToDestination that are contained in the
+     * specified collection (optional operation).  In other words, removes
+     * from this applyTransformToDestination all of its elements that are not contained in the
+     * specified collection.  If the specified collection is also a applyTransformToDestination, this
+     * operation effectively modifies this applyTransformToDestination so that its value is the
+     * <i>intersection</i> of the two sets.
+     *
+     * @param c collection containing elements to be retained in this applyTransformToDestination
+     * @return <tt>true</tt> if this applyTransformToDestination changed as a result of the call
+     * @throws UnsupportedOperationException if the <tt>retainAll</tt> operation
+     *                                       is not supported by this applyTransformToDestination
+     * @throws ClassCastException            if the class of an element of this applyTransformToDestination
+     *                                       is incompatible with the specified collection
+     *                                       (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException          if this applyTransformToDestination contains a null element and the
+     *                                       specified collection does not permit null elements
+     *                                       (<a href="Collection.html#optional-restrictions">optional</a>),
+     *                                       or if the specified collection is null
+     * @see #remove(Object)
+     */
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return backedSet.retainAll(c);
+    }
+
+    /**
+     * Removes from this applyTransformToDestination all of its elements that are contained in the
+     * specified collection (optional operation).  If the specified
+     * collection is also a applyTransformToDestination, this operation effectively modifies this
+     * applyTransformToDestination so that its value is the <i>asymmetric applyTransformToDestination difference</i> of
+     * the two sets.
+     *
+     * @param c collection containing elements to be removed from this applyTransformToDestination
+     * @return <tt>true</tt> if this applyTransformToDestination changed as a result of the call
+     * @throws UnsupportedOperationException if the <tt>removeAll</tt> operation
+     *                                       is not supported by this applyTransformToDestination
+     * @throws ClassCastException            if the class of an element of this applyTransformToDestination
+     *                                       is incompatible with the specified collection
+     *                                       (<a href="Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException          if this applyTransformToDestination contains a null element and the
+     *                                       specified collection does not permit null elements
+     *                                       (<a href="Collection.html#optional-restrictions">optional</a>),
+     *                                       or if the specified collection is null
+     * @see #remove(Object)
+     * @see #contains(Object)
+     */
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return backedSet.removeAll(c);
+    }
+
+    /**
+     * Removes all of the elements from this applyTransformToDestination (optional operation).
+     * The applyTransformToDestination will be empty after this call returns.
+     *
+     * @throws UnsupportedOperationException if the <tt>clear</tt> method
+     *                                       is not supported by this applyTransformToDestination
+     */
+    @Override
+    public void clear() {
+        backedSet.clear();
+    }
+
+
+
+    public boolean contains(K k, V v) {
+        return contains(new Pair<>(k, v));
+    }
+
+    public void add(K k, V v) {
+        add(new Pair<>(k, v));
+    }
+
+}

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/MathUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/MathUtils.java
@@ -1364,4 +1364,15 @@ public class MathUtils {
             array[i] = temp;
         }
     }
+
+    /**
+     * hashCode method, taken from Java 1.8 Double.hashCode(double) method
+     *
+     * @param value Double value to hash
+     * @return Hash code for the double value
+     */
+    public static int hashCode(double value) {
+        long bits = Double.doubleToLongBits(value);
+        return (int) (bits ^ (bits >>> 32));
+    }
 }

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/MathUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/MathUtils.java
@@ -22,10 +22,13 @@ package org.nd4j.linalg.util;
 
 import org.apache.commons.math3.random.RandomGenerator;
 import org.apache.commons.math3.util.FastMath;
+import org.nd4j.linalg.primitives.Counter;
+import org.nd4j.util.SetUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 
 /**
@@ -214,7 +217,39 @@ public class MathUtils {
             ret += Math.pow(targetAttribute[i] - predictedValues[i], 2);
         }
         return ret;
+    }
 
+    /**
+     * Calculate string similarity with tfidf weights relative to each character
+     * frequency and how many times a character appears in a given string
+     * @param strings the strings to calculate similarity for
+     * @return the cosine similarity between the strings
+     */
+    public static double stringSimilarity(String... strings) {
+        if (strings == null)
+            return 0;
+        Counter<String> counter = new Counter<>();
+        Counter<String> counter2 = new Counter<>();
+
+        for (int i = 0; i < strings[0].length(); i++)
+            counter.incrementCount(String.valueOf(strings[0].charAt(i)), 1.0f);
+
+        for (int i = 0; i < strings[1].length(); i++)
+            counter2.incrementCount(String.valueOf(strings[1].charAt(i)), 1.0f);
+        Set<String> v1 = counter.keySet();
+        Set<String> v2 = counter2.keySet();
+
+
+        Set<String> both = SetUtils.intersection(v1, v2);
+
+        double sclar = 0, norm1 = 0, norm2 = 0;
+        for (String k : both)
+            sclar += counter.getCount(k) * counter2.getCount(k);
+        for (String k : v1)
+            norm1 += counter.getCount(k) * counter.getCount(k);
+        for (String k : v2)
+            norm2 += counter2.getCount(k) * counter2.getCount(k);
+        return sclar / Math.sqrt(norm1 * norm2);
     }
 
     /**
@@ -1315,4 +1350,18 @@ public class MathUtils {
     public double slope(double x1, double x2, double y1, double y2) {
         return (y2 - y1) / (x2 - x1);
     }//end slope
+
+    public static void shuffleArray(int[] array, long rngSeed) {
+        shuffleArray(array, new Random(rngSeed));
+    }
+
+    public static void shuffleArray(int[] array, Random rng) {
+        //https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+        for (int i = array.length - 1; i > 0; i--) {
+            int j = rng.nextInt(i + 1);
+            int temp = array[j];
+            array[j] = array[i];
+            array[i] = temp;
+        }
+    }
 }

--- a/nd4j-common/src/main/java/org/nd4j/linalg/util/SerializationUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/util/SerializationUtils.java
@@ -29,7 +29,7 @@ import java.io.*;
  */
 public class SerializationUtils {
 
-    private SerializationUtils() {}
+    protected SerializationUtils() {}
 
     @SuppressWarnings("unchecked")
     public static <T> T readObject(File file) {

--- a/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
@@ -65,11 +65,12 @@ public class ArchiveUtils {
                     String fileName = ze.getName();
                     File newFile = new File(dest + File.separator + fileName);
 
-                    log.debug("File extracted: " + newFile.getAbsoluteFile());
-
-                    //createComplex all non exists folders
-                    //else you will hit FileNotFoundException for compressed folder
-                    new File(newFile.getParent()).mkdirs();
+                    if (ze.isDirectory()) {
+                        newFile.mkdirs();
+                        zis.closeEntry();
+                        ze = zis.getNextEntry();
+                        continue;
+                    }
 
                     FileOutputStream fos = new FileOutputStream(newFile);
 
@@ -80,6 +81,7 @@ public class ArchiveUtils {
 
                     fos.close();
                     ze = zis.getNextEntry();
+                    log.debug("File extracted: " + newFile.getAbsoluteFile());
                 }
 
                 zis.closeEntry();

--- a/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
@@ -1,0 +1,160 @@
+/*-
+ *
+ *  * Copyright 2018 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.nd4j.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * @author Adam Gibson
+ */
+@Slf4j
+public class ArchiveUtils {
+
+    private ArchiveUtils() {}
+
+    /**
+     * Extracts files to the specified destination
+     * @param file the file to extract to
+     * @param dest the destination directory
+     * @throws IOException
+     */
+    public static void unzipFileTo(String file, String dest) throws IOException {
+        File target = new File(file);
+        if (!target.exists())
+            throw new IllegalArgumentException("Archive doesnt exist");
+        FileInputStream fin = new FileInputStream(target);
+        int BUFFER = 2048;
+        byte data[] = new byte[BUFFER];
+
+        if (file.endsWith(".zip")) {
+            //getFromOrigin the zip file content
+            ZipInputStream zis = new ZipInputStream(fin);
+            //getFromOrigin the zipped file list entry
+            ZipEntry ze = zis.getNextEntry();
+
+            while (ze != null) {
+
+                String fileName = ze.getName();
+                File newFile = new File(dest + File.separator + fileName);
+
+                log.info("file unzip : " + newFile.getAbsoluteFile());
+
+                //createComplex all non exists folders
+                //else you will hit FileNotFoundException for compressed folder
+                new File(newFile.getParent()).mkdirs();
+
+                FileOutputStream fos = new FileOutputStream(newFile);
+
+                int len;
+                while ((len = zis.read(data)) > 0) {
+                    fos.write(data, 0, len);
+                }
+
+                fos.close();
+                ze = zis.getNextEntry();
+            }
+
+            zis.closeEntry();
+            zis.close();
+
+
+        }
+
+
+
+        else if (file.endsWith(".tar.gz") || file.endsWith(".tgz")) {
+
+            BufferedInputStream in = new BufferedInputStream(fin);
+            GzipCompressorInputStream gzIn = new GzipCompressorInputStream(in);
+            TarArchiveInputStream tarIn = new TarArchiveInputStream(gzIn);
+
+            TarArchiveEntry entry = null;
+
+            /** Read the tar entries using the getNextEntry method **/
+
+            while ((entry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {
+
+                log.info("Extracting: " + entry.getName());
+
+                /** If the entry is a directory, createComplex the directory. **/
+
+                if (entry.isDirectory()) {
+
+                    File f = new File(dest + File.separator + entry.getName());
+                    f.mkdirs();
+                }
+                /**
+                 * If the entry is a file,write the decompressed file to the disk
+                 * and close destination stream.
+                 **/
+                else {
+                    int count;
+
+                    FileOutputStream fos = new FileOutputStream(dest + File.separator + entry.getName());
+                    BufferedOutputStream destStream = new BufferedOutputStream(fos, BUFFER);
+                    while ((count = tarIn.read(data, 0, BUFFER)) != -1) {
+                        destStream.write(data, 0, count);
+                    }
+
+                    destStream.flush();
+
+                    IOUtils.closeQuietly(destStream);
+                }
+            }
+
+
+
+            /** Close the input stream **/
+
+            tarIn.close();
+        }
+
+        else if (file.endsWith(".gz")) {
+            GZIPInputStream is2 = new GZIPInputStream(fin);
+            File extracted = new File(target.getParent(), target.getName().replace(".gz", ""));
+            if (extracted.exists())
+                extracted.delete();
+            extracted.createNewFile();
+            OutputStream fos = FileUtils.openOutputStream(extracted);
+            IOUtils.copyLarge(is2, fos);
+            is2.close();
+            fos.flush();
+            fos.close();
+        }
+
+
+        target.delete();
+
+    }
+
+
+
+}

--- a/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
@@ -38,7 +38,7 @@ import java.util.zip.ZipInputStream;
 @Slf4j
 public class ArchiveUtils {
 
-    private ArchiveUtils() {
+    protected ArchiveUtils() {
     }
 
     /**

--- a/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
@@ -56,7 +56,7 @@ public class ArchiveUtils {
         int BUFFER = 2048;
         byte data[] = new byte[BUFFER];
 
-        if (file.endsWith(".zip")) {
+        if (file.endsWith(".zip") || file.endsWith(".jar")) {
             try(ZipInputStream zis = new ZipInputStream(fin)) {
                 //get the zipped file list entry
                 ZipEntry ze = zis.getNextEntry();
@@ -65,7 +65,7 @@ public class ArchiveUtils {
                     String fileName = ze.getName();
                     File newFile = new File(dest + File.separator + fileName);
 
-                    log.info("file unzip : " + newFile.getAbsoluteFile());
+                    log.debug("File extracted: " + newFile.getAbsoluteFile());
 
                     //createComplex all non exists folders
                     //else you will hit FileNotFoundException for compressed folder
@@ -129,6 +129,9 @@ public class ArchiveUtils {
                 IOUtils.copyLarge(is2, fos);
                 fos.flush();
             }
+        } else {
+            throw new IllegalStateException("Unable to infer file type (compression format) from source file name: " +
+                    file);
         }
         target.delete();
     }

--- a/nd4j-common/src/main/java/org/nd4j/util/FingerPrintKeyer.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/FingerPrintKeyer.java
@@ -1,0 +1,295 @@
+/*
+
+Copyright 2010, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+package org.nd4j.util;
+
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+/**
+ * Copied from google refine:
+ * takes the key and gets rid of all punctuation, transforms to lower case
+ * and alphabetic sorts the words
+ * @author Adam Gibson
+ *
+ */
+public class FingerPrintKeyer {
+
+    // Punctuation and control characters (except for TAB which we need for split to work)
+    static final Pattern punctctrl = Pattern.compile("\\p{Punct}|[\\x00-\\x08\\x0A-\\x1F\\x7F]");
+
+    public String key(String s, Object... o) {
+        if (s == null || o != null && o.length > 0) {
+            throw new IllegalArgumentException("Fingerprint keyer accepts a single string parameter");
+        }
+        s = s.trim(); // first off, remove whitespace around the string
+        s = s.toLowerCase(); // then lowercase it
+        s = punctctrl.matcher(s).replaceAll(""); // then remove all punctuation and control chars
+        String[] frags = StringUtils.split(s); // split by whitespace
+        TreeSet<String> set = new TreeSet<>();
+        Collections.addAll(set, frags);
+        StringBuilder b = new StringBuilder();
+        Iterator<String> i = set.iterator();
+        while (i.hasNext()) { // join ordered fragments back together
+            b.append(i.next());
+            if (i.hasNext()) {
+                b.append(' ');
+            }
+        }
+        return asciify(b.toString()); // find ASCII equivalent to characters 
+    }
+
+    protected String asciify(String s) {
+        char[] c = s.toCharArray();
+        StringBuilder b = new StringBuilder();
+        for (char element : c) {
+            b.append(translate(element));
+        }
+        return b.toString();
+    }
+
+    /**
+     * Translate the given unicode char in the closest ASCII representation
+     * NOTE: this function deals only with latin-1 supplement and latin-1 extended code charts
+     */
+    private char translate(char c) {
+        switch (c) {
+            case '\u00C0':
+            case '\u00C1':
+            case '\u00C2':
+            case '\u00C3':
+            case '\u00C4':
+            case '\u00C5':
+            case '\u00E0':
+            case '\u00E1':
+            case '\u00E2':
+            case '\u00E3':
+            case '\u00E4':
+            case '\u00E5':
+            case '\u0100':
+            case '\u0101':
+            case '\u0102':
+            case '\u0103':
+            case '\u0104':
+            case '\u0105':
+                return 'a';
+            case '\u00C7':
+            case '\u00E7':
+            case '\u0106':
+            case '\u0107':
+            case '\u0108':
+            case '\u0109':
+            case '\u010A':
+            case '\u010B':
+            case '\u010C':
+            case '\u010D':
+                return 'c';
+            case '\u00D0':
+            case '\u00F0':
+            case '\u010E':
+            case '\u010F':
+            case '\u0110':
+            case '\u0111':
+                return 'd';
+            case '\u00C8':
+            case '\u00C9':
+            case '\u00CA':
+            case '\u00CB':
+            case '\u00E8':
+            case '\u00E9':
+            case '\u00EA':
+            case '\u00EB':
+            case '\u0112':
+            case '\u0113':
+            case '\u0114':
+            case '\u0115':
+            case '\u0116':
+            case '\u0117':
+            case '\u0118':
+            case '\u0119':
+            case '\u011A':
+            case '\u011B':
+                return 'e';
+            case '\u011C':
+            case '\u011D':
+            case '\u011E':
+            case '\u011F':
+            case '\u0120':
+            case '\u0121':
+            case '\u0122':
+            case '\u0123':
+                return 'g';
+            case '\u0124':
+            case '\u0125':
+            case '\u0126':
+            case '\u0127':
+                return 'h';
+            case '\u00CC':
+            case '\u00CD':
+            case '\u00CE':
+            case '\u00CF':
+            case '\u00EC':
+            case '\u00ED':
+            case '\u00EE':
+            case '\u00EF':
+            case '\u0128':
+            case '\u0129':
+            case '\u012A':
+            case '\u012B':
+            case '\u012C':
+            case '\u012D':
+            case '\u012E':
+            case '\u012F':
+            case '\u0130':
+            case '\u0131':
+                return 'i';
+            case '\u0134':
+            case '\u0135':
+                return 'j';
+            case '\u0136':
+            case '\u0137':
+            case '\u0138':
+                return 'k';
+            case '\u0139':
+            case '\u013A':
+            case '\u013B':
+            case '\u013C':
+            case '\u013D':
+            case '\u013E':
+            case '\u013F':
+            case '\u0140':
+            case '\u0141':
+            case '\u0142':
+                return 'l';
+            case '\u00D1':
+            case '\u00F1':
+            case '\u0143':
+            case '\u0144':
+            case '\u0145':
+            case '\u0146':
+            case '\u0147':
+            case '\u0148':
+            case '\u0149':
+            case '\u014A':
+            case '\u014B':
+                return 'n';
+            case '\u00D2':
+            case '\u00D3':
+            case '\u00D4':
+            case '\u00D5':
+            case '\u00D6':
+            case '\u00D8':
+            case '\u00F2':
+            case '\u00F3':
+            case '\u00F4':
+            case '\u00F5':
+            case '\u00F6':
+            case '\u00F8':
+            case '\u014C':
+            case '\u014D':
+            case '\u014E':
+            case '\u014F':
+            case '\u0150':
+            case '\u0151':
+                return 'o';
+            case '\u0154':
+            case '\u0155':
+            case '\u0156':
+            case '\u0157':
+            case '\u0158':
+            case '\u0159':
+                return 'r';
+            case '\u015A':
+            case '\u015B':
+            case '\u015C':
+            case '\u015D':
+            case '\u015E':
+            case '\u015F':
+            case '\u0160':
+            case '\u0161':
+            case '\u017F':
+                return 's';
+            case '\u0162':
+            case '\u0163':
+            case '\u0164':
+            case '\u0165':
+            case '\u0166':
+            case '\u0167':
+                return 't';
+            case '\u00D9':
+            case '\u00DA':
+            case '\u00DB':
+            case '\u00DC':
+            case '\u00F9':
+            case '\u00FA':
+            case '\u00FB':
+            case '\u00FC':
+            case '\u0168':
+            case '\u0169':
+            case '\u016A':
+            case '\u016B':
+            case '\u016C':
+            case '\u016D':
+            case '\u016E':
+            case '\u016F':
+            case '\u0170':
+            case '\u0171':
+            case '\u0172':
+            case '\u0173':
+                return 'u';
+            case '\u0174':
+            case '\u0175':
+                return 'w';
+            case '\u00DD':
+            case '\u00FD':
+            case '\u00FF':
+            case '\u0176':
+            case '\u0177':
+            case '\u0178':
+                return 'y';
+            case '\u0179':
+            case '\u017A':
+            case '\u017B':
+            case '\u017C':
+            case '\u017D':
+            case '\u017E':
+                return 'z';
+        }
+        return c;
+    }
+}

--- a/nd4j-common/src/main/java/org/nd4j/util/Index.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/Index.java
@@ -1,0 +1,123 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.nd4j.util;
+
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An index is a transform of objects augmented with a list and a reverse lookup table
+ * for fast lookups.
+ * Indices are used for vocabulary in many of the natural language processing
+ * @author Adam Gibson
+ *
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class Index implements Serializable {
+
+    private static final long serialVersionUID = 1160629777026141078L;
+    private Map<Integer, Object> objects = new ConcurrentHashMap<>();
+    private Map<Object, Integer> indexes = new ConcurrentHashMap<>();
+
+    public synchronized boolean add(Object o, int idx) {
+        if (o instanceof String && o.toString().isEmpty()) {
+            throw new IllegalArgumentException("Unable to add the empty string");
+        }
+
+        Integer index = indexes.get(o);
+        if (index == null) {
+            index = idx;
+            objects.put(idx, o);
+            indexes.put(o, index);
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized boolean add(Object o) {
+        if (o instanceof String && o.toString().isEmpty()) {
+            throw new IllegalArgumentException("Unable to add the empty string");
+        }
+        Integer index = indexes.get(o);
+        if (index == null) {
+            index = objects.size();
+            objects.put(index, o);
+            indexes.put(o, index);
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized int indexOf(Object o) {
+        Integer index = indexes.get(o);
+        if (index == null) {
+            return -1;
+        } else {
+            return index;
+        }
+    }
+
+    public synchronized Object get(int i) {
+        return objects.get(i);
+    }
+
+    public int size() {
+        return objects.size();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buff = new StringBuilder("[");
+        int sz = objects.size();
+        int i;
+        for (i = 0; i < sz; i++) {
+            Object e = objects.get(i);
+            buff.append(e);
+            if (i < (sz - 1))
+                buff.append(" , ");
+        }
+        buff.append("]");
+        return buff.toString();
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        Index index = (Index) o;
+
+        if (objects != null ? !objects.equals(index.objects) : index.objects != null)
+            return false;
+        return !(indexes != null ? !indexes.equals(index.indexes) : index.indexes != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = objects != null ? objects.hashCode() : 0;
+        result = 31 * result + (indexes != null ? indexes.hashCode() : 0);
+        return result;
+    }
+}

--- a/nd4j-common/src/main/java/org/nd4j/util/OneTimeLogger.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/OneTimeLogger.java
@@ -1,0 +1,75 @@
+package org.nd4j.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ *
+ * @author raver119@gmail.com
+ */
+@Slf4j
+public class OneTimeLogger {
+    protected static HashSet<String> hashSet = new HashSet<>();
+    protected static final Queue<String> buffer = new LinkedTransferQueue<>();
+
+    private static final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    protected static boolean isEligible(String message) {
+
+        try {
+            lock.readLock().lock();
+
+            if (hashSet.contains(message))
+                return false;
+
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        try {
+            lock.writeLock().lock();
+
+            if (buffer.size() >= 100) {
+                String rem = buffer.remove();
+                hashSet.remove(rem);
+            }
+
+            buffer.add(message);
+            hashSet.add(message);
+
+            return true;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public static void info(Logger logger, String format, Object... arguments) {
+        if (!isEligible(format))
+            return;
+
+        logger.info(format, arguments);
+    }
+
+    public static void warn(Logger logger, String format, Object... arguments) {
+        if (!isEligible(format))
+            return;
+
+        logger.warn(format, arguments);
+    }
+
+    public static void error(Logger logger, String format, Object... arguments) {
+        if (!isEligible(format))
+            return;
+
+        logger.error(format, arguments);
+    }
+
+    public static void reset() {
+        buffer.clear();
+    }
+}

--- a/nd4j-common/src/main/java/org/nd4j/util/ReflectionUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/ReflectionUtils.java
@@ -1,0 +1,124 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.nd4j.util;
+
+
+import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * General reflection utils
+ */
+public class ReflectionUtils {
+
+    /**
+     * Cache of constructors for each class. Pins the classes so they
+     * can't be garbage collected until ReflectionUtils can be collected.
+     */
+    private static final Map<Class<?>, Constructor<?>> CONSTRUCTOR_CACHE = new ConcurrentHashMap<>();
+
+    private ReflectionUtils() {}
+
+
+
+    static private ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+
+    public static void setContentionTracing(boolean val) {
+        threadBean.setThreadContentionMonitoringEnabled(val);
+    }
+
+    private static String getTaskName(long id, String name) {
+        if (name == null) {
+            return Long.toString(id);
+        }
+        return id + " (" + name + ")";
+    }
+
+    /**
+     * Print all of the thread's information and stack traces.
+     *
+     * @param stream the stream to
+     * @param title a string title for the stack trace
+     */
+    public static void printThreadInfo(PrintWriter stream, String title) {
+        final int STACK_DEPTH = 20;
+        boolean contention = threadBean.isThreadContentionMonitoringEnabled();
+        long[] threadIds = threadBean.getAllThreadIds();
+        stream.println("Process Thread Dump: " + title);
+        stream.println(threadIds.length + " active threads");
+        for (long tid : threadIds) {
+            ThreadInfo info = threadBean.getThreadInfo(tid, STACK_DEPTH);
+            if (info == null) {
+                stream.println("  Inactive");
+                continue;
+            }
+            stream.println("Thread " + getTaskName(info.getThreadId(), info.getThreadName()) + ":");
+            Thread.State state = info.getThreadState();
+            stream.println("  State: " + state);
+            stream.println("  Blocked count: " + info.getBlockedCount());
+            stream.println("  Waited count: " + info.getWaitedCount());
+            if (contention) {
+                stream.println("  Blocked time: " + info.getBlockedTime());
+                stream.println("  Waited time: " + info.getWaitedTime());
+            }
+            if (state == Thread.State.WAITING) {
+                stream.println("  Waiting on " + info.getLockName());
+            } else if (state == Thread.State.BLOCKED) {
+                stream.println("  Blocked on " + info.getLockName());
+                stream.println("  Blocked by " + getTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
+            }
+            stream.println("  Stack:");
+            for (StackTraceElement frame : info.getStackTrace()) {
+                stream.println("    " + frame.toString());
+            }
+        }
+        stream.flush();
+    }
+
+    private static long previousLogTime = 0;
+
+
+    /**
+     * Return the correctly-typed {@link Class} of the given object.
+     *
+     * @param o object whose correctly-typed <code>Class</code> is to be obtained
+     * @return the correctly typed <code>Class</code> of the given object.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Class<T> getClass(T o) {
+        return (Class<T>) o.getClass();
+    }
+
+    // methods to support testing
+    static void clearCache() {
+        CONSTRUCTOR_CACHE.clear();
+    }
+
+    static int getCacheSize() {
+        return CONSTRUCTOR_CACHE.size();
+    }
+
+
+
+}

--- a/nd4j-common/src/main/java/org/nd4j/util/ReflectionUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/ReflectionUtils.java
@@ -36,9 +36,9 @@ public class ReflectionUtils {
      * Cache of constructors for each class. Pins the classes so they
      * can't be garbage collected until ReflectionUtils can be collected.
      */
-    private static final Map<Class<?>, Constructor<?>> CONSTRUCTOR_CACHE = new ConcurrentHashMap<>();
+    protected static final Map<Class<?>, Constructor<?>> CONSTRUCTOR_CACHE = new ConcurrentHashMap<>();
 
-    private ReflectionUtils() {}
+    protected ReflectionUtils() {}
 
 
 

--- a/nd4j-common/src/main/java/org/nd4j/util/SetUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/SetUtils.java
@@ -1,0 +1,59 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.nd4j.util;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SetUtils {
+    protected SetUtils() {}
+
+    // Set specific operations
+
+    public static <T> Set<T> intersection(Collection<T> parentCollection, Collection<T> removeFromCollection) {
+        Set<T> results = new HashSet<>(parentCollection);
+        results.retainAll(removeFromCollection);
+        return results;
+    }
+
+    public static <T> boolean intersectionP(Set<? extends T> s1, Set<? extends T> s2) {
+        for (T elt : s1) {
+            if (s2.contains(elt))
+                return true;
+        }
+        return false;
+    }
+
+    public static <T> Set<T> union(Set<? extends T> s1, Set<? extends T> s2) {
+        Set<T> s3 = new HashSet<>(s1);
+        s3.addAll(s2);
+        return s3;
+    }
+
+    /** Return is s1 \ s2 */
+
+    public static <T> Set<T> difference(Collection<? extends T> s1, Collection<? extends T> s2) {
+        Set<T> s3 = new HashSet<>(s1);
+        s3.removeAll(s2);
+        return s3;
+    }
+}
+
+

--- a/nd4j-common/src/main/java/org/nd4j/util/StringUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/StringUtils.java
@@ -491,6 +491,59 @@ public class StringUtils {
     }
 
     /**
+     * This function splits the String s into multiple Strings using the
+     * splitChar.  However, it provides an quoting facility: it is possible to
+     * quote strings with the quoteChar.
+     * If the quoteChar occurs within the quotedExpression, it must be prefaced
+     * by the escapeChar
+     *
+     * @param s         The String to split
+     * @param splitChar
+     * @param quoteChar
+     * @return An array of Strings that s is split into
+     */
+    public static String[] splitOnCharWithQuoting(String s, char splitChar, char quoteChar, char escapeChar) {
+        List<String> result = new ArrayList<>();
+        int i = 0;
+        int length = s.length();
+        StringBuilder b = new StringBuilder();
+        while (i < length) {
+            char curr = s.charAt(i);
+            if (curr == splitChar) {
+                // add last buffer
+                if (b.length() > 0) {
+                    result.add(b.toString());
+                    b = new StringBuilder();
+                }
+                i++;
+            } else if (curr == quoteChar) {
+                // find next instance of quoteChar
+                i++;
+                while (i < length) {
+                    curr = s.charAt(i);
+                    if (curr == escapeChar) {
+                        b.append(s.charAt(i + 1));
+                        i += 2;
+                    } else if (curr == quoteChar) {
+                        i++;
+                        break; // break this loop
+                    } else {
+                        b.append(s.charAt(i));
+                        i++;
+                    }
+                }
+            } else {
+                b.append(curr);
+                i++;
+            }
+        }
+        if (b.length() > 0) {
+            result.add(b.toString());
+        }
+        return result.toArray(new String[0]);
+    }
+
+    /**
      * Escape commas in the string using the default escape char
      * @param str a string
      * @return an escaped string
@@ -797,6 +850,20 @@ public class StringUtils {
         return sb.toString();
     }
 
+    /**
+     * Concatenates strings, using whitespaces as separator.
+     *
+     * @param strings Strings to join.
+     */
+    public static String join(Iterable<String> strings){
+        return join(" ", strings);
+    }
+
+    /**
+     * Concatenates strings, using whitespaces as separator.
+     *
+     * @param strings Strings to join.
+     */
     public static String join(char separator, Iterable<?> strings) {
         return join(separator + "", strings);
     }

--- a/nd4j-common/src/main/java/org/nd4j/util/StringUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/StringUtils.java
@@ -1,0 +1,958 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nd4j.util;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Preconditions;
+import com.google.common.net.InetAddresses;
+
+/**
+ * General string utils - adapted from <a href="https://github.com/apache/hadoop/blob/master/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/StringUtils.java">
+ *     Apache Hadoop StringUtils</a>, with modifications
+ *
+ */
+public class StringUtils {
+
+    /**
+     * Make a string representation of the exception.
+     * @param e The exception to stringify
+     * @return A string with exception name and call stack.
+     */
+    public static String stringifyException(Throwable e) {
+        StringWriter stm = new StringWriter();
+        PrintWriter wrt = new PrintWriter(stm);
+        e.printStackTrace(wrt);
+        wrt.close();
+        return stm.toString();
+    }
+
+    /**
+     * Given a full hostname, return the word upto the first dot.
+     * @param fullHostname the full hostname
+     * @return the hostname to the first dot
+     */
+    public static String simpleHostname(String fullHostname) {
+        if (InetAddresses.isInetAddress(fullHostname)) {
+            return fullHostname;
+        }
+        int offset = fullHostname.indexOf('.');
+        if (offset != -1) {
+            return fullHostname.substring(0, offset);
+        }
+        return fullHostname;
+    }
+
+    /**
+     * Given an integer, return a string that is in an approximate, but human
+     * readable format.
+     * @param number the number to format
+     * @return a human readable form of the integer
+     *
+     * @deprecated use {@link TraditionalBinaryPrefix#long2String(long, String, int)}.
+     */
+    @Deprecated
+    public static String humanReadableInt(long number) {
+        return TraditionalBinaryPrefix.long2String(number, "", 1);
+    }
+
+    /** The same as String.format(Locale.ENGLISH, format, objects). */
+    public static String format(final String format, final Object... objects) {
+        return String.format(Locale.ENGLISH, format, objects);
+    }
+
+    /**
+     * Format a percentage for presentation to the user.
+     * @param fraction the percentage as a fraction, e.g. 0.1 = 10%
+     * @param decimalPlaces the number of decimal places
+     * @return a string representation of the percentage
+     */
+    public static String formatPercent(double fraction, int decimalPlaces) {
+        return format("%." + decimalPlaces + "f%%", fraction*100);
+    }
+
+    /**
+     * Given an array of strings, return a comma-separated list of its elements.
+     * @param strs Array of strings
+     * @return Empty string if strs.length is 0, comma separated list of strings
+     * otherwise
+     */
+    public static String arrayToString(String[] strs) {
+        if (strs.length == 0) { return ""; }
+        StringBuilder sbuf = new StringBuilder();
+        sbuf.append(strs[0]);
+        for (int idx = 1; idx < strs.length; idx++) {
+            sbuf.append(",");
+            sbuf.append(strs[idx]);
+        }
+        return sbuf.toString();
+    }
+
+    /**
+     * Given an array of bytes it will convert the bytes to a hex string
+     * representation of the bytes
+     * @param bytes
+     * @param start start index, inclusively
+     * @param end end index, exclusively
+     * @return hex string representation of the byte array
+     */
+    public static String byteToHexString(byte[] bytes, int start, int end) {
+        if (bytes == null) {
+            throw new IllegalArgumentException("bytes == null");
+        }
+        StringBuilder s = new StringBuilder();
+        for(int i = start; i < end; i++) {
+            s.append(format("%02x", bytes[i]));
+        }
+        return s.toString();
+    }
+
+    /** Same as byteToHexString(bytes, 0, bytes.length). */
+    public static String byteToHexString(byte bytes[]) {
+        return byteToHexString(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Convert a byte to a hex string.
+     * @see #byteToHexString(byte[])
+     * @see #byteToHexString(byte[], int, int)
+     * @param b byte
+     * @return byte's hex value as a String
+     */
+    public static String byteToHexString(byte b) {
+        return byteToHexString(new byte[] {b});
+    }
+
+    /**
+     * Given a hexstring this will return the byte array corresponding to the
+     * string
+     * @param hex the hex String array
+     * @return a byte array that is a hex string representation of the given
+     *         string. The size of the byte array is therefore hex.length/2
+     */
+    public static byte[] hexStringToByte(String hex) {
+        byte[] bts = new byte[hex.length() / 2];
+        for (int i = 0; i < bts.length; i++) {
+            bts[i] = (byte) Integer.parseInt(hex.substring(2 * i, 2 * i + 2), 16);
+        }
+        return bts;
+    }
+    /**
+     *
+     * @param uris
+     */
+    public static String uriToString(URI[] uris){
+        if (uris == null) {
+            return null;
+        }
+        StringBuilder ret = new StringBuilder(uris[0].toString());
+        for(int i = 1; i < uris.length;i++){
+            ret.append(",");
+            ret.append(uris[i].toString());
+        }
+        return ret.toString();
+    }
+
+    /**
+     * @param str
+     *          The string array to be parsed into an URI array.
+     * @return <tt>null</tt> if str is <tt>null</tt>, else the URI array
+     *         equivalent to str.
+     * @throws IllegalArgumentException
+     *           If any string in str violates RFC&nbsp;2396.
+     */
+    public static URI[] stringToURI(String[] str){
+        if (str == null)
+            return null;
+        URI[] uris = new URI[str.length];
+        for (int i = 0; i < str.length;i++){
+            try{
+                uris[i] = new URI(str[i]);
+            }catch(URISyntaxException ur){
+                throw new IllegalArgumentException(
+                        "Failed to create uri for " + str[i], ur);
+            }
+        }
+        return uris;
+    }
+
+    /**
+     *
+     * Given a finish and start time in long milliseconds, returns a
+     * String in the format Xhrs, Ymins, Z sec, for the time difference between two times.
+     * If finish time comes before start time then negative valeus of X, Y and Z wil return.
+     *
+     * @param finishTime finish time
+     * @param startTime start time
+     */
+    public static String formatTimeDiff(long finishTime, long startTime){
+        long timeDiff = finishTime - startTime;
+        return formatTime(timeDiff);
+    }
+
+    /**
+     *
+     * Given the time in long milliseconds, returns a
+     * String in the format Xhrs, Ymins, Z sec.
+     *
+     * @param timeDiff The time difference to format
+     */
+    public static String formatTime(long timeDiff){
+        StringBuilder buf = new StringBuilder();
+        long hours = timeDiff / (60*60*1000);
+        long rem = (timeDiff % (60*60*1000));
+        long minutes =  rem / (60*1000);
+        rem = rem % (60*1000);
+        long seconds = rem / 1000;
+
+        if (hours != 0){
+            buf.append(hours);
+            buf.append("hrs, ");
+        }
+        if (minutes != 0){
+            buf.append(minutes);
+            buf.append("mins, ");
+        }
+        // return "0sec if no difference
+        buf.append(seconds);
+        buf.append("sec");
+        return buf.toString();
+    }
+
+    /**
+     *
+     * Given the time in long milliseconds, returns a String in the sortable
+     * format Xhrs, Ymins, Zsec. X, Y, and Z are always two-digit. If the time is
+     * more than 100 hours ,it is displayed as 99hrs, 59mins, 59sec.
+     *
+     * @param timeDiff The time difference to format
+     */
+    public static String formatTimeSortable(long timeDiff) {
+        StringBuilder buf = new StringBuilder();
+        long hours = timeDiff / (60 * 60 * 1000);
+        long rem = (timeDiff % (60 * 60 * 1000));
+        long minutes = rem / (60 * 1000);
+        rem = rem % (60 * 1000);
+        long seconds = rem / 1000;
+
+        // if hours is more than 99 hours, it will be set a max value format
+        if (hours > 99) {
+            hours = 99;
+            minutes = 59;
+            seconds = 59;
+        }
+
+        buf.append(String.format("%02d", hours));
+        buf.append("hrs, ");
+
+        buf.append(String.format("%02d", minutes));
+        buf.append("mins, ");
+
+        buf.append(String.format("%02d", seconds));
+        buf.append("sec");
+        return buf.toString();
+    }
+
+    /**
+     * Formats time in ms and appends difference (finishTime - startTime)
+     * as returned by formatTimeDiff().
+     * If finish time is 0, empty string is returned, if start time is 0
+     * then difference is not appended to return value.
+     * @param formattedFinishTime formattedFinishTime to use
+     * @param finishTime finish time
+     * @param startTime start time
+     * @return formatted value.
+     */
+    public static String getFormattedTimeWithDiff(String formattedFinishTime,
+                                                  long finishTime, long startTime){
+        StringBuilder buf = new StringBuilder();
+        if (0 != finishTime) {
+            buf.append(formattedFinishTime);
+            if (0 != startTime){
+                buf.append(" (" + formatTimeDiff(finishTime , startTime) + ")");
+            }
+        }
+        return buf.toString();
+    }
+
+    /**
+     * Returns an arraylist of strings.
+     * @param str the comma separated string values
+     * @return the arraylist of the comma separated string values
+     */
+    public static String[] getStrings(String str){
+        String delim = ",";
+        return getStrings(str, delim);
+    }
+
+    /**
+     * Returns an arraylist of strings.
+     * @param str the string values
+     * @param delim delimiter to separate the values
+     * @return the arraylist of the separated string values
+     */
+    public static String[] getStrings(String str, String delim){
+        Collection<String> values = getStringCollection(str, delim);
+        if(values.size() == 0) {
+            return null;
+        }
+        return values.toArray(new String[values.size()]);
+    }
+
+    /**
+     * Returns a collection of strings.
+     * @param str comma separated string values
+     * @return an <code>ArrayList</code> of string values
+     */
+    public static Collection<String> getStringCollection(String str){
+        String delim = ",";
+        return getStringCollection(str, delim);
+    }
+
+    /**
+     * Returns a collection of strings.
+     *
+     * @param str
+     *          String to parse
+     * @param delim
+     *          delimiter to separate the values
+     * @return Collection of parsed elements.
+     */
+    public static Collection<String> getStringCollection(String str, String delim) {
+        List<String> values = new ArrayList<String>();
+        if (str == null)
+            return values;
+        StringTokenizer tokenizer = new StringTokenizer(str, delim);
+        while (tokenizer.hasMoreTokens()) {
+            values.add(tokenizer.nextToken());
+        }
+        return values;
+    }
+
+    /**
+     * Splits a comma separated value <code>String</code>, trimming leading and
+     * trailing whitespace on each value. Duplicate and empty values are removed.
+     *
+     * @param str a comma separated <String> with values, may be null
+     * @return a <code>Collection</code> of <code>String</code> values, empty
+     *         Collection if null String input
+     */
+    public static Collection<String> getTrimmedStringCollection(String str){
+        Set<String> set = new LinkedHashSet<String>(
+                Arrays.asList(getTrimmedStrings(str)));
+        set.remove("");
+        return set;
+    }
+
+    /**
+     * Splits a comma or newline separated value <code>String</code>, trimming
+     * leading and trailing whitespace on each value.
+     *
+     * @param str a comma or newline separated <code>String</code> with values,
+     *            may be null
+     * @return an array of <code>String</code> values, empty array if null String
+     *         input
+     */
+    public static String[] getTrimmedStrings(String str){
+        if (null == str || str.trim().isEmpty()) {
+            return emptyStringArray;
+        }
+
+        return str.trim().split("\\s*[,\n]\\s*");
+    }
+
+    final public static String[] emptyStringArray = {};
+    final public static char COMMA = ',';
+    final public static char ESCAPE_CHAR = '\\';
+
+    /**
+     * Split a string using the default separator
+     * @param str a string that may have escaped separator
+     * @return an array of strings
+     */
+    public static String[] split(String str) {
+        return split(str, ESCAPE_CHAR, COMMA);
+    }
+
+    /**
+     * Split a string using the given separator
+     * @param str a string that may have escaped separator
+     * @param escapeChar a char that be used to escape the separator
+     * @param separator a separator char
+     * @return an array of strings
+     */
+    public static String[] split(
+            String str, char escapeChar, char separator) {
+        if (str==null) {
+            return null;
+        }
+        ArrayList<String> strList = new ArrayList<String>();
+        StringBuilder split = new StringBuilder();
+        int index = 0;
+        while ((index = findNext(str, separator, escapeChar, index, split)) >= 0) {
+            ++index; // move over the separator for next search
+            strList.add(split.toString());
+            split.setLength(0); // reset the buffer
+        }
+        strList.add(split.toString());
+        // remove trailing empty split(s)
+        int last = strList.size(); // last split
+        while (--last>=0 && "".equals(strList.get(last))) {
+            strList.remove(last);
+        }
+        return strList.toArray(new String[strList.size()]);
+    }
+
+    /**
+     * Split a string using the given separator, with no escaping performed.
+     * @param str a string to be split. Note that this may not be null.
+     * @param separator a separator char
+     * @return an array of strings
+     */
+    public static String[] split(
+            String str, char separator) {
+        // String.split returns a single empty result for splitting the empty
+        // string.
+        if (str.isEmpty()) {
+            return new String[]{""};
+        }
+        ArrayList<String> strList = new ArrayList<String>();
+        int startIndex = 0;
+        int nextIndex = 0;
+        while ((nextIndex = str.indexOf(separator, startIndex)) != -1) {
+            strList.add(str.substring(startIndex, nextIndex));
+            startIndex = nextIndex + 1;
+        }
+        strList.add(str.substring(startIndex));
+        // remove trailing empty split(s)
+        int last = strList.size(); // last split
+        while (--last>=0 && "".equals(strList.get(last))) {
+            strList.remove(last);
+        }
+        return strList.toArray(new String[strList.size()]);
+    }
+
+    /**
+     * Finds the first occurrence of the separator character ignoring the escaped
+     * separators starting from the index. Note the substring between the index
+     * and the position of the separator is passed.
+     * @param str the source string
+     * @param separator the character to find
+     * @param escapeChar character used to escape
+     * @param start from where to search
+     * @param split used to pass back the extracted string
+     */
+    public static int findNext(String str, char separator, char escapeChar,
+                               int start, StringBuilder split) {
+        int numPreEscapes = 0;
+        for (int i = start; i < str.length(); i++) {
+            char curChar = str.charAt(i);
+            if (numPreEscapes == 0 && curChar == separator) { // separator
+                return i;
+            } else {
+                split.append(curChar);
+                numPreEscapes = (curChar == escapeChar)
+                        ? (++numPreEscapes) % 2
+                        : 0;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Escape commas in the string using the default escape char
+     * @param str a string
+     * @return an escaped string
+     */
+    public static String escapeString(String str) {
+        return escapeString(str, ESCAPE_CHAR, COMMA);
+    }
+
+    /**
+     * Escape <code>charToEscape</code> in the string
+     * with the escape char <code>escapeChar</code>
+     *
+     * @param str string
+     * @param escapeChar escape char
+     * @param charToEscape the char to be escaped
+     * @return an escaped string
+     */
+    public static String escapeString(
+            String str, char escapeChar, char charToEscape) {
+        return escapeString(str, escapeChar, new char[] {charToEscape});
+    }
+
+    // check if the character array has the character
+    private static boolean hasChar(char[] chars, char character) {
+        for (char target : chars) {
+            if (character == target) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param charsToEscape array of characters to be escaped
+     */
+    public static String escapeString(String str, char escapeChar,
+                                      char[] charsToEscape) {
+        if (str == null) {
+            return null;
+        }
+        StringBuilder result = new StringBuilder();
+        for (int i=0; i<str.length(); i++) {
+            char curChar = str.charAt(i);
+            if (curChar == escapeChar || hasChar(charsToEscape, curChar)) {
+                // special char
+                result.append(escapeChar);
+            }
+            result.append(curChar);
+        }
+        return result.toString();
+    }
+
+    /**
+     * Unescape commas in the string using the default escape char
+     * @param str a string
+     * @return an unescaped string
+     */
+    public static String unEscapeString(String str) {
+        return unEscapeString(str, ESCAPE_CHAR, COMMA);
+    }
+
+    /**
+     * Unescape <code>charToEscape</code> in the string
+     * with the escape char <code>escapeChar</code>
+     *
+     * @param str string
+     * @param escapeChar escape char
+     * @param charToEscape the escaped char
+     * @return an unescaped string
+     */
+    public static String unEscapeString(
+            String str, char escapeChar, char charToEscape) {
+        return unEscapeString(str, escapeChar, new char[] {charToEscape});
+    }
+
+    /**
+     * @param charsToEscape array of characters to unescape
+     */
+    public static String unEscapeString(String str, char escapeChar,
+                                        char[] charsToEscape) {
+        if (str == null) {
+            return null;
+        }
+        StringBuilder result = new StringBuilder(str.length());
+        boolean hasPreEscape = false;
+        for (int i=0; i<str.length(); i++) {
+            char curChar = str.charAt(i);
+            if (hasPreEscape) {
+                if (curChar != escapeChar && !hasChar(charsToEscape, curChar)) {
+                    // no special char
+                    throw new IllegalArgumentException("Illegal escaped string " + str +
+                            " unescaped " + escapeChar + " at " + (i-1));
+                }
+                // otherwise discard the escape char
+                result.append(curChar);
+                hasPreEscape = false;
+            } else {
+                if (hasChar(charsToEscape, curChar)) {
+                    throw new IllegalArgumentException("Illegal escaped string " + str +
+                            " unescaped " + curChar + " at " + i);
+                } else if (curChar == escapeChar) {
+                    hasPreEscape = true;
+                } else {
+                    result.append(curChar);
+                }
+            }
+        }
+        if (hasPreEscape ) {
+            throw new IllegalArgumentException("Illegal escaped string " + str +
+                    ", not expecting " + escapeChar + " in the end." );
+        }
+        return result.toString();
+    }
+
+    /**
+     * The traditional binary prefixes, kilo, mega, ..., exa,
+     * which can be represented by a 64-bit integer.
+     * TraditionalBinaryPrefix symbol are case insensitive.
+     */
+    public enum TraditionalBinaryPrefix {
+        KILO(10),
+        MEGA(KILO.bitShift + 10),
+        GIGA(MEGA.bitShift + 10),
+        TERA(GIGA.bitShift + 10),
+        PETA(TERA.bitShift + 10),
+        EXA (PETA.bitShift + 10);
+
+        public final long value;
+        public final char symbol;
+        public final int bitShift;
+        public final long bitMask;
+
+        private TraditionalBinaryPrefix(int bitShift) {
+            this.bitShift = bitShift;
+            this.value = 1L << bitShift;
+            this.bitMask = this.value - 1L;
+            this.symbol = toString().charAt(0);
+        }
+
+        /**
+         * @return The TraditionalBinaryPrefix object corresponding to the symbol.
+         */
+        public static TraditionalBinaryPrefix valueOf(char symbol) {
+            symbol = Character.toUpperCase(symbol);
+            for(TraditionalBinaryPrefix prefix : TraditionalBinaryPrefix.values()) {
+                if (symbol == prefix.symbol) {
+                    return prefix;
+                }
+            }
+            throw new IllegalArgumentException("Unknown symbol '" + symbol + "'");
+        }
+
+        /**
+         * Convert a string to long.
+         * The input string is first be trimmed
+         * and then it is parsed with traditional binary prefix.
+         *
+         * For example,
+         * "-1230k" will be converted to -1230 * 1024 = -1259520;
+         * "891g" will be converted to 891 * 1024^3 = 956703965184;
+         *
+         * @param s input string
+         * @return a long value represented by the input string.
+         */
+        public static long string2long(String s) {
+            s = s.trim();
+            final int lastpos = s.length() - 1;
+            final char lastchar = s.charAt(lastpos);
+            if (Character.isDigit(lastchar))
+                return Long.parseLong(s);
+            else {
+                long prefix;
+                try {
+                    prefix = TraditionalBinaryPrefix.valueOf(lastchar).value;
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("Invalid size prefix '" + lastchar
+                            + "' in '" + s
+                            + "'. Allowed prefixes are k, m, g, t, p, e(case insensitive)");
+                }
+                long num = Long.parseLong(s.substring(0, lastpos));
+                if (num > (Long.MAX_VALUE/prefix) || num < (Long.MIN_VALUE/prefix)) {
+                    throw new IllegalArgumentException(s + " does not fit in a Long");
+                }
+                return num * prefix;
+            }
+        }
+
+        /**
+         * Convert a long integer to a string with traditional binary prefix.
+         *
+         * @param n the value to be converted
+         * @param unit The unit, e.g. "B" for bytes.
+         * @param decimalPlaces The number of decimal places.
+         * @return a string with traditional binary prefix.
+         */
+        public static String long2String(long n, String unit, int decimalPlaces) {
+            if (unit == null) {
+                unit = "";
+            }
+            //take care a special case
+            if (n == Long.MIN_VALUE) {
+                return "-8 " + EXA.symbol + unit;
+            }
+
+            final StringBuilder b = new StringBuilder();
+            //take care negative numbers
+            if (n < 0) {
+                b.append('-');
+                n = -n;
+            }
+            if (n < KILO.value) {
+                //no prefix
+                b.append(n);
+                return (unit.isEmpty()? b: b.append(" ").append(unit)).toString();
+            } else {
+                //find traditional binary prefix
+                int i = 0;
+                for(; i < values().length && n >= values()[i].value; i++);
+                TraditionalBinaryPrefix prefix = values()[i - 1];
+
+                if ((n & prefix.bitMask) == 0) {
+                    //exact division
+                    b.append(n >> prefix.bitShift);
+                } else {
+                    final String  format = "%." + decimalPlaces + "f";
+                    String s = format(format, n/(double)prefix.value);
+                    //check a special rounding up case
+                    if (s.startsWith("1024")) {
+                        prefix = values()[i];
+                        s = format(format, n/(double)prefix.value);
+                    }
+                    b.append(s);
+                }
+                return b.append(' ').append(prefix.symbol).append(unit).toString();
+            }
+        }
+    }
+
+    /**
+     * Escapes HTML Special characters present in the string.
+     * @param string
+     * @return HTML Escaped String representation
+     */
+    public static String escapeHTML(String string) {
+        if(string == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        boolean lastCharacterWasSpace = false;
+        char[] chars = string.toCharArray();
+        for(char c : chars) {
+            if(c == ' ') {
+                if(lastCharacterWasSpace){
+                    lastCharacterWasSpace = false;
+                    sb.append("&nbsp;");
+                }else {
+                    lastCharacterWasSpace=true;
+                    sb.append(" ");
+                }
+            }else {
+                lastCharacterWasSpace = false;
+                switch(c) {
+                    case '<': sb.append("&lt;"); break;
+                    case '>': sb.append("&gt;"); break;
+                    case '&': sb.append("&amp;"); break;
+                    case '"': sb.append("&quot;"); break;
+                    default : sb.append(c);break;
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * @return a byte description of the given long interger value.
+     */
+    public static String byteDesc(long len) {
+        return TraditionalBinaryPrefix.long2String(len, "B", 2);
+    }
+
+    /** @deprecated use StringUtils.format("%.2f", d). */
+    @Deprecated
+    public static String limitDecimalTo2(double d) {
+        return format("%.2f", d);
+    }
+
+    /**
+     * Concatenates strings, using a separator.
+     *
+     * @param separator Separator to join with.
+     * @param strings Strings to join.
+     */
+    public static String join(CharSequence separator, Iterable<?> strings) {
+        Iterator<?> i = strings.iterator();
+        if (!i.hasNext()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(i.next().toString());
+        while (i.hasNext()) {
+            sb.append(separator);
+            sb.append(i.next().toString());
+        }
+        return sb.toString();
+    }
+
+    public static String join(char separator, Iterable<?> strings) {
+        return join(separator + "", strings);
+    }
+
+    /**
+     * Concatenates strings, using a separator.
+     *
+     * @param separator to join with
+     * @param strings to join
+     * @return  the joined string
+     */
+    public static String join(CharSequence separator, String[] strings) {
+        // Ideally we don't have to duplicate the code here if array is iterable.
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (String s : strings) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(separator);
+            }
+            sb.append(s);
+        }
+        return sb.toString();
+    }
+
+    public static String join(char separator, String[] strings) {
+        return join(separator + "", strings);
+    }
+
+    /**
+     * Convert SOME_STUFF to SomeStuff
+     *
+     * @param s input string
+     * @return camelized string
+     */
+    public static String camelize(String s) {
+        StringBuilder sb = new StringBuilder();
+        String[] words = split(StringUtils.toLowerCase(s), ESCAPE_CHAR,  '_');
+
+        for (String word : words)
+            sb.append(org.apache.commons.lang3.StringUtils.capitalize(word));
+
+        return sb.toString();
+    }
+
+    /**
+     * Matches a template string against a pattern, replaces matched tokens with
+     * the supplied replacements, and returns the result.  The regular expression
+     * must use a capturing group.  The value of the first capturing group is used
+     * to look up the replacement.  If no replacement is found for the token, then
+     * it is replaced with the empty string.
+     *
+     * For example, assume template is "%foo%_%bar%_%baz%", pattern is "%(.*?)%",
+     * and replacements contains 2 entries, mapping "foo" to "zoo" and "baz" to
+     * "zaz".  The result returned would be "zoo__zaz".
+     *
+     * @param template String template to receive replacements
+     * @param pattern Pattern to match for identifying tokens, must use a capturing
+     *   group
+     * @param replacements Map<String, String> mapping tokens identified by the
+     *   capturing group to their replacement values
+     * @return String template with replacements
+     */
+    public static String replaceTokens(String template, Pattern pattern,
+                                       Map<String, String> replacements) {
+        StringBuffer sb = new StringBuffer();
+        Matcher matcher = pattern.matcher(template);
+        while (matcher.find()) {
+            String replacement = replacements.get(matcher.group(1));
+            if (replacement == null) {
+                replacement = "";
+            }
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Get stack trace for a given thread.
+     */
+    public static String getStackTrace(Thread t) {
+        final StackTraceElement[] stackTrace = t.getStackTrace();
+        StringBuilder str = new StringBuilder();
+        for (StackTraceElement e : stackTrace) {
+            str.append(e.toString() + "\n");
+        }
+        return str.toString();
+    }
+
+    /**
+     * Converts all of the characters in this String to lower case with
+     * Locale.ENGLISH.
+     *
+     * @param str  string to be converted
+     * @return     the str, converted to lowercase.
+     */
+    public static String toLowerCase(String str) {
+        return str.toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Converts all of the characters in this String to upper case with
+     * Locale.ENGLISH.
+     *
+     * @param str  string to be converted
+     * @return     the str, converted to uppercase.
+     */
+    public static String toUpperCase(String str) {
+        return str.toUpperCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Compare strings locale-freely by using String#equalsIgnoreCase.
+     *
+     * @param s1  Non-null string to be converted
+     * @param s2  string to be converted
+     * @return     the str, converted to uppercase.
+     */
+    public static boolean equalsIgnoreCase(String s1, String s2) {
+        Preconditions.checkNotNull(s1);
+        // don't check non-null against s2 to make the semantics same as
+        // s1.equals(s2)
+        return s1.equalsIgnoreCase(s2);
+    }
+
+    /**
+     * <p>Checks if the String contains only unicode letters.</p>
+     *
+     * <p><code>null</code> will return <code>false</code>.
+     * An empty String (length()=0) will return <code>true</code>.</p>
+     *
+     * <pre>
+     * StringUtils.isAlpha(null)   = false
+     * StringUtils.isAlpha("")     = true
+     * StringUtils.isAlpha("  ")   = false
+     * StringUtils.isAlpha("abc")  = true
+     * StringUtils.isAlpha("ab2c") = false
+     * StringUtils.isAlpha("ab-c") = false
+     * </pre>
+     *
+     * @param str  the String to check, may be null
+     * @return <code>true</code> if only contains letters, and is non-null
+     */
+    public static boolean isAlpha(String str) {
+        if (str == null) {
+            return false;
+        }
+        int sz = str.length();
+        for (int i = 0; i < sz; i++) {
+            if (!Character.isLetter(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/nd4j-common/src/main/java/org/nd4j/util/StringUtils.java
+++ b/nd4j-common/src/main/java/org/nd4j/util/StringUtils.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1022,4 +1023,57 @@ public class StringUtils {
         return true;
     }
 
+
+    public static String timeUnitToString(long time, TimeUnit unit) {
+        String str = String.valueOf(time);
+        switch (unit) {
+            case MILLISECONDS:
+                str += "Millisecond";
+                break;
+            case SECONDS:
+                str += "Second";
+                break;
+            case MINUTES:
+                str += "Minute";
+                break;
+            case HOURS:
+                str += "Hour";
+                break;
+            case DAYS:
+                str += "Day";
+                break;
+            default:
+                throw new RuntimeException();
+        }
+        if (time == 1)
+            return str;
+        return str + "s";
+    }
+
+    public static TimeUnit stringToTimeUnit(String str) {
+        switch (str.toLowerCase()) {
+            case "ms":
+            case "millisecond":
+            case "milliseconds":
+                return TimeUnit.MILLISECONDS;
+            case "s":
+            case "sec":
+            case "second":
+            case "seconds":
+                return TimeUnit.SECONDS;
+            case "min":
+            case "minute":
+            case "minutes":
+                return TimeUnit.MINUTES;
+            case "h":
+            case "hour":
+            case "hours":
+                return TimeUnit.HOURS;
+            case "day":
+            case "days":
+                return TimeUnit.DAYS;
+            default:
+                throw new RuntimeException("Unknown time unit: \"" + str + "\"");
+        }
+    }
 }

--- a/nd4j-common/src/test/java/org/nd4j/util/OneTimeLoggerTest.java
+++ b/nd4j-common/src/test/java/org/nd4j/util/OneTimeLoggerTest.java
@@ -1,0 +1,28 @@
+package org.nd4j.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author raver119@gmail.com
+ */
+@Slf4j
+public class OneTimeLoggerTest {
+
+    @Test
+    public void testLogger1() throws Exception {
+        OneTimeLogger.info(log, "Format: {}; Pew: {};", 1, 2);
+    }
+
+    @Test
+    public void testBuffer1() throws Exception {
+        assertTrue(OneTimeLogger.isEligible("Message here"));
+
+        assertFalse(OneTimeLogger.isEligible("Message here"));
+
+        assertTrue(OneTimeLogger.isEligible("Message here 23"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,7 @@
         <commons-math3.version>3.4.1</commons-math3.version>
         <commons-lang3.version>3.3.1</commons-lang3.version>
         <commons-collections4.version>4.1</commons-collections4.version>
+        <commons-compress.version>1.16.1</commons-compress.version>
         <camel.version>2.18.2</camel.version>
         <unirest.version>1.4.9</unirest.version>
         <mapdb.version>3.0.5</mapdb.version>


### PR DESCRIPTION
***WIP DO NOT MERGE***

This PR moves a lot of the utility classes/methods from DL4J and DataVec to nd4j-common.
There was a lot of duplication - both functionality and copy/pasted code - in DL4J and DataVec.

This also provides the correct license headers, that were incorrectly changed for a couple of classes.

DataVec: https://github.com/deeplearning4j/DataVec/pull/514
DL4J: https://github.com/deeplearning4j/deeplearning4j/pull/4725

Before merging:
- [x] DataVec unit tests
- [x] DL4J unit tests
- [x] Arbiter unit tests