### PR TITLE
Improvement to DataSet's SplitTestAndTrain (WIP)

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -833,25 +833,10 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
     }
 
     /**
-     * Splits a dataset in to test and train randomly.
-     * This will modify the dataset in place to shuffle it before splitting into test/train!
+     * Split the DataSet into a test and a training DataSet object
      *
-     * @param numHoldout the number to hold out for training
-     * @param  rng Random Number Generator to use to shuffle the dataset
-     * @return the pair of datasets for the train test split
-     */
-    @Override
-    public SplitTestAndTrain splitTestAndTrain(int numHoldout, Random rng) {
-        long seed = rng.nextLong();
-        this.shuffle(seed);
-        return splitTestAndTrain(numHoldout);
-    }
-
-    /**
-     * Splits a dataset in to test and train
-     *
-     * @param numHoldout the number to hold out for training
-     * @return the pair of datasets for the train test split
+     * @param numHoldout Number of examples to be returned in the training DataSet object
+     * @return A {@link SplitTestAndTrain} object containing the two DataSets
      */
     @Override
     public SplitTestAndTrain splitTestAndTrain(int numHoldout) {
@@ -922,6 +907,56 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
         return new SplitTestAndTrain(first, second);
     }
 
+    /**
+     * Randomly split the DataSet into a test and a training DataSet object
+     *
+     * This will shuffle the original DataSet in place prior to splitting it.
+     *
+     * @param numHoldout the number to hold out for training
+     * @param  rng Random Number Generator to use to shuffle the dataset
+     * @return the pair of datasets for the train test split
+     */
+    @Override
+    public SplitTestAndTrain splitTestAndTrain(int numHoldout, Random rng) {
+        long seed = rng.nextLong();
+        this.shuffle(seed);
+        return splitTestAndTrain(numHoldout);
+    }
+
+    /**
+     * Split the DataSet into a test and a training DataSet object
+     *
+     * @param fractionTrain Fraction (in range 0 to 1) of examples to be returned in the training DataSet object
+     * @return A {@link SplitTestAndTrain} object containing the two DataSets
+     */
+    @Override
+    public SplitTestAndTrain splitTestAndTrain(double fractionTrain) {
+        Preconditions.checkArgument(fractionTrain > 0.0 && fractionTrain < 1.0,
+                "Train fraction must be > 0.0 and < 1.0 - got %s", fractionTrain);
+        int numTrain = (int) (fractionTrain * numExamples());
+        if (numTrain <= 0)
+            numTrain = 1;
+        return splitTestAndTrain(numTrain);
+    }
+
+    /**
+     * Randomly split the DataSet into a test and a training DataSet object
+     *
+     * This will shuffle the original DataSet in place prior to splitting it.
+     *
+     * @param fractionTrain Fraction (range 0 to 1) of examples to be returned in the training DataSet object
+     * @param rng Random number generator used to shuffle the original DataSet prior to splitting
+     * @return A {@link SplitTestAndTrain} object containing the two DataSets
+     */
+    @Override
+    public SplitTestAndTrain splitTestAndTrain(double fractionTrain, Random rng) {
+        Preconditions.checkArgument(fractionTrain > 0.0 && fractionTrain < 1.0,
+                "Train fraction must be > 0.0 and < 1.0 - got %s", fractionTrain);
+        int numTrain = (int) (fractionTrain * numExamples());
+        if (numTrain <= 0)
+            numTrain = 1;
+        return splitTestAndTrain(numTrain, rng);
+    }
 
     /**
      * Returns the labels for the dataset
@@ -1244,17 +1279,6 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
     public void setColumnNames(List<String> columnNames) {
         this.columnNames = columnNames;
     }
-
-    @Override
-    public SplitTestAndTrain splitTestAndTrain(double fractionTrain) {
-        Preconditions.checkArgument(fractionTrain > 0.0 && fractionTrain < 1.0,
-                "Train fraction must be > 0.0 and < 1.0 - got %s", fractionTrain);
-        int numTrain = (int) (fractionTrain * numExamples());
-        if (numTrain <= 0)
-            numTrain = 1;
-        return splitTestAndTrain(numTrain);
-    }
-
 
     @Override
     public Iterator<DataSet> iterator() {

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSet.java
@@ -192,9 +192,39 @@ public interface DataSet extends Iterable<org.nd4j.linalg.dataset.DataSet>, Seri
      */
     List<org.nd4j.linalg.dataset.DataSet> asList();
 
-    SplitTestAndTrain splitTestAndTrain(int numHoldout, java.util.Random rnd);
-
+    /**
+     * Split the DataSet into two DataSet objects
+     *
+     * @param numHoldout Number of of examples to be returned in the training DataSet object
+     * @return A {@link SplitTestAndTrain} object containing the two DataSets
+     */
     SplitTestAndTrain splitTestAndTrain(int numHoldout);
+
+    /**
+     * Randomly split the DataSet into two DataSet objects
+     *
+     * @param numHoldout Number of of examples to be returned in the training DataSet object
+     * @param rng Random number generator used for randomization of the splitting
+     * @return A {@link SplitTestAndTrain} object containing the two DataSets
+     */
+    SplitTestAndTrain splitTestAndTrain(int numHoldout, java.util.Random rng);
+
+    /**
+     * Split the DataSet into two DataSet objects
+     *
+     * @param fractionTrain Fraction (range 0 to 1) of examples to be returned in the training DataSet object
+     * @return A {@link SplitTestAndTrain} object containing the two DataSets
+     */
+    SplitTestAndTrain splitTestAndTrain(double fractionTrain);
+
+    /**
+     * Randomly split the DataSet into two DataSet objects
+     *
+     * @param fractionTrain Fraction (range 0 to 1) of examples to be returned in the training DataSet object
+     * @param rng Random number generator used for randomization of the splitting
+     * @return A {@link SplitTestAndTrain} object containing the two DataSets
+     */
+    SplitTestAndTrain splitTestAndTrain(double fractionTrain, java.util.Random rng);
 
     INDArray getLabels();
 
@@ -252,11 +282,6 @@ public interface DataSet extends Iterable<org.nd4j.linalg.dataset.DataSet>, Seri
 
     void setColumnNames(List<String> columnNames);
 
-    /**
-     * SplitV the DataSet into two DataSets randomly
-     * @param fractionTrain    Fraction (in range 0 to 1) of examples to be returned in the training DataSet object
-     */
-    SplitTestAndTrain splitTestAndTrain(double fractionTrain);
 
     @Override
     Iterator<org.nd4j.linalg.dataset.DataSet> iterator();

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/DataSetTest.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/DataSetTest.java
@@ -73,11 +73,13 @@ public class DataSetTest extends BaseNd4jTest {
         INDArray labels = FeatureUtil.toOutcomeMatrix(new int[] {0, 0, 0, 0, 0, 0, 0, 0}, 1);
         DataSet data = new DataSet(Nd4j.rand(8, 1), labels);
 
-        SplitTestAndTrain train = data.splitTestAndTrain(6, new Random(1));
+        SplitTestAndTrain train = data.splitTestAndTrain(6);
         assertEquals(train.getTrain().getLabels().length(), 6);
+        assertEquals(train.getTest().getLabels().length(), 2);
 
-        SplitTestAndTrain train2 = data.splitTestAndTrain(6, new Random(1));
+        SplitTestAndTrain train2 = data.splitTestAndTrain(6);
         assertEquals(getFailureMessage(), train.getTrain().getFeatureMatrix(), train2.getTrain().getFeatureMatrix());
+        assertEquals(getFailureMessage(), train.getTest().getFeatureMatrix(), train2.getTest().getFeatureMatrix());
 
         DataSet x0 = new IrisDataSetIterator(150, 150).next();
         SplitTestAndTrain testAndTrain = x0.splitTestAndTrain(10);
@@ -85,6 +87,9 @@ public class DataSetTest extends BaseNd4jTest {
         assertEquals(x0.getFeatureMatrix().getRows(ArrayUtil.range(0, 10)), testAndTrain.getTrain().getFeatureMatrix());
         assertEquals(x0.getLabels().getRows(ArrayUtil.range(0, 10)), testAndTrain.getTrain().getLabels());
 
+        SplitTestAndTrain train3 = data.splitTestAndTrain(0.5);
+        assertEquals(train3.getTrain().getLabels().length(), 4);
+        assertEquals(train3.getTest().getLabels().length(), 4);
 
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, SplitTestAndTrain supports specifying either

- the fraction of data to go into the training data set
- a fixed number of items to go into the training data set
- a fixed number of items to go into the training data set combined with shuffling the DataSet prior to drawing the training data

I added the option to combine specifying a fraction and shuffling the DataSet. In the process, I improved the Javadoc and also improved the unit tests, where until now it seems the shuffling option was always used, even when the "static" variant was to be tested.

## How was this patch tested?

I wrote unit tests, but as a Java newbie I haven't managed to set up the project correctly to actually run them. On Gitter, Adam Gibson encouraged me to submit a pull request anyway.

