### PR TITLE
DataSet.load(): don't simply print stack trace and move on 

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -267,7 +267,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
 
             dis.close();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException("Error loading DataSet",e);
         }
     }
 


### PR DESCRIPTION
Currently, exception stack trace is printed, and DataSet can be left in corrupted/invalid state - resulting in some hard to debug issues...