### PR TITLE
Increase the maximum heap size for tests with CUDA backend

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -49,6 +49,11 @@
                         <org.nd4j.linalg.defaultbackend>org.nd4j.linalg.jcublas.JCublasBackend</org.nd4j.linalg.defaultbackend>
                         <org.nd4j.linalg.tests.backendstorun>org.nd4j.linalg.jcublas.JCublasBackend</org.nd4j.linalg.tests.backendstorun>
                     </systemPropertyVariables>
+                    <!--
+                        Maximum heap size was set to 6g, as a minimum required value for tests run.
+                        Depending on a build machine, default value is not always enough.
+                    -->
+                    <argLine>-Xmx6g</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

If maximum heap size less than 6g (rounded value), you may see following kind of errors `Caused by: java.lang.OutOfMemoryError: Physical memory usage is too high: physicalBytes = 3G > maxPhysicalBytes = 3G` from the build log.

## How was this patch tested?
Tested locally and with Jenkins

