### PR TITLE
Add Java ND4J (Moore-Penrose) Pseudo Inverse (left/right) Implementation

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/inverse/InvertMatrix.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/inverse/InvertMatrix.java
@@ -2,9 +2,9 @@ package org.nd4j.linalg.inverse;
 
 import org.apache.commons.math3.linear.LUDecomposition;
 import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.SingularMatrixException;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.checkutil.CheckUtil;
-import org.nd4j.linalg.factory.Nd4j;
 
 /**
  * Created by agibsoncccc on 11/30/15.
@@ -15,6 +15,7 @@ public class InvertMatrix {
     /**
      * Inverts a matrix
      * @param arr the array to invert
+     * @param inPlace Whether to store the result in {@code arr}
      * @return the inverted matrix
      */
     public static INDArray invert(INDArray arr, boolean inPlace) {
@@ -41,4 +42,45 @@ public class InvertMatrix {
 
     }
 
+    /**
+     * Compute the left pseudo inverse. Input matrix must have full column rank.
+     *
+     * See also: <a href="https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Definition">Moore–Penrose inverse</a>
+     *
+     * @param arr Input matrix
+     * @param inPlace Whether to store the result in {@code arr}
+     * @return Left pseudo inverse of {@code arr}
+     * @exception IllegalArgumentException Input matrix {@code arr} did not have full column rank.
+     */
+    public static INDArray pLeftInvert(INDArray arr, boolean inPlace) {
+        try {
+          final INDArray inv = invert(arr.transpose().mmul(arr), inPlace).mmul(arr.transpose());
+          if (inPlace) arr.assign(inv);
+          return inv;
+        } catch (SingularMatrixException e) {
+          throw new IllegalArgumentException(
+              "Full column rank condition for left pseudo inverse was not met.");
+        }
+    }
+
+    /**
+     * Compute the right pseudo inverse. Input matrix must have full row rank.
+     *
+     * See also: <a href="https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Definition">Moore–Penrose inverse</a>
+     *
+     * @param arr Input matrix
+     * @param inPlace Whether to store the result in {@code arr}
+     * @return Right pseudo inverse of {@code arr}
+     * @exception IllegalArgumentException Input matrix {@code arr} did not have full row rank.
+     */
+    public static INDArray pRightInvert(INDArray arr, boolean inPlace) {
+        try{
+            final INDArray inv = arr.transpose().mmul(invert(arr.mmul(arr.transpose()), inPlace));
+            if (inPlace) arr.assign(inv);
+            return inv;
+        } catch (SingularMatrixException e){
+            throw new IllegalArgumentException(
+                "Full row rank condition for right pseudo inverse was not met.");
+        }
+    }
 }

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/inverse/TestInvertMatrices.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/inverse/TestInvertMatrices.java
@@ -108,6 +108,25 @@ public class TestInvertMatrices extends BaseNd4jTest {
         // general condition X = X * X^-1 * X
         final INDArray generalCond = X.mmul(leftInverse).mmul(X);
         assertTrue(X.equalsWithEps(generalCond, precision));
+        checkMoorePenroseConditions(X, leftInverse, precision);
+    }
+
+    /**
+     * Check the Moore-Penrose conditions for pseudo-matrices.
+     *
+     * @param A Initial matrix
+     * @param B Pseudo-Inverse of {@code A}
+     * @param precision Precision when comparing matrix elements
+     */
+    private void checkMoorePenroseConditions(INDArray A, INDArray B, double precision) {
+        // ABA=A (AB need not be the general identity matrix, but it maps all column vectors of A to themselves)
+        assertTrue(A.equalsWithEps(A.mmul(B).mmul(A), precision));
+        // BAB=B (B is a weak inverse for the multiplicative semigroup)
+        assertTrue(B.equalsWithEps(B.mmul(A).mmul(B), precision));
+        // (AB)^T=AB (AB is Hermitian)
+        assertTrue((A.mmul(B)).transpose().equalsWithEps(A.mmul(B), precision));
+        // (BA)^T=BA (BA is also Hermitian)
+        assertTrue((B.mmul(A)).transpose().equalsWithEps(B.mmul(A), precision));
     }
 
     /**
@@ -136,6 +155,7 @@ public class TestInvertMatrices extends BaseNd4jTest {
         // general condition X = X * X^-1 * X
         final INDArray generalCond = X.mmul(rightInverse).mmul(X);
         assertTrue(X.equalsWithEps(generalCond, precision));
+        checkMoorePenroseConditions(X, rightInverse, precision);
     }
 
     /**

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/inverse/TestInvertMatrices.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/inverse/TestInvertMatrices.java
@@ -148,11 +148,11 @@ public class TestInvertMatrices extends BaseNd4jTest {
     }
 
     /**
-     * Try to compute the right pseudo inverse of a matrix without full row rank (x1 = 2*x2)
+     * Try to compute the left pseudo inverse of a matrix without full column rank (x1 = 2*x2)
      */
     @Test(expected = IllegalArgumentException.class)
     public void testLeftPseudoInvertWithNonFullColumnRank() {
-        INDArray X = Nd4j.create(new double[][]{{1, 2}, {3, 6}, {5, 10}}).transpose();
+        INDArray X = Nd4j.create(new double[][]{{1, 2}, {3, 6}, {5, 10}});
         INDArray leftInverse = InvertMatrix.pLeftInvert(X, false);
     }
 

--- a/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/inverse/TestInvertMatrices.java
+++ b/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/inverse/TestInvertMatrices.java
@@ -4,6 +4,7 @@ import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.LUDecomposition;
 import org.apache.commons.math3.linear.MatrixUtils;
 import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.SingularMatrixException;
 import org.nd4j.linalg.primitives.Pair;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,6 +80,80 @@ public class TestInvertMatrices extends BaseNd4jTest {
             fail("No exception thrown for invalid input");
         } catch (Exception e) {
         }
+    }
+
+    /**
+     * Example from: <a href="https://www.wolframalpha.com/input/?i=invert+matrix+((1,2),(3,4),(5,6))">here</a>
+     */
+    @Test
+    public void testLeftPseudoInvert() {
+        INDArray X = Nd4j.create(new double[][]{{1, 2}, {3, 4}, {5, 6}});
+        INDArray expectedLeftInverse = Nd4j.create(new double[][]{{-16, -4, 8}, {13, 4, -5}}).mul(1 / 12d);
+        INDArray leftInverse = InvertMatrix.pLeftInvert(X, false);
+        assertEquals(expectedLeftInverse, leftInverse);
+
+        final INDArray identity3x3 = Nd4j.create(new double[][]{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
+        final INDArray identity2x2 = Nd4j.create(new double[][]{{1, 0}, {0, 1}});
+        final double precision = 1e-5;
+
+        // right inverse
+        final INDArray rightInverseCheck = X.mmul(leftInverse);
+        // right inverse must not hold since X rows are not linear independent (x_3 + x_1 = 2*x_2)
+        assertFalse(rightInverseCheck.equalsWithEps(identity3x3, precision));
+
+        // left inverse must hold since X columns are linear independent
+        final INDArray leftInverseCheck = leftInverse.mmul(X);
+        assertTrue(leftInverseCheck.equalsWithEps(identity2x2, precision));
+
+        // general condition X = X * X^-1 * X
+        final INDArray generalCond = X.mmul(leftInverse).mmul(X);
+        assertTrue(X.equalsWithEps(generalCond, precision));
+    }
+
+    /**
+     * Example from: <a href="https://www.wolframalpha.com/input/?i=invert+matrix+((1,2),(3,4),(5,6))^T">here</a>
+     */
+    @Test
+    public void testRightPseudoInvert() {
+        INDArray X = Nd4j.create(new double[][]{{1, 2}, {3, 4}, {5, 6}}).transpose();
+        INDArray expectedRightInverse = Nd4j.create(new double[][]{{-16, 13}, {-4, 4}, {8, -5}}).mul(1 / 12d);
+        INDArray rightInverse = InvertMatrix.pRightInvert(X, false);
+        assertEquals(expectedRightInverse, rightInverse);
+
+        final INDArray identity3x3 = Nd4j.create(new double[][]{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
+        final INDArray identity2x2 = Nd4j.create(new double[][]{{1, 0}, {0, 1}});
+        final double precision = 1e-5;
+
+        // left inverse
+        final INDArray leftInverseCheck = rightInverse.mmul(X);
+        // left inverse must not hold since X columns are not linear independent (x_3 + x_1 = 2*x_2)
+        assertFalse(leftInverseCheck.equalsWithEps(identity3x3, precision));
+
+        // left inverse must hold since X rows are linear independent
+        final INDArray rightInverseCheck = X.mmul(rightInverse);
+        assertTrue(rightInverseCheck.equalsWithEps(identity2x2, precision));
+
+        // general condition X = X * X^-1 * X
+        final INDArray generalCond = X.mmul(rightInverse).mmul(X);
+        assertTrue(X.equalsWithEps(generalCond, precision));
+    }
+
+    /**
+     * Try to compute the right pseudo inverse of a matrix without full row rank (x1 = 2*x2)
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testRightPseudoInvertWithNonFullRowRank() {
+        INDArray X = Nd4j.create(new double[][]{{1, 2}, {3, 6}, {5, 10}}).transpose();
+        INDArray rightInverse = InvertMatrix.pRightInvert(X, false);
+    }
+
+    /**
+     * Try to compute the right pseudo inverse of a matrix without full row rank (x1 = 2*x2)
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testLeftPseudoInvertWithNonFullColumnRank() {
+        INDArray X = Nd4j.create(new double[][]{{1, 2}, {3, 6}, {5, 10}}).transpose();
+        INDArray leftInverse = InvertMatrix.pLeftInvert(X, false);
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add methods to compute the left and right pseudo-inverse by simple
matrix multiplications directly in ND4J according to
https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Definition

The method makes use of `InvertMatrix.invert(..)` which at the moment
uses apache commons math so this is not a 100% ND4J based implementation but
as soon as someone implements an invert method in ND4J using Blas this
should be fine.

See also: #2858

## How was this patch tested?

Tests for left and right inverse are added in TestInvertMatrices.java
for working and nonworking (singular matrix) cases.

