### PR TITLE
Make printAllocationStatisticsForCurrentThread() more readable

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java
@@ -10,6 +10,7 @@ import org.nd4j.linalg.api.memory.pointers.PointersPair;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.memory.abstracts.DummyWorkspace;
 import org.nd4j.linalg.memory.abstracts.Nd4jWorkspace;
+import org.nd4j.util.StringUtils;
 
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayList;
@@ -308,12 +309,16 @@ public abstract class BasicWorkspaceManager implements MemoryWorkspaceManager {
         Map<String, MemoryWorkspace> map = backingMap.get();
         log.info("Workspace statistics: ---------------------------------");
         log.info("Number of workspaces in current thread: {}", map.size());
+        log.info("Workspace name: Allocated / external (spilled) / external (pinned)");
         for (String key : map.keySet()) {
-            log.info("Workspace: {}", key);
-            log.info("Allocated amount: {} bytes", ((Nd4jWorkspace) map.get(key)).getCurrentSize());
-            log.info("External (spilled) amount: {} bytes", ((Nd4jWorkspace) map.get(key)).getSpilledSize());
-            log.info("External (pinned) amount: {} bytes", ((Nd4jWorkspace) map.get(key)).getPinnedSize());
-            System.out.println();
+            long current = ((Nd4jWorkspace) map.get(key)).getCurrentSize();
+            long spilled = ((Nd4jWorkspace) map.get(key)).getSpilledSize();
+            long pinned = ((Nd4jWorkspace) map.get(key)).getPinnedSize();
+            log.info(String.format("%-26s %8s / %8s / %8s (%11d / %11d / %11d)", (key + ":"),
+                    StringUtils.TraditionalBinaryPrefix.long2String(current, "", 2),
+                    StringUtils.TraditionalBinaryPrefix.long2String(spilled, "", 2),
+                    StringUtils.TraditionalBinaryPrefix.long2String(pinned, "", 2),
+                    current, spilled, pinned));
         }
     }
 


### PR DESCRIPTION
I've refactored this to:
1. Require fewer lines
2. Print human-readable quantities also (MB, GB etc)
3. Format to enable quick visual comparison (i.e., everything is aligned consistently, so you can scan easily)

```
o.n.l.m.p.BasicWorkspaceManager - Workspace statistics: ---------------------------------
o.n.l.m.p.BasicWorkspaceManager - Number of workspaces in current thread: 4
o.n.l.m.p.BasicWorkspaceManager - Workspace name: Allocated / external (spilled) / external (pinned)
o.n.l.m.p.BasicWorkspaceManager - WS_LAYER_WORKING_MEM:        3.46 G /        0 /        0 ( 3713381946 /           0 /           0)
o.n.l.m.p.BasicWorkspaceManager - WS_ALL_LAYERS_ACT:         958.83 M /        0 /        0 ( 1005400897 /           0 /           0)
o.n.l.m.p.BasicWorkspaceManager - WS_LAYER_ACT_2:            567.70 M /        0 /        0 (  595275264 /           0 /           0)
o.n.l.m.p.BasicWorkspaceManager - WS_LAYER_ACT_1:            141.92 M /        0 /        0 (  148818816 /           0 /           0)
```