### PR TITLE
Add AMSGrad updater

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/AMSGradUpdater.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/AMSGradUpdater.java
@@ -78,11 +78,11 @@ public class AMSGradUpdater implements GradientUpdater<AMSGrad> {
         double learningRate = config.getLearningRate(iteration, epoch);
         double epsilon = config.getEpsilon();
 
-        //m_t = b_1t * m_{t-1} + (1-b_1t) * g_t
+        //m_t = b_1 * m_{t-1} + (1-b_1) * g_t       eq 1 pg 3
         INDArray oneMinusBeta1Grad = gradient.mul(1.0 - beta1);
         m.muli(beta1).addi(oneMinusBeta1Grad);
 
-        //v_t = b_2 * v_{t-1} + (1-b_2) * (g_t)^2
+        //v_t = b_2 * v_{t-1} + (1-b_2) * (g_t)^2   eq 1 pg 3
         INDArray oneMinusBeta2GradSquared = gradient.mul(gradient).muli(1 - beta2);
         v.muli(beta2).addi(oneMinusBeta2GradSquared);
 

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/AMSGradUpdater.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/AMSGradUpdater.java
@@ -1,0 +1,105 @@
+/*-
+ *
+ *  * Copyright 2017 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.learning;
+
+import lombok.Data;
+import org.apache.commons.math3.util.FastMath;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.transforms.Sqrt;
+import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.NDArrayIndex;
+import org.nd4j.linalg.learning.config.AMSGrad;
+import org.nd4j.linalg.ops.transforms.Transforms;
+
+/**
+ * The AMSGrad updater<br>
+ * Reference: On the Convergence of Adam and Beyond - https://openreview.net/forum?id=ryQu7f-RZ
+ *
+ * @author Alex Black
+ */
+@Data
+public class AMSGradUpdater implements GradientUpdater<AMSGrad> {
+
+    private AMSGrad config;
+    private INDArray m, v, vHat; // moving avg, sqrd gradients, max
+
+    private char gradientReshapeOrder;
+
+    public AMSGradUpdater(AMSGrad config) {
+        this.config = config;
+    }
+
+    @Override
+    public void setStateViewArray(INDArray viewArray, int[] gradientShape, char gradientOrder, boolean initialize) {
+        if (!viewArray.isRowVector())
+            throw new IllegalArgumentException("Invalid input: expect row vector input");
+        if (initialize)
+            viewArray.assign(0);
+        int n = viewArray.length() / 3;
+        this.m = viewArray.get(NDArrayIndex.point(0), NDArrayIndex.interval(0, n));
+        this.v = viewArray.get(NDArrayIndex.point(0), NDArrayIndex.interval(n, 2*n));
+        this.vHat = viewArray.get(NDArrayIndex.point(0), NDArrayIndex.interval(2*n, 3*n));
+
+        //Reshape to match the expected shape of the input gradient arrays
+        this.m = Shape.newShapeNoCopy(this.m, gradientShape, gradientOrder == 'f');
+        this.v = Shape.newShapeNoCopy(this.v, gradientShape, gradientOrder == 'f');
+        this.vHat = Shape.newShapeNoCopy(this.vHat, gradientShape, gradientOrder == 'f');
+        if (m == null || v == null || vHat == null)
+            throw new IllegalStateException("Could not correctly reshape gradient view arrays");
+
+        this.gradientReshapeOrder = gradientOrder;
+    }
+
+    @Override
+    public void applyUpdater(INDArray gradient, int iteration, int epoch) {
+        if (m == null || v == null || vHat == null)
+            throw new IllegalStateException("Updater has not been initialized with view state");
+
+        double beta1 = config.getBeta1();
+        double beta2 = config.getBeta2();
+        double learningRate = config.getLearningRate(iteration, epoch);
+        double epsilon = config.getEpsilon();
+
+        //m_t = b_1t * m_{t-1} + (1-b_1t) * g_t
+        INDArray oneMinusBeta1Grad = gradient.mul(1.0 - beta1);
+        m.muli(beta1).addi(oneMinusBeta1Grad);
+
+        //v_t = b_2 * v_{t-1} + (1-b_2) * (g_t)^2
+        INDArray oneMinusBeta2GradSquared = gradient.mul(gradient).muli(1 - beta2);
+        v.muli(beta2).addi(oneMinusBeta2GradSquared);
+
+        double beta1t = FastMath.pow(beta1, iteration + 1);
+        double beta2t = FastMath.pow(beta2, iteration + 1);
+
+        //vHat_t = max(vHat_{t-1}, v_t)
+        Transforms.max(vHat, v, false);
+
+        double alphat = learningRate * FastMath.sqrt(1 - beta2t) / (1 - beta1t);
+        if (Double.isNaN(alphat) || alphat == 0.0)
+            alphat = epsilon;
+
+        //gradient array contains: sqrt(vHat) + eps
+        Nd4j.getExecutioner().execAndReturn(new Sqrt(vHat, gradient)).addi(epsilon);
+
+        //gradient = alphat * m_t / (sqrt(vHat) + eps)
+        gradient.rdivi(m).muli(alphat);
+    }
+}

--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/config/AMSGrad.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/config/AMSGrad.java
@@ -1,0 +1,106 @@
+package org.nd4j.linalg.learning.config;
+
+import lombok.Builder;
+import lombok.Data;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.learning.AMSGradUpdater;
+import org.nd4j.linalg.learning.GradientUpdater;
+import org.nd4j.linalg.schedule.ISchedule;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+import java.util.Arrays;
+
+/**
+ * The AMSGrad updater<br>
+ * Reference: On the Convergence of Adam and Beyond - https://openreview.net/forum?id=ryQu7f-RZ
+ *
+ * @author Alex Black
+ */
+@Data
+@Builder(builderClassName = "Builder")
+public class AMSGrad implements IUpdater {
+
+    public static final double DEFAULT_AMSGRAD_LEARNING_RATE = 1e-3;
+    public static final double DEFAULT_AMSGRAD_EPSILON = 1e-8;
+    public static final double DEFAULT_AMSGRAD_BETA1_MEAN_DECAY = 0.9;
+    public static final double DEFAULT_AMSGRAD_BETA2_VAR_DECAY = 0.999;
+
+    @lombok.Builder.Default private double learningRate = DEFAULT_AMSGRAD_LEARNING_RATE; // learning rate
+    private ISchedule learningRateSchedule;
+    @lombok.Builder.Default private double beta1 = DEFAULT_AMSGRAD_BETA1_MEAN_DECAY; // gradient moving avg decay rate
+    @lombok.Builder.Default private double beta2 = DEFAULT_AMSGRAD_BETA2_VAR_DECAY; // gradient sqrt decay rate
+    @lombok.Builder.Default private double epsilon = DEFAULT_AMSGRAD_EPSILON;
+
+    public AMSGrad() {
+        this(DEFAULT_AMSGRAD_LEARNING_RATE, DEFAULT_AMSGRAD_BETA1_MEAN_DECAY, DEFAULT_AMSGRAD_BETA2_VAR_DECAY,
+                        DEFAULT_AMSGRAD_EPSILON);
+    }
+
+    public AMSGrad(double learningRate){
+        this(learningRate, null, DEFAULT_AMSGRAD_BETA1_MEAN_DECAY, DEFAULT_AMSGRAD_BETA2_VAR_DECAY, DEFAULT_AMSGRAD_EPSILON);
+    }
+
+    public AMSGrad(ISchedule learningRateSchedule){
+        this(Double.NaN, learningRateSchedule, DEFAULT_AMSGRAD_BETA1_MEAN_DECAY, DEFAULT_AMSGRAD_BETA2_VAR_DECAY, DEFAULT_AMSGRAD_EPSILON);
+    }
+
+    public AMSGrad(double learningRate, double beta1, double beta2, double epsilon) {
+        this(learningRate, null, beta1, beta2, epsilon);
+    }
+
+    private AMSGrad(@JsonProperty("learningRate") double learningRate,
+                    @JsonProperty("learningRateSchedule") ISchedule learningRateSchedule,
+                    @JsonProperty("beta1") double beta1,
+                    @JsonProperty("beta2") double beta2,
+                    @JsonProperty("epsilon") double epsilon){
+        this.learningRate = learningRate;
+        this.learningRateSchedule = learningRateSchedule;
+        this.beta1 = beta1;
+        this.beta2 = beta2;
+        this.epsilon = epsilon;
+    }
+
+    @Override
+    public long stateSize(long numParams) {
+        return 3 * numParams;
+    }
+
+    @Override
+    public GradientUpdater instantiate(INDArray viewArray, boolean initializeViewArray) {
+        AMSGradUpdater u = new AMSGradUpdater(this);
+        int[] gradientShape = viewArray.shape();
+        gradientShape = Arrays.copyOf(gradientShape, gradientShape.length);
+        gradientShape[1] /= 3;
+        u.setStateViewArray(viewArray, gradientShape, viewArray.ordering(), initializeViewArray);
+        return u;
+    }
+
+    @Override
+    public AMSGrad clone() {
+        return new AMSGrad(learningRate, learningRateSchedule, beta1, beta2, epsilon);
+    }
+
+    @Override
+    public double getLearningRate(int iteration, int epoch){
+        if(learningRateSchedule != null){
+            return learningRateSchedule.valueAt(iteration, epoch);
+        }
+        return learningRate;
+    }
+
+    @Override
+    public boolean hasLearningRate() {
+        return true;
+    }
+
+    @Override
+    public void setLrAndSchedule(double lr, ISchedule lrSchedule) {
+        this.learningRate = lr;
+        this.learningRateSchedule = lrSchedule;
+    }
+
+    //Partial builder implementation to give public no-arg constructor
+    public static class Builder {
+        public Builder(){ }
+    }
+}


### PR DESCRIPTION
This *should* be correct, but some detailed reviews checking the math would be great.

Addresses: https://github.com/deeplearning4j/deeplearning4j/issues/5023
https://openreview.net/pdf?id=ryQu7f-RZ
Keras implementation: https://github.com/keras-team/keras/blob/083a41cc6be7b1796e3817df198d1557bb8557b8/keras/optimizers.py#L419

I've tested this out on one of the examples (Shakespeare / character RNN, LR 0.04) and it definitely learns:
![image](https://user-images.githubusercontent.com/2360237/39753260-7c1fc65a-5301-11e8-9092-ba7c890205fa.png)


I do have one concern, however... from the original paper (top page 2):
> we propose new variants of ADAM which rely on long-term memory of past gradients, but can be implemented in the **same time and space requirements** as the original ADAM algorithm.

Yet my reading of the math shows that we need an extra array for storing vHat. Unless maybe they mean O(n) space, at which point yes it's strictly correct in a big-O notation sense, but in practice it's a non-negligible difference (3n instead of 2n) for the state...

I also scanned the Keras implementation as a sanity check, and I believe this matches.