### PR TITLE
Link dynamically to GCC runtimes on Mac to support C++ exceptions

### DIFF
--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -316,12 +316,15 @@
                     <plugin>
                         <groupId>org.bytedeco</groupId>
                         <artifactId>javacpp</artifactId>
+<!-- We cannot use those to propagate C++ exceptions across shared libraries. -->
+<!--
                         <configuration>
                             <compilerOptions>
                                 <compilerOption>-static-libgcc</compilerOption>
                                 <compilerOption>-static-libstdc++</compilerOption>
                             </compilerOptions>
                         </configuration>
+-->
                     </plugin>
                 </plugins>
             </build>

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Scanner;
 
 /**
@@ -108,7 +109,8 @@ import java.util.Scanner;
                                                 preloadpath = {"/lib64/", "/lib/", "/usr/lib64/", "/usr/lib/",
                                                                 "/usr/lib/powerpc64-linux-gnu/",
                                                                 "/usr/lib/powerpc64le-linux-gnu/"}),
-                @Platform(value = "ios", includepath = "/usr/local/Cellar/llvm/4.0.0/include/c++/v1"),
+                @Platform(value = "macosx", preload = {"gcc_s@.1", "gomp@.1", "stdc++@.6"},
+                                preloadpath = {"/usr/local/lib/gcc/7/", "/usr/local/lib/gcc/6/", "/usr/local/lib/gcc/5/"}),
                 @Platform(extension = {"-avx512", "-avx2"}) })
 public class Nd4jCpuPresets implements InfoMapper, BuildEnabled {
 
@@ -190,6 +192,7 @@ public class Nd4jCpuPresets implements InfoMapper, BuildEnabled {
         ArrayList<String> opTemplates = new ArrayList<String>();
         files.add(file);
         files.addAll(Arrays.asList(new File(file.getParent(), "headers").listFiles()));
+        Collections.sort(files);
         for (File f : files) {
             try (Scanner scanner = new Scanner(f)) {
                 while (scanner.hasNextLine()) {


### PR DESCRIPTION
Fixes #2813 

## What changes were proposed in this pull request?

Linking with static runtime libraries results in SIGABRT when throwing C++ exceptions across libraries on Mac, so let's link with the dynamic ones and bundle them in the JAR.

## How was this patch tested?

Along with https://github.com/deeplearning4j/libnd4j/pull/853, tested that failing tests don't terminate with SIGABRT anymore.