### PR TITLE
Set hasLearningRate flag function for AdaDelta to false

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/config/AdaDelta.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/config/AdaDelta.java
@@ -62,7 +62,7 @@ public class AdaDelta implements IUpdater {
 
     @Override
     public boolean hasLearningRate() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

`IUpdater.hasLearningRate():bool` is supposed to indicate whether the
updater has a learning rate which is not the case for `AdaDelta`.

This pull request sets `AdaDelta.hasLearningRate()` to `false`.

## How was this patch tested?

The [runtests.sh](https://github.com/deeplearning4j/nd4j/blob/master/runtests.sh) script was run as regression test with no failures.
