### PR TITLE
fix writeTxt producing invalid json by swapping around colons and quotes

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2113,8 +2113,8 @@ public class Nd4j {
     public static void writeTxt(INDArray write, String filePath, String split, int precision) {
         //TO DO: Write to file one line at time
         String lineOne = "{\n";
-        String lineTwo = "\"filefrom:\" \"dl4j\",\n";
-        String lineThree = "\"ordering:\" \"" + write.ordering() + "\",\n";
+        String lineTwo = "\"filefrom\": \"dl4j\",\n";
+        String lineThree = "\"ordering\": \"" + write.ordering() + "\",\n";
         String lineFour = "\"shape\":\t" + java.util.Arrays.toString(write.shape()) + ",\n";
         String lineFive = "\"data\":\n";
         String fileData = new NDArrayStrings(" " + split + " ", precision).format(write);


### PR DESCRIPTION
## What changes were proposed in this pull request?
writeTxt in Nd4j.java was producing invalid json.
This simple pull request swaps two colons and quotes to fix that.

## How was this patch tested?
Manually ran writeTxt and checked it produced valid json output
