### PR TITLE
ClassPathResource improvements

### DIFF
--- a/nd4j-common/src/main/java/org/nd4j/linalg/io/ClassPathResource.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/io/ClassPathResource.java
@@ -4,6 +4,8 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileAttribute;
 
 /**
  * A slightly upgraded version of spring's
@@ -12,6 +14,7 @@ import java.net.URL;
  *
  */
 public class ClassPathResource extends AbstractFileResolvingResource {
+
     private final String path;
     private ClassLoader classLoader;
     private Class<?> clazz;
@@ -54,12 +57,11 @@ public class ClassPathResource extends AbstractFileResolvingResource {
 
 
     /**
-     * Get a temp file from the classpath.
-     * This is for resources where
-     * a file is needed and the
-     * classpath resource is in a jar file
+     * Get a temp file from the classpath.<br>
+     * This is for resources where a file is needed and the classpath resource is in a jar file. The file is copied
+     * to the default temporary directory, using {@link Files#createTempFile(String, String, FileAttribute[])}
      * @return the temp file
-     * @throws IOException
+     * @throws IOException If an error occurs when files are being copied
      */
     public File getTempFileFromArchive() throws IOException {
         InputStream is = getInputStream();
@@ -67,12 +69,11 @@ public class ClassPathResource extends AbstractFileResolvingResource {
         if (path.contains("/") || path.contains("\\")) {
             int idx = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
             String subpath = path.substring(idx + 1);
-            tmpFile = new File(subpath + "tmp");
+            tmpFile = Files.createTempFile(subpath, ".tmp").toFile();
         } else {
-            tmpFile = new File(path + "tmp");
+            tmpFile = Files.createTempFile(path, "tmp").toFile();
         }
         tmpFile.deleteOnExit();
-
 
         BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(tmpFile));
 

--- a/nd4j-common/src/main/java/org/nd4j/linalg/io/ClassPathResource.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/io/ClassPathResource.java
@@ -1,5 +1,6 @@
 package org.nd4j.linalg.io;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 
 import java.io.*;
@@ -106,15 +107,9 @@ public class ClassPathResource extends AbstractFileResolvingResource {
         File tmpFile;
         if(rootDirectory != null){
             //Maintain original file names, as it's going in a directory...
-            if (path.contains("/") || path.contains("\\")) {
-                int idx = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
-                String subpath = path.substring(idx + 1);
-                tmpFile = new File(rootDirectory, subpath);
-            } else {
-                tmpFile = new File(rootDirectory, path);
-            }
+            tmpFile = new File(rootDirectory, FilenameUtils.getName(path));
         } else {
-            tmpFile = Files.createTempFile(path, "tmp").toFile();
+            tmpFile = Files.createTempFile(FilenameUtils.getName(path), "tmp").toFile();
         }
 
         tmpFile.deleteOnExit();

--- a/nd4j-common/src/main/java/org/nd4j/linalg/io/ClassPathResource.java
+++ b/nd4j-common/src/main/java/org/nd4j/linalg/io/ClassPathResource.java
@@ -54,6 +54,24 @@ public class ClassPathResource extends AbstractFileResolvingResource {
         return this.classLoader != null ? this.classLoader : this.clazz.getClassLoader();
     }
 
+    /**
+     * Get the File.
+     * If the file cannot be accessed directly (for example, it is in a JAR file), we will attempt to extract it from
+     * the JAR and copy it to the temporary directory, using {@link #getTempFileFromArchive()}
+     *
+     * @return The File, or a temporary copy if it can not be accessed directly
+     * @throws IOException
+     */
+    @Override
+    public File getFile() throws IOException {
+        try{
+            return super.getFile();
+        } catch (FileNotFoundException e){
+            //java.io.FileNotFoundException: class path resource [iris.txt] cannot be resolved to absolute file path because
+            // it does not reside in the file system: jar:file:/.../dl4j-test-resources-0.9.2-SNAPSHOT.jar!/iris.txt
+            return getTempFileFromArchive();
+        }
+    }
 
 
     /**


### PR DESCRIPTION
Three minor improvements:
1. getFile() falls back on getTempFileFromArchive() if required
2. getTempFileFromArchive() places files in the temp directory, not the current working directory
3. Adds getTempFileFromArchive(File rootDir) to specify where the temp file should be extracted