### PR TITLE
Provide more informative feedback if normalizer was not yet fitted

### DIFF
--- a/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/AbstractDataSetNormalizer.java
+++ b/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/preprocessor/AbstractDataSetNormalizer.java
@@ -8,6 +8,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.api.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.dataset.api.preprocessor.stats.NormalizerStats;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
 
 /**
  * Abstract base class for normalizers
@@ -137,8 +138,13 @@ public abstract class AbstractDataSetNormalizer<S extends NormalizerStats> exten
 
     @Override
     public void transform(INDArray features, INDArray featuresMask) {
-        strategy.preProcess(features, featuresMask, getFeatureStats());
-    }
+        S featureStats = getFeatureStats();
+
+        if(featureStats == null){
+            throw new ND4JIllegalStateException("Features statistics were not yet calculated. Make sure to run fit() first.");
+        }
+
+        strategy.preProcess(features, featuresMask, featureStats);    }
 
     /**
      * Transform the labels. If {@link #isFitLabel()} == false, this is a no-op


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of throwing an unspecific NPE when using `transform()` without a preciding `fit()`, the `AbstractDataSetNormalizer` was changed to throw a ND4JIllegalStateException with a more informative error message.
