### PR TITLE
Make lombok artifact provided in pom.xml files

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -200,6 +200,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/nd4j-buffer/pom.xml
+++ b/nd4j-buffer/pom.xml
@@ -124,6 +124,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nd4j-common/pom.xml
+++ b/nd4j-common/pom.xml
@@ -111,6 +111,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nd4j-parameter-server-parent/nd4j-parameterserver-model/pom.xml
+++ b/nd4j-parameter-server-parent/nd4j-parameterserver-model/pom.xml
@@ -21,6 +21,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nd4j-serde/nd4j-jackson-reflectionloader/pom.xml
+++ b/nd4j-serde/nd4j-jackson-reflectionloader/pom.xml
@@ -18,7 +18,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -543,7 +543,7 @@
         <jcommander.version>1.27</jcommander.version>
         <guava.version>20.0</guava.version>
         <playframework.version>2.4.6</playframework.version>
-        <lombok.version>1.16.18</lombok.version>
+        <lombok.version>1.16.20</lombok.version>
         <jackson.version>2.5.1</jackson.version>
         <reflections.version>0.9.10</reflections.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -885,6 +885,15 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
     <reporting>
       <plugins>


### PR DESCRIPTION
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/4839

## What changes were proposed in this pull request?

Prevent Lombok from leaking to dependent projects, update version, and rearrange dependencies as required because no longer transitive.

## How was this patch tested?

Build passes, running LenetMnistExample from dl4j-examples works, and confirmed manually on it that `mvn dependency:tree` does not contain lombok anymore.