### PR TITLE
Log about initializeDevicesAndFunctions() potentially taking a while

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOpsHolder.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOpsHolder.java
@@ -29,6 +29,9 @@ public class NativeOpsHolder {
             Class<? extends NativeOps> nativeOpsClazz = Class.forName(name).asSubclass(NativeOps.class);
             deviceNativeOps = nativeOpsClazz.newInstance();
 
+            if (name.contains("Nd4jCuda")) {
+                log.info("Initializing device and functions... (may take 10 minutes or more)");
+            }
             deviceNativeOps.initializeDevicesAndFunctions();
             int numThreads;
             String numThreadsString = System.getenv("OMP_NUM_THREADS");


### PR DESCRIPTION
Fixes #2715 

## What changes were proposed in this pull request?

Add call to log.info() before call to initializeDevicesAndFunctions()

## How was this patch tested?

Tested manually: Message shows with nd4j-cuda backend, doesn't show with nd4j-native one.
