### PR TITLE
Make findbugs artifact provided in pom.xml file

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -228,6 +228,12 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>${reflections.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/nd4j-common/pom.xml
+++ b/nd4j-common/pom.xml
@@ -83,13 +83,6 @@
             <version>${commons-io.version}</version>
         </dependency>
 
-        <!-- used to alleviate licensing issues with findbugs -->
-        <dependency>
-          <groupId>com.github.stephenc.findbugs</groupId>
-          <artifactId>findbugs-annotations</artifactId>
-          <version>1.3.9-1</version>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -887,6 +887,13 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- used to alleviate licensing issues with findbugs -->
+        <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>1.3.9-1</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>


### PR DESCRIPTION
Fixes issue #2797

## What changes were proposed in this pull request?

Prevent FindBugs from leaking to dependent projects and rearrange dependencies as required because no longer transitive.

Also add missing findbugs exclusion for reflections in nd4j-api.

## How was this patch tested?

Build passes, running LenetMnistExample from dl4j-examples works, and confirmed manually on it that `mvn dependency:tree` does not contain findbugs anymore.