### PR TITLE
No-arg constructor for Choose op

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/comparison/Choose.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/comparison/Choose.java
@@ -52,7 +52,6 @@ public class Choose extends DynamicCustomOp {
         addInputArgument(inputs);
         addIArgument(condition.condtionNum());
         addOutputArgument(Nd4j.create(inputs[0].length()),Nd4j.scalar(1.0));
-
     }
 
     /**
@@ -94,6 +93,10 @@ public class Choose extends DynamicCustomOp {
 
     public Choose(String opName, SameDiff sameDiff, SDVariable[] args, boolean inPlace) {
         super(opName, sameDiff, args, inPlace);
+    }
+
+    public Choose(){
+        //No-arg constructor for use in DifferentialFunctionClassHolder
     }
 
     @Override


### PR DESCRIPTION
I ran into this issue in DL4J... seems a no-arg constructor is required in practice.

```
java.lang.ExceptionInInitializerError
	at org.nd4j.linalg.api.ops.factory.DefaultOpFactory.createTransform(DefaultOpFactory.java:298)
	at org.nd4j.linalg.api.ops.factory.DefaultOpFactory.createTransform(DefaultOpFactory.java:249)
	at org.nd4j.linalg.lossfunctions.impl.LossL1.scoreArray(LossL1.java:74)
	at org.nd4j.linalg.lossfunctions.impl.LossL1.computeScore(LossL1.java:94)
	at org.deeplearning4j.nn.layers.BaseOutputLayer.computeScore(BaseOutputLayer.java:92)
	at org.deeplearning4j.nn.multilayer.MultiLayerNetwork.computeGradientAndScore(MultiLayerNetwork.java:2409)
	at org.deeplearning4j.gradientcheck.GradientCheckUtil.checkGradients(GradientCheckUtil.java:186)
	at org.deeplearning4j.gradientcheck.GradientCheckUtil.checkGradients(GradientCheckUtil.java:117)
	at org.deeplearning4j.gradientcheck.GradientCheckTestsMasking.testPerOutputMaskingMLP(GradientCheckTestsMasking.java:264)
...
Caused by: java.lang.RuntimeException: java.lang.InstantiationException: org.nd4j.linalg.api.ops.impl.transforms.comparison.Choose
	at org.nd4j.imports.converters.DifferentialFunctionClassHolder.<init>(DifferentialFunctionClassHolder.java:210)
	at org.nd4j.imports.converters.DifferentialFunctionClassHolder.<clinit>(DifferentialFunctionClassHolder.java:27)
	... 33 more
Caused by: java.lang.InstantiationException: org.nd4j.linalg.api.ops.impl.transforms.comparison.Choose
	at java.lang.Class.newInstance(Class.java:427)
	at org.nd4j.imports.converters.DifferentialFunctionClassHolder.<init>(DifferentialFunctionClassHolder.java:136)
	... 34 more
Caused by: java.lang.NoSuchMethodException: org.nd4j.linalg.api.ops.impl.transforms.comparison.Choose.<init>()
	at java.lang.Class.getConstructor0(Class.java:3082)
	at java.lang.Class.newInstance(Class.java:412)
	... 35 more
```