### PR TITLE
Disable nd4j-native when building for nd4j-cuda on AppVeyor and Travis CI

### DIFF
--- a/ci/build-ios.sh
+++ b/ci/build-ios.sh
@@ -9,8 +9,6 @@ if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
 else
     BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
     MAVEN_PHASE="install"
-    echo Skipping Mac OS X builds on pull request because of limited resources
-    exit 0
 fi
 
 if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$BRANCH; then

--- a/ci/build-linux-x86_64.sh
+++ b/ci/build-linux-x86_64.sh
@@ -45,15 +45,14 @@ docker run -ti -e SONATYPE_USERNAME -e SONATYPE_PASSWORD -v $HOME/.m2:/root/.m2 
     make -j2; \
     cd /build/libnd4j/; \
     sed -i /cmake_minimum_required/d CMakeLists.txt; \
-    MAKEJ=2 bash buildnativeoperations.sh -c cpu -e ${EXT:-}; \
     if [[ -n \"${CUDA:-}\" ]]; then \
         MAKEJ=1 bash buildnativeoperations.sh -c cuda -v $CUDA -cc 30; \
-    fi; \
-    cd /build/nd4j/; \
-    if [[ -n \"${CUDA:-}\" ]]; then \
+        cd /build/nd4j/; \
         bash change-cuda-versions.sh $CUDA; \
-        EXTRA_OPTIONS='-pl !nd4j-uberjar'; \
+        EXTRA_OPTIONS='-pl !nd4j-uberjar,!nd4j-backends/nd4j-backend-impls/nd4j-native,!nd4j-backends/nd4j-backend-impls/nd4j-native-platform,!nd4j-backends/nd4j-tests'; \
     else \
+        MAKEJ=2 bash buildnativeoperations.sh -c cpu -e ${EXT:-}; \
+        cd /build/nd4j/; \
         EXTRA_OPTIONS='-pl !nd4j-uberjar,!nd4j-backends/nd4j-backend-impls/nd4j-cuda,!nd4j-backends/nd4j-backend-impls/nd4j-cuda-platform,!nd4j-backends/nd4j-tests'; \
     fi; \
     bash change-scala-versions.sh $SCALA; \

--- a/ci/build-macosx-x86_64.sh
+++ b/ci/build-macosx-x86_64.sh
@@ -9,8 +9,6 @@ if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
 else
     BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
     MAVEN_PHASE="install"
-    echo Skipping Mac OS X builds on pull request because of limited resources
-    exit 0
 fi
 
 if ! git -C $TRAVIS_BUILD_DIR/.. clone https://github.com/deeplearning4j/libnd4j/ --depth=50 --branch=$BRANCH; then

--- a/ci/build-macosx-x86_64.sh
+++ b/ci/build-macosx-x86_64.sh
@@ -41,15 +41,14 @@ fi
 
 cd $TRAVIS_BUILD_DIR/../libnd4j/
 sed -i="" /cmake_minimum_required/d CMakeLists.txt
-MAKEJ=2 bash buildnativeoperations.sh -c cpu -e ${EXT:-}
 if [[ -n "${CUDA:-}" ]]; then
     MAKEJ=1 bash buildnativeoperations.sh -c cuda -v $CUDA -cc 30
-fi
-cd $TRAVIS_BUILD_DIR/
-if [[ -n "${CUDA:-}" ]]; then
+    cd $TRAVIS_BUILD_DIR/
     bash change-cuda-versions.sh $CUDA
-    EXTRA_OPTIONS='-pl !nd4j-uberjar'
+    EXTRA_OPTIONS='-pl !nd4j-uberjar,!nd4j-backends/nd4j-backend-impls/nd4j-native,!nd4j-backends/nd4j-backend-impls/nd4j-native-platform,!nd4j-backends/nd4j-tests'
 else
+    MAKEJ=2 bash buildnativeoperations.sh -c cpu -e ${EXT:-}
+    cd $TRAVIS_BUILD_DIR/
     EXTRA_OPTIONS='-pl !nd4j-uberjar,!nd4j-backends/nd4j-backend-impls/nd4j-cuda,!nd4j-backends/nd4j-backend-impls/nd4j-cuda-platform,!nd4j-backends/nd4j-tests'
 fi
 bash change-scala-versions.sh $SCALA

--- a/ci/build-windows-x86_64.cmd
+++ b/ci/build-windows-x86_64.cmd
@@ -36,12 +36,12 @@ bash -lc "pacman -Syu --noconfirm"
 bash -lc "pacman -Su --noconfirm"
 bash -lc "pacman -S --needed --noconfirm base-devel make mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc"
 
-bash -c "cd ../libnd4j/; MAKEJ=2 bash buildnativeoperations.sh -c cpu -e $EXT"
 if not "%CUDA%" == "" (
     bash -c "cd ../libnd4j/; MAKEJ=1 bash buildnativeoperations.sh -c cuda -v $CUDA -cc 30"
     bash -c "bash change-cuda-versions.sh $CUDA"
-    set "EXTRA_OPTIONS=-pl !nd4j-uberjar"
+    set "EXTRA_OPTIONS=-pl !nd4j-uberjar,!nd4j-backends/nd4j-backend-impls/nd4j-native,!nd4j-backends/nd4j-backend-impls/nd4j-native-platform,!nd4j-backends/nd4j-tests"
 ) else (
+    bash -c "cd ../libnd4j/; MAKEJ=2 bash buildnativeoperations.sh -c cpu -e $EXT"
     set "EXTRA_OPTIONS=-pl !nd4j-uberjar,!nd4j-backends/nd4j-backend-impls/nd4j-cuda,!nd4j-backends/nd4j-backend-impls/nd4j-cuda-platform,!nd4j-backends/nd4j-tests"
 )
 bash -c "bash change-scala-versions.sh $SCALA"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Speed up builds by removing duplicate processing for nd4j-native.

## How was this patch tested?

Leaving AppVeyor and Travis CI test this before merging...
