### PR TITLE
Added back INDArray constructors to Mmul

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/Mmul.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/Mmul.java
@@ -25,6 +25,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.descriptors.properties.PropertyMapping;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
+import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
@@ -73,6 +74,23 @@ public class Mmul extends DynamicCustomOp {
         this(sameDiff,i_v1,i_v2,MMulTranspose.allFalse());
     }
 
+    /**
+     *
+     * @param x
+     * @param y
+     * @param z
+     */
+    public Mmul(INDArray x,
+                INDArray y,
+                INDArray z,
+                MMulTranspose mMulTranspose) {
+        super(null, new INDArray[]{x, y}, z == null ? null : new INDArray[]{z});
+        if (mMulTranspose != null) {
+          this.mMulTranspose = mMulTranspose;
+          addIArgument(ArrayUtil.fromBoolean(mMulTranspose.isTransposeA()),
+                       ArrayUtil.fromBoolean(mMulTranspose.isTransposeB()));
+        }
+    }
 
 
     public Mmul() {}

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
@@ -28,6 +28,7 @@ import org.apache.commons.math3.util.FastMath;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.ops.impl.accum.LogSumExp;
+import org.nd4j.linalg.api.ops.impl.accum.Mmul;
 import org.nd4j.linalg.api.ops.impl.layers.convolution.Im2col;
 import org.nd4j.linalg.api.ops.impl.layers.convolution.config.Conv2DConfig;
 import org.nd4j.linalg.indexing.BooleanIndexing;
@@ -419,9 +420,24 @@ public class Nd4jTestsC extends BaseNd4jTest {
 
         INDArray test = arr.mmul(arr.transpose());
         assertEquals(getFailureMessage(), assertion, test);
-
     }
 
+    @Test
+    public void testMmulOp() {
+        INDArray arr = Nd4j.create(new double[][] {{1, 2, 3}, {4, 5, 6}});
+        INDArray z = Nd4j.create(2, 2);
+        INDArray assertion = Nd4j.create(new double[][] {{14, 32}, {32, 77}});
+        MMulTranspose mMulTranspose = MMulTranspose.builder()
+          .transposeB(true)
+          .a(arr)
+          .b(arr)
+          .build();
+
+        DynamicCustomOp op = new Mmul(arr, arr, z, mMulTranspose);
+        Nd4j.getExecutioner().exec(op);
+        
+        assertEquals(getFailureMessage(), assertion, z);
+    }
 
 
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add an INDArray-based constructor back to the Mmul class

## How was this patch tested?

By adding a new test case to `Nd4jTestsC` and running all the tests in that suite.