### PR TITLE
Make getCustomOperations() map unmodifiable; cache for CUDA

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/converters/DifferentialFunctionClassHolder.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/converters/DifferentialFunctionClassHolder.java
@@ -223,7 +223,7 @@ public class DifferentialFunctionClassHolder {
         }
 
 
-        val map = Nd4j.getExecutioner().getCustomOperations();
+        val map = new HashMap<>(Nd4j.getExecutioner().getCustomOperations());
         val set = map.keySet();
         set.removeAll(nodeConverters.keySet());
         missingOps.addAll(set);

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
@@ -1517,13 +1517,13 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
         if (customOps == null) {
             String list = loop.getAllCustomOps();
 
-            customOps = new HashMap<>();
-
-
             if (list == null || list.isEmpty()) {
                 log.warn("No customs ops available!");
+                customOps = Collections.emptyMap();
                 return customOps;
             }
+
+            val map = new HashMap<String, CustomOpDescriptor>();
 
             String[] split = list.split(";");
             for (String op : split) {
@@ -1541,8 +1541,10 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                         .numIArgs(Integer.valueOf(another[6]))
                         .build();
 
-                customOps.put(another[0], descriptor);
+                map.put(another[0], descriptor);
             }
+
+            customOps = Collections.unmodifiableMap(map);
         }
 
         return customOps;


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/nd4j/issues/2700

Why? Previously, NativeOpExecutioner.getCustomOperations() returned a copy (which was inefficient, but safe). It was recently modified to return the underlying (avoids the copy) here: https://github.com/deeplearning4j/nd4j/commit/206199b295c1adfbd72388abdd0405f6f7c9b5c8

However, the map was modified by DifferentialFunctionClassHolder - this had the unintended consequence of causing the above-linked issues

This PR also caches custom op descriptors for CUDA
