### PR TITLE
Minor changes for DL4J workspace optimizations

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -5799,11 +5799,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         }
 
         MemoryWorkspace current = Nd4j.getMemoryManager().getCurrentWorkspace();
-
         MemoryWorkspace target = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(id);
-
-        if (current == target)
-            return this;
 
         if (this.data.getParentWorkspace() == target)
             return this;

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -66,6 +66,7 @@ import org.nd4j.linalg.util.ArrayUtil;
 import org.nd4j.linalg.util.LinAlgExceptions;
 import org.nd4j.linalg.util.LongUtils;
 import org.nd4j.linalg.util.NDArrayMath;
+import org.nd4j.linalg.workspace.WorkspaceUtils;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -1694,6 +1695,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public INDArray dup() {
+        WorkspaceUtils.assertValidArray(this, "Cannot duplicate INDArray");
         if (this.isCompressed() && this.ordering() == Nd4j.order().charValue()) {
             INDArray ret = Nd4j.createArrayFromShapeBuffer(data().dup(), this.shapeInfoDataBuffer());
             ret.markAsCompressed(true);
@@ -1706,6 +1708,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public INDArray dup(char order) {
+        WorkspaceUtils.assertValidArray(this, "Cannot duplicate INDArray");
         if (this.isCompressed() && this.ordering() == order) {
             INDArray ret = Nd4j.createArrayFromShapeBuffer(data().dup(), this.shapeInfoDataBuffer());
             ret.markAsCompressed(true);
@@ -1724,7 +1727,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Override
     public int getInt(int... indices) {
         return (int) getDouble(indices);
-
     }
 
     /**
@@ -5659,6 +5661,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if (!isAttached())
             return this;
 
+        WorkspaceUtils.assertValidArray(this, "Cannot detach INDArray");
+
         Nd4j.getExecutioner().commit();
 
         /*
@@ -5718,6 +5722,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public INDArray leverage() {
+        WorkspaceUtils.assertValidArray(this, "Cannot leverage INDArray to new workspace");
         if (!isAttached())
             return this;
 
@@ -5787,6 +5792,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public INDArray leverageTo(String id, boolean enforceExistence) throws Nd4jNoSuchWorkspaceException {
+        WorkspaceUtils.assertValidArray(this, "Cannot leverage INDArray to new workspace");
         if (!isAttached())
             return this;
 
@@ -5869,6 +5875,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public INDArray migrate(boolean detachOnNoWs){
+        WorkspaceUtils.assertValidArray(this, "Cannot leverage INDArray to new workspace");
+
         MemoryWorkspace current = Nd4j.getMemoryManager().getCurrentWorkspace();
 
         if (current == null) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
@@ -37,6 +37,7 @@ import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.profiler.OpProfiler;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -433,12 +434,12 @@ public class DefaultOpExecutioner implements OpExecutioner {
 
                 if (!ws.isScopeActive()) {
                     throw new ND4JIllegalStateException("Op [" + op.opName() + "] X argument uses leaked workspace pointer from workspace ["
-                            + ws.getId() + "]\n" + SCOPE_PANIC_MSG);
+                            + ws.getId() + "]\nAll open workspaces: " + allOpenWorkspaces() + "\n" + SCOPE_PANIC_MSG);
                 }
 
                 if (ws.getGenerationId() != x.data().getGenerationId())
                     throw new ND4JIllegalStateException("Op [" + op.opName() + "] X argument uses outdated workspace pointer from workspace ["
-                            + ws.getId() + "]\n" + SCOPE_PANIC_MSG);
+                            + ws.getId() + "]\nAll open workspaces: " + allOpenWorkspaces() + "\n" + SCOPE_PANIC_MSG);
             }
 
         }
@@ -450,12 +451,12 @@ public class DefaultOpExecutioner implements OpExecutioner {
             if (ws.getWorkspaceType() != MemoryWorkspace.Type.CIRCULAR) {
                 if (!ws.isScopeActive()) {
                     throw new ND4JIllegalStateException("Op [" + op.opName() + "] Y argument uses leaked workspace pointer from workspace ["
-                            + ws.getId() + "]\n" + SCOPE_PANIC_MSG);
+                            + ws.getId() + "]\nAll open workspaces: " + allOpenWorkspaces() + "\n" + SCOPE_PANIC_MSG);
                 }
 
                 if (ws.getGenerationId() != y.data().getGenerationId())
                     throw new ND4JIllegalStateException("Op [" + op.opName() + "] Y argument uses outdated workspace pointer from workspace ["
-                            + ws.getId() + "]\n" + SCOPE_PANIC_MSG);
+                            + ws.getId() + "]\nAll open workspaces: " + allOpenWorkspaces() + "\n" + SCOPE_PANIC_MSG);
             }
         }
 
@@ -466,14 +467,25 @@ public class DefaultOpExecutioner implements OpExecutioner {
             if (ws.getWorkspaceType() != MemoryWorkspace.Type.CIRCULAR) {
                 if (!ws.isScopeActive()) {
                     throw new ND4JIllegalStateException("Op [" + op.opName() + "] Z argument uses leaked workspace pointer from workspace ["
-                            + ws.getId() + "]\n" + SCOPE_PANIC_MSG);
+                            + ws.getId() + "]\nAll open workspaces: " + allOpenWorkspaces() + "\n" + SCOPE_PANIC_MSG);
                 }
 
                 if (ws.getGenerationId() != z.data().getGenerationId())
                     throw new ND4JIllegalStateException("Op [" + op.opName() + "] Z argument uses outdated workspace pointer from workspace ["
-                            + ws.getId() + "]\n" + SCOPE_PANIC_MSG);
+                            + ws.getId() + "]\nAll open workspaces: " + allOpenWorkspaces() + "\n" + SCOPE_PANIC_MSG);
             }
         }
+    }
+
+    private static List<String> allOpenWorkspaces(){
+        List<MemoryWorkspace> l = Nd4j.getWorkspaceManager().getAllWorkspacesForCurrentThread();
+        List<String> workspaces = new ArrayList<>(l.size());
+        for( MemoryWorkspace ws : l){
+            if(ws.isScopeActive()) {
+                workspaces.add(ws.getId());
+            }
+        }
+        return workspaces;
     }
 
     public long profilingHookIn(Op op) {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
@@ -133,7 +133,8 @@ public class Shape {
                 dims.add(i);
             }
             else if(left[leftIdx] != right[rightIdx]) {
-                throw new IllegalArgumentException("Unable to broadcast dimension " + i + " due to shape mismatch. Right shape must be 1.");
+                throw new IllegalArgumentException("Unable to broadcast dimension " + i + " due to shape mismatch. Right shape must be 1. "
+                        + "Left array shape: " + Arrays.toString(left) + ", right array shape: " + Arrays.toString(right));
             }
 
             leftIdx--;

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
@@ -428,6 +428,8 @@ public interface NDArrayFactory {
     INDArray pullRows(INDArray source, int sourceDimension, int[] indexes, char order);
 
 
+    INDArray pullRows(INDArray source, INDArray destination, int sourceDimension, int[] indexes);
+
     /**
      * In place shuffle of an ndarray
      * along a specified set of dimensions

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -5837,6 +5837,36 @@ public class Nd4j {
     }
 
     /**
+     * This method produces concatenated array, that consist from tensors, fetched from source array, against some
+     * dimension and specified indexes.
+     * The concatenated arrays are placed in the specified array.
+     *
+     * @param source source tensor
+     * @param destination Destination tensor (result will be placed here)
+     * @param sourceDimension dimension of source tensor
+     * @param indexes indexes from source array
+     * @return Destination array with specified tensors
+     */
+    public static INDArray pullRows(INDArray source, INDArray destination, int sourceDimension, int[] indexes){
+        if (sourceDimension >= source.rank())
+            throw new IllegalStateException("Source dimension can't be higher the rank of source tensor");
+
+        if (indexes == null || indexes.length == 0)
+            throw new IllegalStateException("Indexes shouldn't be empty");
+
+        for (int idx : indexes) {
+            if (idx < 0 || idx >= source.shape()[source.rank() - sourceDimension - 1]) {
+                throw new IllegalStateException(
+                        "Index can't be < 0 and >= " + source.shape()[source.rank() - sourceDimension - 1]);
+            }
+        }
+
+        INDArray ret = INSTANCE.pullRows(source, destination, sourceDimension, indexes);
+        logCreationIfNecessary(ret);
+        return ret;
+    }
+
+    /**
      * Concatneate ndarrays along a dimension
      *
      * @param dimension the dimension to concatneate along

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/DummyWorkspace.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/DummyWorkspace.java
@@ -233,4 +233,9 @@ public class DummyWorkspace implements MemoryWorkspace {
     public MemoryWorkspace tagOutOfScopeUse() {
         return this;
     }
+
+    @Override
+    public void setPreviousWorkspace(MemoryWorkspace memoryWorkspace) {
+        parentWorkspace = memoryWorkspace;
+    }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/abstracts/Nd4jWorkspace.java
@@ -3,19 +3,19 @@ package org.nd4j.linalg.memory.abstracts;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.Pointer;
 import org.nd4j.linalg.api.buffer.DataBuffer;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
 import org.nd4j.linalg.api.memory.enums.*;
-import org.nd4j.linalg.api.ops.executioner.GridExecutioner;
+import org.nd4j.linalg.api.memory.pointers.PagedPointer;
+import org.nd4j.linalg.api.memory.pointers.PointersPair;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.memory.MemoryManager;
-import org.nd4j.linalg.api.memory.MemoryWorkspace;
-import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
-import org.nd4j.linalg.api.memory.pointers.PagedPointer;
-import org.nd4j.linalg.api.memory.pointers.PointersPair;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -98,6 +98,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
     // pinned allocations are purged with delay, used for circular mode only
     protected Queue<PointersPair> pinnedAllocations = new LinkedTransferQueue<>();
 
+    @Setter
     protected MemoryWorkspace previousWorkspace;
     protected MemoryWorkspace borrowingWorkspace;
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java
@@ -329,4 +329,17 @@ public abstract class BasicWorkspaceManager implements MemoryWorkspaceManager {
         ensureThreadExistense();
         return new ArrayList<>(backingMap.get().values());
     }
+
+    @Override
+    public boolean anyWorkspaceActiveForCurrentThread(){
+        ensureThreadExistense();
+        boolean anyActive = false;
+        for(MemoryWorkspace ws : backingMap.get().values()){
+            if(ws.isScopeActive()){
+                anyActive = true;
+                break;
+            }
+        }
+        return anyActive;
+    }
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
@@ -1,0 +1,275 @@
+package org.nd4j.linalg.workspace;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+public class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMgr<T> {
+    private static final boolean DISABLE_LEVERAGE = false;  //Mainly for debugging/optimization purposes
+
+    protected final Set<T> scopeOutOfWs;
+    protected final Map<T, WorkspaceConfiguration> configMap;
+    protected final Map<T, String> workspaceNames;
+
+    protected BaseWorkspaceMgr(Set<T> scopeOutOfWs, Map<T, WorkspaceConfiguration> configMap,
+                               Map<T, String> workspaceNames){
+        this.scopeOutOfWs = scopeOutOfWs;
+        this.configMap = configMap;
+        this.workspaceNames = workspaceNames;
+    }
+
+    protected BaseWorkspaceMgr(){
+        scopeOutOfWs = new HashSet<>();
+        configMap = new HashMap<>();
+        workspaceNames = new HashMap<>();
+    }
+
+    @Override
+    public void setConfiguration(@NonNull T arrayType, WorkspaceConfiguration configuration) {
+        configMap.put(arrayType, configuration);
+    }
+
+    @Override
+    public WorkspaceConfiguration getConfiguration(@NonNull T arrayType) {
+        return configMap.get(arrayType);
+    }
+
+    @Override
+    public void setScopedOutFor(@NonNull T arrayType) {
+        scopeOutOfWs.add(arrayType);
+        configMap.remove(arrayType);
+        workspaceNames.remove(arrayType);
+    }
+
+    @Override
+    public boolean isScopedOut(@NonNull T arrayType) {
+        return scopeOutOfWs.contains(arrayType);
+    }
+
+    @Override
+    public MemoryWorkspace notifyScopeEntered(@NonNull T arrayType) {
+        validateConfig(arrayType);
+
+        if(isScopedOut(arrayType)){
+            return Nd4j.getWorkspaceManager().scopeOutOfWorkspaces();
+        } else {
+            MemoryWorkspace ws = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(
+                    getConfiguration(arrayType), getWorkspaceName(arrayType));
+            return ws.notifyScopeEntered();
+        }
+    }
+
+    @Override
+    public WorkspacesCloseable notifyScopeEntered(@NonNull T... arrayTypes) {
+        MemoryWorkspace[] ws = new MemoryWorkspace[arrayTypes.length];
+        for(int i=0; i<arrayTypes.length; i++ ){
+            ws[i] = notifyScopeEntered(arrayTypes[i]);
+        }
+        return new WorkspacesCloseable(ws);
+    }
+
+    @Override
+    public MemoryWorkspace notifyScopeBorrowed(@NonNull T arrayType) {
+        validateConfig(arrayType);
+
+        if(scopeOutOfWs.contains(arrayType)){
+            return Nd4j.getWorkspaceManager().scopeOutOfWorkspaces();
+        } else {
+            MemoryWorkspace ws = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(
+                    getConfiguration(arrayType), getWorkspaceName(arrayType));
+            return ws.notifyScopeBorrowed();
+        }
+    }
+
+    @Override
+    public void setWorkspaceName(@NonNull T arrayType, @NonNull String name) {
+        workspaceNames.put(arrayType, name);
+    }
+
+    @Override
+    public String getWorkspaceName(@NonNull T arrayType) {
+        return workspaceNames.get(arrayType);
+    }
+
+    @Override
+    public void setWorkspace(@NonNull T forEnum, @NonNull String wsName, @NonNull WorkspaceConfiguration configuration) {
+        if(scopeOutOfWs.contains(forEnum)){
+            scopeOutOfWs.remove(forEnum);
+        }
+        setWorkspaceName(forEnum, wsName);
+        setConfiguration(forEnum, configuration);
+    }
+
+    @Override
+    public boolean isWorkspaceOpen(@NonNull T arrayType) {
+        validateConfig(arrayType);
+        if(!scopeOutOfWs.contains(arrayType)) {
+            return Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(getWorkspaceName(arrayType));
+        }
+        return true;
+    }
+
+    @Override
+    public void assertNotOpen(@NonNull T arrayType, @NonNull String msg) {
+        if(!scopeOutOfWs.contains(arrayType) && isWorkspaceOpen(arrayType)){
+            throw new ND4JWorkspaceException("Assertion failed: expected workspace for array type " + arrayType
+                    + " to not be open: " + msg);
+        }
+    }
+
+    @Override
+    public void assertCurrentWorkspace(@NonNull T arrayType, String msg) {
+        validateConfig(arrayType);
+        MemoryWorkspace curr = Nd4j.getMemoryManager().getCurrentWorkspace();
+        if(!scopeOutOfWs.contains(arrayType) && (curr == null || !getWorkspaceName(arrayType).equals(curr.getId()))){
+            throw new ND4JWorkspaceException("Assertion failed: expected current workspace to be \"" + getWorkspaceName(arrayType)
+                    + "\" (for array type " + arrayType + ") - actual current workspace is " + (curr == null ? null : curr.getId())
+                    + (msg == null ? "" : ": " + msg));
+        };
+    }
+
+    @Override
+    public INDArray leverageTo(@NonNull T arrayType, @NonNull INDArray array) {
+        if(array == null || !array.isAttached()){
+            return array;
+        }
+        validateConfig(arrayType);
+        enforceExistsAndActive(arrayType);
+
+        if(!DISABLE_LEVERAGE){
+            if(scopeOutOfWs.contains(arrayType)){
+                return array.detach();
+            }
+            return array.leverageTo(getWorkspaceName(arrayType), true);
+        } else {
+            if(array.isAttached()){
+                if(!array.data().getParentWorkspace().getId().equals(getWorkspaceName(arrayType))){
+                    throw new IllegalStateException("Array of type " + arrayType + " is leveraged from " + array.data().getParentWorkspace().getId()
+                            + " to " + getWorkspaceName(arrayType) + " but WorkspaceMgn.leverageTo() is currently disabled");
+                }
+            }
+            return array;
+        }
+    }
+
+    @Override
+    public INDArray validateArrayLocation(@NonNull T arrayType, @NonNull INDArray array, boolean migrateIfInvalid, boolean exceptionIfDetached) {
+        validateConfig(arrayType);
+
+        if(scopeOutOfWs.contains(arrayType)){
+            //Array is supposed to be detached (no workspace)
+            boolean ok = !array.isAttached();
+            if(!ok){
+                if(migrateIfInvalid){
+                    return leverageTo(arrayType, array);
+                } else {
+                    throw new ND4JWorkspaceException("Array workspace validation failed: Array of type " + arrayType
+                            + " should be detached (no workspace) but is in workspace: " + array.data().getParentWorkspace().getId());
+                }
+            } else {
+                //Detached array, as expected
+                return array;
+            }
+        }
+
+        //At this point: we expect the array to be in a workspace
+        String wsNameExpected = getWorkspaceName(arrayType);
+        if(!array.isAttached()){
+            if(exceptionIfDetached) {
+                throw new ND4JWorkspaceException("Array workspace validation failed: Array of type " + arrayType +
+                        " should be in workspace \"" + wsNameExpected + "\" but is detached");
+            } else {
+                return array;
+            }
+        }
+
+
+        String wsNameAct = array.data().getParentWorkspace().getId();
+        if(!wsNameExpected.equals(wsNameAct)){
+            if(migrateIfInvalid){
+                return leverageTo(arrayType, array);
+            } else {
+                throw new ND4JWorkspaceException("Array workspace validation failed: Array of type " + arrayType +
+                        " should be in workspace \"" + wsNameExpected + "\" but is in workspace \"" + wsNameAct + "\"");
+            }
+        }
+
+        //OK - return as-is
+        return array;
+    }
+
+    @Override
+    public INDArray create(@NonNull T arrayType, @NonNull int... shape) {
+        enforceExistsAndActive(arrayType);
+        return create(arrayType, shape, Nd4j.order());
+    }
+
+    @Override
+    public INDArray create(@NonNull T arrayType, @NonNull int[] shape, @NonNull char order) {
+        enforceExistsAndActive(arrayType);
+        try(MemoryWorkspace ws = notifyScopeBorrowed(arrayType)){
+            return Nd4j.create(shape, order);
+        }
+    }
+
+    @Override
+    public INDArray createUninitialized(@NonNull T arrayType, @NonNull int... shape) {
+        return createUninitialized(arrayType, shape, Nd4j.order());
+    }
+
+    @Override
+    public INDArray createUninitialized(@NonNull T arrayType, @NonNull int[] shape, char order) {
+        enforceExistsAndActive(arrayType);
+        try(MemoryWorkspace ws = notifyScopeBorrowed(arrayType)){
+            return Nd4j.createUninitialized(shape, order);
+        }
+    }
+
+    @Override
+    public INDArray dup(@NonNull T arrayType, @NonNull INDArray toDup, char order){
+        enforceExistsAndActive(arrayType);
+        try(MemoryWorkspace ws = notifyScopeBorrowed(arrayType)){
+            return toDup.dup(order);
+        }
+    }
+
+    @Override
+    public INDArray dup(@NonNull T arrayType, @NonNull INDArray toDup){
+        return dup(arrayType, toDup, toDup.ordering());
+    }
+
+
+    private void validateConfig(@NonNull T arrayType){
+        if(scopeOutOfWs.contains(arrayType)){
+            return;
+        }
+
+        if(!configMap.containsKey(arrayType)){
+            throw new ND4JWorkspaceException("No workspace configuration has been provided for arrayType: " + arrayType);
+        }
+        if(!workspaceNames.containsKey(arrayType)){
+            throw new ND4JWorkspaceException("No workspace name has been provided for arrayType: " + arrayType);
+        }
+    }
+
+    private void enforceExistsAndActive(@NonNull T arrayType){
+        validateConfig(arrayType);
+        if(scopeOutOfWs.contains(arrayType)){
+            return;
+        }
+
+        if(!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(workspaceNames.get(arrayType))){
+            throw new ND4JWorkspaceException("Workspace \"" + workspaceNames.get(arrayType) + "\" for array type " + arrayType
+                    + " is not open");
+        }
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
@@ -91,6 +91,7 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
     @Override
     public MemoryWorkspace notifyScopeBorrowed(@NonNull T arrayType) {
         validateConfig(arrayType);
+        enforceExistsAndActive(arrayType);
 
         if(scopeOutOfWs.contains(arrayType)){
             return Nd4j.getWorkspaceManager().scopeOutOfWorkspaces();

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
@@ -12,8 +12,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * A standard/baseline {@link WorkspaceMgr} implementation
+ *
+ * @param <T> Array type
+ * @author Alex Black
+ */
 @Slf4j
-public class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMgr<T> {
+public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMgr<T> {
     private static final boolean DISABLE_LEVERAGE = false;  //Mainly for debugging/optimization purposes
 
     protected final Set<T> scopeOutOfWs;

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
@@ -62,6 +62,11 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
     }
 
     @Override
+    public boolean hasConfiguration(@NonNull T arrayType){
+        return scopeOutOfWs.contains(arrayType) || workspaceNames.containsKey(arrayType);
+    }
+
+    @Override
     public MemoryWorkspace notifyScopeEntered(@NonNull T arrayType) {
         validateConfig(arrayType);
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
@@ -130,6 +130,14 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
     }
 
     @Override
+    public void assertOpen(T arrayType, String msg) throws ND4JWorkspaceException {
+        if(!scopeOutOfWs.contains(arrayType) && !isWorkspaceOpen(arrayType)){
+            throw new ND4JWorkspaceException("Assertion failed: expected workspace for array type " + arrayType
+                    + " to be open: " + msg);
+        }
+    }
+
+    @Override
     public void assertNotOpen(@NonNull T arrayType, @NonNull String msg) {
         if(!scopeOutOfWs.contains(arrayType) && isWorkspaceOpen(arrayType)){
             throw new ND4JWorkspaceException("Assertion failed: expected workspace for array type " + arrayType

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/ND4JWorkspaceException.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/ND4JWorkspaceException.java
@@ -1,0 +1,21 @@
+package org.nd4j.linalg.workspace;
+
+public class ND4JWorkspaceException extends RuntimeException {
+
+    public ND4JWorkspaceException(){
+
+    }
+
+    public ND4JWorkspaceException(Throwable cause){
+        super(cause);
+    }
+
+    public ND4JWorkspaceException(String msg){
+        super(msg);
+    }
+
+    public ND4JWorkspaceException(String msg, Throwable cause){
+        super(msg, cause);
+    }
+
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/ND4JWorkspaceException.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/ND4JWorkspaceException.java
@@ -1,5 +1,10 @@
 package org.nd4j.linalg.workspace;
 
+/**
+ * An exception to specify than a workspace-related error has occurred
+ *
+ * @author Alex Black
+ */
 public class ND4JWorkspaceException extends RuntimeException {
 
     public ND4JWorkspaceException(){

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceMgr.java
@@ -108,6 +108,15 @@ public interface WorkspaceMgr<T extends Enum<T>> {
     boolean isWorkspaceOpen(T arrayType);
 
     /**
+     * Assert thath the workspace for the specified array type is open.
+     * For array types that are set to scoped out, this will be treated as a no-op
+     * @param arrayType Array type to check
+     * @param msg       May be null. If non-null: include this in the exception
+     * @throws ND4JWorkspaceException If the specified workspace is not open
+     */
+    void assertOpen(T arrayType, String msg) throws ND4JWorkspaceException;
+
+    /**
      * Assert thath the workspace for the specified array type is not open.
      * For array types that are set to scoped out, this will be treated as a no-op
      * @param arrayType Array type to check

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceMgr.java
@@ -6,81 +6,194 @@ import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**
- *
  * WorkspaceMgr is an interface for managing a set of workspaces, for a set of array types (where the array types
  * are specified by an enumeration).
- * Note that multiple array types may be stored in the one underlying 
+ * Note that multiple array types may be stored in the one underlying workspace
  *
  * @param <T> Enumeration type to specify the type of array. For example, in DL4J the type values include things
- *           like inputs, activations, working memory etc.
- *
+ *            like inputs, activations, working memory etc.
  * @author Alex Black
  */
 public interface WorkspaceMgr<T extends Enum<T>> {
 
     /**
+     * Set the workspace name for the specified array type
      *
-     * @param workspace
-     * @param configuration
+     * @param arrayType Array type to set the workspace name for
+     * @param wsName    Workspace name to set
      */
-    void setConfiguration(T workspace, WorkspaceConfiguration configuration);
-
-    WorkspaceConfiguration getConfiguration(T arrayType);
-
-    void setScopedOutFor(T arrayType);
-
-    boolean isScopedOut(T arrayType);
-
-    MemoryWorkspace notifyScopeEntered(T arrayType);
-
-    AutoCloseable notifyScopeEntered(T... arrayTypes);
-
-    MemoryWorkspace notifyScopeBorrowed(T workspace);
-
     void setWorkspaceName(T arrayType, String wsName);
 
+    /**
+     * @param arrayType Array type to get the workspace name for (if set)
+     * @return The workspace name for the specified array type (or null, if none has been set)
+     */
     String getWorkspaceName(T arrayType);
 
+    /**
+     * Seth the workspace name and configuration for the specified array type
+     *
+     * @param arrayType     Array type
+     * @param wsName        Workspace name
+     * @param configuration Workspace configuration
+     */
     void setWorkspace(T arrayType, String wsName, WorkspaceConfiguration configuration);
 
-    boolean isWorkspaceOpen(T arrayType);
-
-    void assertNotOpen(T arrayType, String msg);
-
-    void assertCurrentWorkspace(T arrayType, String msg);
+    /**
+     * Set the workspace configuration for the specified array type
+     *
+     * @param arrayType     Type of array to set the configuration for
+     * @param configuration Configuration for the specified array type
+     */
+    void setConfiguration(T arrayType, WorkspaceConfiguration configuration);
 
     /**
+     * @param arrayType Array type to get the workspace configuration for
+     * @return Workspace configuration for the specified array type (or note, if no configuration has been set)
+     */
+    WorkspaceConfiguration getConfiguration(T arrayType);
+
+    /**
+     * Set arrays to be scoped out (not in any workspace) for the specified array type.
+     * This means that create, dup, leverage etc methods will return result arrays that are not attached to any workspace
+     *
+     * @param arrayType Array type to set scoped out for
+     */
+    void setScopedOutFor(T arrayType);
+
+    /**
+     * @param arrayType Array type
+     * @return True if the specified array type is set to be scoped out
+     */
+    boolean isScopedOut(T arrayType);
+
+    /**
+     * @param arrayType Array type to enter the scope for
+     * @return Workspace for the specified array type
+     */
+    MemoryWorkspace notifyScopeEntered(T arrayType);
+
+    /**
+     * Open/enter multiple workspaces. This is equivalent to nested opening of the specified workspaces
+     *
+     * @param arrayTypes Open the specified workspaces
+     * @return Closeable for the specified workspaces
+     */
+    WorkspacesCloseable notifyScopeEntered(T... arrayTypes);
+
+    /**
+     * Borrow the scope for the specified array type
+     *
+     * @param arrayType Array type to borrow the scope for
+     * @return Workspace
+     */
+    MemoryWorkspace notifyScopeBorrowed(T arrayType);
+
+    /**
+     * Check if the workspace for the specified array type is open. If the array type is set to be scoped out,
+     * this will return true
+     *
+     * @param arrayType Array type
+     * @return True if the workspace is open (or array type is set to scoped out)
+     */
+    boolean isWorkspaceOpen(T arrayType);
+
+    /**
+     * Assert thath the workspace for the specified array type is not open.
+     * For array types that are set to scoped out, this will be treated as a no-op
+     * @param arrayType Array type to check
+     * @param msg       May be null. If non-null: include this in the exception
+     * @throws ND4JWorkspaceException If the specified workspace is open
+     */
+    void assertNotOpen(T arrayType, String msg) throws ND4JWorkspaceException;
+
+    /**
+     * Assert that the current workspace is the one for the specified array type.
+     * As per {@link #isWorkspaceOpen(Enum)} scoped out array types are ignored here.
+     *
+     * @param arrayType Array type to check
+     * @param msg       May be null. Message to include in the exception
+     */
+    void assertCurrentWorkspace(T arrayType, String msg) throws ND4JWorkspaceException;
+
+    /**
+     * Leverage the array to the specified array type's workspace (or detach if required).
      * If the array is not attached (not defined in a workspace) - array is returned unmodified
      *
-     * @param toWorkspace
-     * @param array
-     * @return
+     * @param toWorkspace Array type's workspace to move the array to
+     * @param array       Array to leverage
+     * @return Leveraged array (if leveraged, or original array otherwise)
      */
     INDArray leverageTo(T toWorkspace, INDArray array);
 
     /**
      * Validate that the specified array type is actually in the workspace it's supposed to be in
      *
-     * @param arrayType        Array type of the array
-     * @param array            Array to check
-     * @param migrateIfInvalid if true: migrate. If false: exception
+     * @param arrayType           Array type of the array
+     * @param array               Array to check
+     * @param migrateIfInvalid    if true, and array is in the wrong WS: migrate the array and return. If false and in
+     *                            the wrong WS: exception
      * @param exceptionIfDetached If true: if the workspace is detached, but is expected to be in a workspace: should an
      *                            exception be thrown?
-     * @return
+     * @return The original array, or (if required, and if migrateIfInvalid == true) the migrated array
+     * @throws ND4JWorkspaceException If the array is in the incorrect workspace (and migrateIfInvalid == false)
      */
-    INDArray validateArrayLocation(T arrayType, INDArray array, boolean migrateIfInvalid, boolean exceptionIfDetached);
+    INDArray validateArrayLocation(T arrayType, INDArray array, boolean migrateIfInvalid, boolean exceptionIfDetached) throws ND4JWorkspaceException;
 
-    INDArray create(T workspace, int... shape);
+    /**
+     * Create an array in the specified array type's workspace (or detached if none is specified).
+     * Equivalent to {@link org.nd4j.linalg.factory.Nd4j#create(int...)}, other than the array location
+     * @param arrayType Array type
+     * @param shape     Shape
+     * @return Created arary
+     */
+    INDArray create(T arrayType, int... shape);
 
-    INDArray create(T workspace, int[] shape, char ordering);
+    /**
+     * Create an array in the specified array type's workspace (or detached if none is specified).
+     * Equivalent to {@link org.nd4j.linalg.factory.Nd4j#create(int[],char)}, other than the array location
+     * @param arrayType Array type
+     * @param shape     Shape
+     * @param ordering Order of the array
+     * @return Created arary
+     */
+    INDArray create(T arrayType, int[] shape, char ordering);
 
+    /**
+     * Create an uninitialized array in the specified array type's workspace (or detached if none is specified).
+     * Equivalent to {@link org.nd4j.linalg.factory.Nd4j#createUninitialized(int)} (int...)}, other than the array location
+     * @param arrayType Array type
+     * @param shape     Shape
+     * @return Created array
+     */
     INDArray createUninitialized(T arrayType, int... shape);
 
+    /**
+     * Create an uninitialized array in the specified array type's workspace (or detached if none is specified).
+     * Equivalent to {@link org.nd4j.linalg.factory.Nd4j#createUninitialized(int[], char)}}, other than the array location
+     * @param arrayType Array type
+     * @param shape     Shape
+     * @param order Order of the array
+     * @return Created array
+     */
     INDArray createUninitialized(T arrayType, int[] shape, char order);
 
-    INDArray dup(T arrayType, INDArray toDup, char order);
-
+    /**
+     * Duplicate the array, where the array is put into the specified array type's workspace (if applicable)
+     * @param arrayType Array type for the result
+     * @param toDup     Array to duplicate
+     * @return Duplicated array in the specified array type's workspace
+     */
     INDArray dup(@NonNull T arrayType, @NonNull INDArray toDup);
+
+    /**
+     * Duplicate the array, where the array is put into the specified array type's workspace (if applicable)
+     * @param arrayType Array type for the result
+     * @param toDup     Array to duplicate
+     * @param order     Order for the duplicated array
+     * @return Duplicated array in the specified array type's workspace
+     */
+    INDArray dup(T arrayType, INDArray toDup, char order);
 
 
 }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceMgr.java
@@ -68,6 +68,15 @@ public interface WorkspaceMgr<T extends Enum<T>> {
     boolean isScopedOut(T arrayType);
 
     /**
+     * Has the specified array type been configured in this workspace manager?
+     *
+     * @param arrayType Array type to check
+     * @return True if the array type has been configured (either scoped out, or a workspace has been set for this
+     *  array type)
+     */
+    boolean hasConfiguration(T arrayType);
+
+    /**
      * @param arrayType Array type to enter the scope for
      * @return Workspace for the specified array type
      */

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceMgr.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceMgr.java
@@ -1,0 +1,86 @@
+package org.nd4j.linalg.workspace;
+
+import lombok.NonNull;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ *
+ * WorkspaceMgr is an interface for managing a set of workspaces, for a set of array types (where the array types
+ * are specified by an enumeration).
+ * Note that multiple array types may be stored in the one underlying 
+ *
+ * @param <T> Enumeration type to specify the type of array. For example, in DL4J the type values include things
+ *           like inputs, activations, working memory etc.
+ *
+ * @author Alex Black
+ */
+public interface WorkspaceMgr<T extends Enum<T>> {
+
+    /**
+     *
+     * @param workspace
+     * @param configuration
+     */
+    void setConfiguration(T workspace, WorkspaceConfiguration configuration);
+
+    WorkspaceConfiguration getConfiguration(T arrayType);
+
+    void setScopedOutFor(T arrayType);
+
+    boolean isScopedOut(T arrayType);
+
+    MemoryWorkspace notifyScopeEntered(T arrayType);
+
+    AutoCloseable notifyScopeEntered(T... arrayTypes);
+
+    MemoryWorkspace notifyScopeBorrowed(T workspace);
+
+    void setWorkspaceName(T arrayType, String wsName);
+
+    String getWorkspaceName(T arrayType);
+
+    void setWorkspace(T arrayType, String wsName, WorkspaceConfiguration configuration);
+
+    boolean isWorkspaceOpen(T arrayType);
+
+    void assertNotOpen(T arrayType, String msg);
+
+    void assertCurrentWorkspace(T arrayType, String msg);
+
+    /**
+     * If the array is not attached (not defined in a workspace) - array is returned unmodified
+     *
+     * @param toWorkspace
+     * @param array
+     * @return
+     */
+    INDArray leverageTo(T toWorkspace, INDArray array);
+
+    /**
+     * Validate that the specified array type is actually in the workspace it's supposed to be in
+     *
+     * @param arrayType        Array type of the array
+     * @param array            Array to check
+     * @param migrateIfInvalid if true: migrate. If false: exception
+     * @param exceptionIfDetached If true: if the workspace is detached, but is expected to be in a workspace: should an
+     *                            exception be thrown?
+     * @return
+     */
+    INDArray validateArrayLocation(T arrayType, INDArray array, boolean migrateIfInvalid, boolean exceptionIfDetached);
+
+    INDArray create(T workspace, int... shape);
+
+    INDArray create(T workspace, int[] shape, char ordering);
+
+    INDArray createUninitialized(T arrayType, int... shape);
+
+    INDArray createUninitialized(T arrayType, int[] shape, char order);
+
+    INDArray dup(T arrayType, INDArray toDup, char order);
+
+    INDArray dup(@NonNull T arrayType, @NonNull INDArray toDup);
+
+
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceUtils.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceUtils.java
@@ -3,38 +3,62 @@ package org.nd4j.linalg.workspace;
 import lombok.NonNull;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.memory.abstracts.Nd4jWorkspace;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Workspace utility methods
+ *
+ * @author Alex Black
+ */
 public class WorkspaceUtils {
 
-    private WorkspaceUtils() { }
+    private WorkspaceUtils() {
+    }
 
-    public static void assertNoWorkspacesOpen(String msg){
-        if(Nd4j.getWorkspaceManager().anyWorkspaceActiveForCurrentThread()){
+    /**
+     * Assert that no workspaces are currently open
+     *
+     * @param msg Message to include in the exception, if required
+     */
+    public static void assertNoWorkspacesOpen(String msg) throws ND4JWorkspaceException {
+        if (Nd4j.getWorkspaceManager().anyWorkspaceActiveForCurrentThread()) {
             List<MemoryWorkspace> l = Nd4j.getWorkspaceManager().getAllWorkspacesForCurrentThread();
             List<String> workspaces = new ArrayList<>(l.size());
-            for( MemoryWorkspace ws : l){
+            for (MemoryWorkspace ws : l) {
                 workspaces.add(ws.getId());
             }
-            throw new IllegalStateException(msg + " - Open/active workspaces: " + workspaces);
+            throw new ND4JWorkspaceException(msg + " - Open/active workspaces: " + workspaces);
         }
     }
 
-    public static void assertOpenAndActive(@NonNull String ws, @NonNull String errorMsg){
-        if(!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(ws)){
-            throw new IllegalStateException(errorMsg);
+    /**
+     * Assert that the specified workspace is open and active
+     *
+     * @param ws       Name of the workspace to assert open and active
+     * @param errorMsg Message to include in the exception, if required
+     */
+    public static void assertOpenAndActive(@NonNull String ws, @NonNull String errorMsg) throws ND4JWorkspaceException {
+        if (!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(ws)) {
+            throw new ND4JWorkspaceException(errorMsg);
         }
     }
 
-    public static void assertOpenActiveAndCurrent(@NonNull String ws, @NonNull String errorMsg){
-        if(!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(ws)){
-            throw new IllegalStateException(errorMsg + " - workspace is not open and active");
+    /**
+     * Assert that the specified workspace is open, active, and is the current workspace
+     *
+     * @param ws       Name of the workspace to assert open/active/current
+     * @param errorMsg Message to include in the exception, if required
+     */
+    public static void assertOpenActiveAndCurrent(@NonNull String ws, @NonNull String errorMsg) throws ND4JWorkspaceException {
+        if (!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(ws)) {
+            throw new ND4JWorkspaceException(errorMsg + " - workspace is not open and active");
         }
         MemoryWorkspace currWs = Nd4j.getMemoryManager().getCurrentWorkspace();
-        if(currWs == null || !ws.equals(currWs.getId())){
-            throw new IllegalStateException(errorMsg + " - not the current workspace (current workspace: "
+        if (currWs == null || !ws.equals(currWs.getId())) {
+            throw new ND4JWorkspaceException(errorMsg + " - not the current workspace (current workspace: "
                     + (currWs == null ? null : currWs.getId()));
         }
     }

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceUtils.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceUtils.java
@@ -1,0 +1,42 @@
+package org.nd4j.linalg.workspace;
+
+import lombok.NonNull;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WorkspaceUtils {
+
+    private WorkspaceUtils() { }
+
+    public static void assertNoWorkspacesOpen(String msg){
+        if(Nd4j.getWorkspaceManager().anyWorkspaceActiveForCurrentThread()){
+            List<MemoryWorkspace> l = Nd4j.getWorkspaceManager().getAllWorkspacesForCurrentThread();
+            List<String> workspaces = new ArrayList<>(l.size());
+            for( MemoryWorkspace ws : l){
+                workspaces.add(ws.getId());
+            }
+            throw new IllegalStateException(msg + " - Open/active workspaces: " + workspaces);
+        }
+    }
+
+    public static void assertOpenAndActive(@NonNull String ws, @NonNull String errorMsg){
+        if(!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(ws)){
+            throw new IllegalStateException(errorMsg);
+        }
+    }
+
+    public static void assertOpenActiveAndCurrent(@NonNull String ws, @NonNull String errorMsg){
+        if(!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(ws)){
+            throw new IllegalStateException(errorMsg + " - workspace is not open and active");
+        }
+        MemoryWorkspace currWs = Nd4j.getMemoryManager().getCurrentWorkspace();
+        if(currWs == null || !ws.equals(currWs.getId())){
+            throw new IllegalStateException(errorMsg + " - not the current workspace (current workspace: "
+                    + (currWs == null ? null : currWs.getId()));
+        }
+    }
+
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspacesCloseable.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspacesCloseable.java
@@ -1,0 +1,18 @@
+package org.nd4j.linalg.workspace;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+
+@AllArgsConstructor
+@Data
+public class WorkspacesCloseable implements AutoCloseable {
+    private MemoryWorkspace[] workspaces;
+
+    @Override
+    public void close() {
+        for(MemoryWorkspace ws : workspaces){
+            ws.close();
+        }
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspacesCloseable.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspacesCloseable.java
@@ -1,18 +1,28 @@
 package org.nd4j.linalg.workspace;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NonNull;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 
-@AllArgsConstructor
+/**
+ * An {@link AutoCloseable} for multiple workspaces
+ * NOTE: Workspaces are closed in REVERSED order to how they are provided to the costructor;
+ * this is to mirror nested workspace use
+ *
+ * @author Alex Black
+ */
 @Data
 public class WorkspacesCloseable implements AutoCloseable {
     private MemoryWorkspace[] workspaces;
 
+    public WorkspacesCloseable(@NonNull MemoryWorkspace... workspaces){
+        this.workspaces = workspaces;
+    }
+
     @Override
     public void close() {
-        for(MemoryWorkspace ws : workspaces){
-            ws.close();
+        for( int i=workspaces.length-1; i>=0; i-- ){
+            workspaces[i].close();
         }
     }
 }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCusparseNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCusparseNDArrayFactory.java
@@ -130,6 +130,11 @@ public class JCusparseNDArrayFactory extends BaseSparseNDArrayFactory{
     }
 
     @Override
+    public INDArray pullRows(INDArray source, INDArray destination, int sourceDimension, int[] indexes) {
+        return null;
+    }
+
+    @Override
     public void shuffle(INDArray array, Random rnd, int... dimension) {
 
     }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
@@ -759,6 +759,21 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
         if (indexes == null || indexes.length < 1)
             throw new IllegalStateException("Indexes can't be null or zero-length");
 
+        int[] shape;
+        if (sourceDimension == 1)
+            shape = new int[] {indexes.length, source.shape()[sourceDimension]};
+        else if (sourceDimension == 0)
+            shape = new int[] {source.shape()[sourceDimension], indexes.length};
+        else
+            throw new UnsupportedOperationException("2D input is expected");
+        return pullRows(source, Nd4j.createUninitialized(shape, order), sourceDimension, indexes);
+    }
+
+    @Override
+    public INDArray pullRows(INDArray source, INDArray destination, int sourceDimension, int[] indexes) {
+        if (indexes == null || indexes.length < 1)
+            throw new IllegalStateException("Indexes can't be null or zero-length");
+
         int[] shape = null;
         if (sourceDimension == 1)
             shape = new int[] {indexes.length, source.shape()[sourceDimension]};
@@ -767,7 +782,15 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
         else
             throw new UnsupportedOperationException("2D input is expected");
 
-        INDArray ret = Nd4j.createUninitialized(shape, order);
+        INDArray ret = destination;
+        if(ret == null){
+            ret = Nd4j.createUninitialized(shape, order);
+        } else {
+            if(!Arrays.equals(shape, destination.shape())){
+                throw new IllegalStateException("Cannot pull rows into destination array: expected destination array of" +
+                        " shape " + Arrays.toString(shape) + " but got destination array of shape " + Arrays.toString(destination.shape()));
+            }
+        }
 
         Nd4j.getCompressor().autoDecompress(source);
 

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuSparseNDArrayFactory.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuSparseNDArrayFactory.java
@@ -113,6 +113,11 @@ public class CpuSparseNDArrayFactory extends BaseSparseNDArrayFactory {
     }
 
     @Override
+    public INDArray pullRows(INDArray source, INDArray destination, int sourceDimension, int[] indexes) {
+        return null;
+    }
+
+    @Override
     public INDArray create(float[] data, int[] shape, int[] stride, long offset) {
         return null;
     }

--- a/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/NDArray.java
+++ b/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/NDArray.java
@@ -28,6 +28,7 @@ import org.nd4j.linalg.api.ndarray.BaseNDArray;
 import org.nd4j.linalg.api.ndarray.BaseNDArrayProxy;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.workspace.WorkspaceUtils;
 
 import java.util.List;
 
@@ -365,6 +366,7 @@ public class NDArray extends BaseNDArray {
      */
     @Override
     public INDArray unsafeDuplication() {
+        WorkspaceUtils.assertValidArray(this, "Cannot duplicate array");
         if (isView())
             return this.dup(this.ordering());
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/BasicWorkspaceTests.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/workspace/BasicWorkspaceTests.java
@@ -945,6 +945,218 @@ public class BasicWorkspaceTests extends BaseNd4jTest {
     }
 
 
+    @Test
+    public void testInvalidLeverageMigrateDetach(){
+
+        try {
+            MemoryWorkspace ws = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(basicConfig, "testInvalidLeverage");
+
+            INDArray invalidArray = null;
+
+            for (int i = 0; i < 10; i++) {
+                try (MemoryWorkspace ws2 = ws.notifyScopeEntered()) {
+                    invalidArray = Nd4j.linspace(1, 10, 10);
+                }
+            }
+            assertTrue(invalidArray.isAttached());
+
+            MemoryWorkspace ws2 = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(basicConfig, "testInvalidLeverage2");
+
+            //Leverage
+            try (MemoryWorkspace ws3 = ws2.notifyScopeEntered()) {
+                invalidArray.leverage();
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e) {
+                //Expected exception
+                e.printStackTrace();
+            }
+
+            try (MemoryWorkspace ws3 = ws2.notifyScopeEntered()) {
+                invalidArray.leverageTo("testInvalidLeverage2");
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e) {
+                //Expected exception
+                e.printStackTrace();
+            }
+
+            try (MemoryWorkspace ws3 = ws2.notifyScopeEntered()) {
+                invalidArray.leverageOrDetach("testInvalidLeverage2");
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e) {
+                //Expected exception
+                e.printStackTrace();
+            }
+
+            try {
+                invalidArray.leverageTo("testInvalidLeverage2");
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e) {
+                //Expected exception
+                e.printStackTrace();
+            }
+
+            //Detach
+            try{
+                invalidArray.detach();
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e){
+                e.printStackTrace();
+            }
+
+
+            //Migrate
+            try (MemoryWorkspace ws3 = ws2.notifyScopeEntered()) {
+                invalidArray.migrate();
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e) {
+                //Expected exception
+                e.printStackTrace();
+            }
+
+            try {
+                invalidArray.migrate(true);
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e) {
+                //Expected exception
+                e.printStackTrace();
+            }
+
+
+            //Dup
+            try{
+                invalidArray.dup();
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e){
+                e.printStackTrace();
+            }
+
+            //Unsafe dup:
+            try{
+                invalidArray.unsafeDuplication();
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e){
+                e.printStackTrace();
+            }
+
+            try{
+                invalidArray.unsafeDuplication(true);
+                fail("Exception should be thrown");
+            } catch (ND4JWorkspaceException e){
+                e.printStackTrace();
+            }
+
+
+        } finally {
+            Nd4j.getWorkspaceManager().destroyAllWorkspacesForCurrentThread();
+        }
+    }
+
+    @Test
+    public void testBadGenerationLeverageMigrateDetach(){
+        INDArray gen2 = null;
+
+        for (int i = 0; i < 4; i++) {
+            MemoryWorkspace wsOuter = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(basicConfig, "testBadGeneration");
+
+            try (MemoryWorkspace wsOuter2 = wsOuter.notifyScopeEntered()) {
+                INDArray arr = Nd4j.linspace(1, 10, 10);
+                if (i == 2) {
+                    gen2 = arr;
+                }
+
+                if (i == 3) {
+                    MemoryWorkspace wsInner = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(basicConfig, "testBadGeneration2");
+                    try (MemoryWorkspace wsInner2 = wsInner.notifyScopeEntered()) {
+
+                        //Leverage
+                        try {
+                            gen2.leverage();
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            //Expected exception
+                            e.printStackTrace();
+                        }
+
+                        try {
+                            gen2.leverageTo("testBadGeneration2");
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            //Expected exception
+                            e.printStackTrace();
+                        }
+
+                        try {
+                            gen2.leverageOrDetach("testBadGeneration2");
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            //Expected exception
+                            e.printStackTrace();
+                        }
+
+                        try {
+                            gen2.leverageTo("testBadGeneration2");
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            //Expected exception
+                            e.printStackTrace();
+                        }
+
+                        //Detach
+                        try {
+                            gen2.detach();
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            e.printStackTrace();
+                        }
+
+
+                        //Migrate
+                        try {
+                            gen2.migrate();
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            //Expected exception
+                            e.printStackTrace();
+                        }
+
+                        try {
+                            gen2.migrate(true);
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            //Expected exception
+                            e.printStackTrace();
+                        }
+
+
+                        //Dup
+                        try {
+                            gen2.dup();
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            e.printStackTrace();
+                        }
+
+                        //Unsafe dup:
+                        try {
+                            gen2.unsafeDuplication();
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            e.printStackTrace();
+                        }
+
+                        try {
+                            gen2.unsafeDuplication(true);
+                            fail("Exception should be thrown");
+                        } catch (ND4JWorkspaceException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
     @Override
     public char ordering() {
         return 'c';

--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/memory/MemoryWorkspace.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/memory/MemoryWorkspace.java
@@ -194,4 +194,14 @@ public interface MemoryWorkspace extends AutoCloseable {
      * @return
      */
     MemoryWorkspace tagOutOfScopeUse();
+
+    /**
+     * Set the previous workspace, if any<br>
+     * NOTE: this method should only be used if you are fully aware of the consequences of doing so. Incorrect use
+     * of this method may leave workspace management in an invalid/indeterminant state!
+     *
+     * @param memoryWorkspace Workspace to set as the previous workspace. This is the workspace that will become active
+     *                        when this workspace is closed.
+     */
+    void setPreviousWorkspace(MemoryWorkspace memoryWorkspace);
 }

--- a/nd4j-buffer/src/main/java/org/nd4j/linalg/api/memory/MemoryWorkspaceManager.java
+++ b/nd4j-buffer/src/main/java/org/nd4j/linalg/api/memory/MemoryWorkspaceManager.java
@@ -183,4 +183,11 @@ public interface MemoryWorkspaceManager {
      * This method returns all workspaces for current thread
      */
     List<MemoryWorkspace> getAllWorkspacesForCurrentThread();
+
+    /**
+     * Determine if there are any workspaces open for the current thread.
+     *
+     * @return True if any workspaces are open for this thread, false otherwise
+     */
+    boolean anyWorkspaceActiveForCurrentThread();
 }

--- a/nd4j-common/src/main/java/org/nd4j/base/Preconditions.java
+++ b/nd4j-common/src/main/java/org/nd4j/base/Preconditions.java
@@ -181,6 +181,24 @@ public class Preconditions {
     }
 
     /**
+     * See {@link #checkArgument(boolean, String, Object...)}
+     */
+    public static void checkArgument(boolean b, String msg, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        if (!b) {
+            throwEx(msg, arg1, arg2, arg3, arg4, arg5);
+        }
+    }
+
+    /**
+     * See {@link #checkArgument(boolean, String, Object...)}
+     */
+    public static void checkArgument(boolean b, String msg, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        if (!b) {
+            throwEx(msg, arg1, arg2, arg3, arg4, arg5, arg6);
+        }
+    }
+
+    /**
      * Check the specified boolean argument. Throws an IllegalArgumentException with the specified message if {@code b} is false.
      * Note that the message may specify argument locations using "%s" - for example,
      * {@code checkArgument(false, "Got %s values, expected %s", 3, "more"} would throw an IllegalArgumentException
@@ -325,6 +343,24 @@ public class Preconditions {
     public static void checkState(boolean b, String msg, Object arg1, Object arg2, Object arg3, Object arg4) {
         if (!b) {
             throwStateEx(msg, arg1, arg2, arg3, arg4);
+        }
+    }
+
+    /**
+     * See {@link #checkState(boolean, String, Object...)}
+     */
+    public static void checkState(boolean b, String msg, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        if (!b) {
+            throwStateEx(msg, arg1, arg2, arg3, arg4, arg5);
+        }
+    }
+
+    /**
+     * See {@link #checkState(boolean, String, Object...)}
+     */
+    public static void checkState(boolean b, String msg, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        if (!b) {
+            throwStateEx(msg, arg1, arg2, arg3, arg4, arg5, arg6);
         }
     }
 


### PR DESCRIPTION
ND4J changes to match DL4J PR: https://github.com/deeplearning4j/deeplearning4j/pull/4900

Why I removed the condition from BaseNDArray.leverageTo: consider the folowing situation:

open WS1
define array X
open WS2
leverage X to WS2	-> no op, as current == target
close WS1
use X -> scope panic as leverage didn't execute
close WS2

I don't think there's a need for that condition anyway.